### PR TITLE
MAKE-1172: add POST routes for login

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -512,7 +512,7 @@ func (c *Client) GetAuthKey(ctx context.Context, username, password string) (str
 		return "", errors.Wrap(err, "problem building payload")
 	}
 
-	req, err := c.makeRequest(ctx, http.MethodGet, url, bytes.NewBuffer(payload))
+	req, err := c.makeRequest(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		return "", errors.Wrap(err, "problem building request")
 	}
@@ -579,7 +579,7 @@ func (c *Client) authCredRequest(ctx context.Context, url string, creds *userCre
 		return "", errors.Wrap(err, "problem building payload")
 	}
 
-	req, err := c.makeRequest(ctx, http.MethodGet, url, bytes.NewBuffer(payload))
+	req, err := c.makeRequest(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		return "", errors.Wrap(err, "problem building request")
 	}

--- a/rest/routes.go
+++ b/rest/routes.go
@@ -198,7 +198,6 @@ func (s *Service) simpleLogInjestion(w http.ResponseWriter, r *http.Request) {
 	req := &simpleLogRequest{}
 	resp := &SimpleLogInjestionResponse{}
 	resp.LogID = gimlet.GetVars(r)["id"]
-	defer r.Body.Close()
 
 	if resp.LogID == "" {
 		resp.Errors = []string{"no log id specified"}
@@ -321,7 +320,6 @@ type SystemInfoReceivedResponse struct {
 func (s *Service) recieveSystemInfo(w http.ResponseWriter, r *http.Request) {
 	resp := &SystemInfoReceivedResponse{}
 	req := message.SystemInfo{}
-	defer r.Body.Close()
 
 	if err := gimlet.GetJSON(r.Body, &req); err != nil {
 		grip.Error(err)
@@ -654,7 +652,6 @@ type userAPIKeyResponse struct {
 }
 
 func (s *Service) fetchUserToken(rw http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
 	creds := &userCredentials{}
 	if err := gimlet.GetJSON(r.Body, creds); err != nil {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(errors.Wrap(err, "problem reading request body")))

--- a/rest/service.go
+++ b/rest/service.go
@@ -209,9 +209,13 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/admin/service/flag/{flagName}/enabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagEnabled)
 	s.app.AddRoute("/admin/service/flag/{flagName}/disabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagDisabled)
 	s.app.AddRoute("/admin/ca").Version(1).Get().Handler(s.fetchRootCert)
+	// TODO (MAKE-1173): GET variants should be removed.
 	s.app.AddRoute("/admin/users/key").Version(1).Get().Handler(s.fetchUserToken)
+	s.app.AddRoute("/admin/users/key").Version(1).Post().Handler(s.fetchUserToken)
 	s.app.AddRoute("/admin/users/certificate").Version(1).Get().Handler(s.fetchUserCert)
+	s.app.AddRoute("/admin/users/certificate").Version(1).Post().Handler(s.fetchUserCert)
 	s.app.AddRoute("/admin/users/certificate/key").Version(1).Get().Handler(s.fetchUserCertKey)
+	s.app.AddRoute("/admin/users/certificate/key").Version(1).Post().Handler(s.fetchUserCertKey)
 
 	s.app.AddRoute("/simple_log/{id}").Version(1).Post().Wrap(checkUser).Handler(s.simpleLogInjestion)
 	s.app.AddRoute("/simple_log/{id}").Version(1).Get().Handler(s.simpleLogRetrieval)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1172

* Add POST routes for login. The GET routes will be removed after people update their CLIs.
* Dont close request bodies. The docs say that the underlying http.Server is responsible for closing them so the `http.Handler` doesn't have to.