### PR TITLE
MAKE-1151: Initialize float series as empty array to avoid null JSON …

### DIFF
--- a/units/recalculate_change_points.go
+++ b/units/recalculate_change_points.go
@@ -99,7 +99,7 @@ func (j *recalculateChangePointsJob) Run(ctx context.Context) {
 		sort.Slice(series.TimeSeries, func(i, j int) bool {
 			return series.TimeSeries[i].Order < series.TimeSeries[j].Order
 		})
-		var float_series []float64
+		float_series := make([]float64, 0)
 		for _, item := range series.TimeSeries {
 			float_series = append(float_series, item.Value)
 		}

--- a/units/recalculate_change_points.go
+++ b/units/recalculate_change_points.go
@@ -99,12 +99,12 @@ func (j *recalculateChangePointsJob) Run(ctx context.Context) {
 		sort.Slice(series.TimeSeries, func(i, j int) bool {
 			return series.TimeSeries[i].Order < series.TimeSeries[j].Order
 		})
-		float_series := make([]float64, 0)
-		for _, item := range series.TimeSeries {
-			float_series = append(float_series, item.Value)
+		floatSeries := make([]float64, len(series.TimeSeries))
+		for i, item := range series.TimeSeries {
+			floatSeries[i] = item.Value
 		}
 
-		changePoints, err := j.changePointDetector.DetectChanges(ctx, float_series)
+		changePoints, err := j.changePointDetector.DetectChanges(ctx, floatSeries)
 		if err != nil {
 			j.AddError(errors.Wrapf(err, "Unable to detect change points in time series %s", j.PerformanceResultId))
 			return


### PR DESCRIPTION
…value

When marshaled, nil slices get encoded as `null` while empty arrays get encoded as `[]`.

https://golang.org/pkg/encoding/json/#Marshal

https://play.golang.org/p/jvZ7Sx9hoz2
