### PR TITLE
EVG-9709: fix benchmarks compilation

### DIFF
--- a/benchmarks/log_iterator_benchmarks.go
+++ b/benchmarks/log_iterator_benchmarks.go
@@ -101,7 +101,7 @@ func uploadLog(ctx context.Context, logSize int) (string, error) {
 		RPCAddress: rpcAddress,
 		Insecure:   true,
 	}
-	logger, err := timber.MakeLogger(ctx, "benchmark", opts)
+	logger, err := timber.MakeLogger("benchmark", opts)
 	if err != nil {
 		return "", errors.Wrap(err, "problem creating buildlogger sender")
 	}

--- a/benchmarks/timber_benchmarks.go
+++ b/benchmarks/timber_benchmarks.go
@@ -152,7 +152,7 @@ func getBasicSenderBenchmark(logSize, maxBufferSize int) poplar.Benchmark {
 			Insecure:      true,
 			MaxBufferSize: maxBufferSize,
 		}
-		logger, err := timber.MakeLogger(ctx, "benchmark", opts)
+		logger, err := timber.MakeLogger("benchmark", opts)
 		if err != nil {
 			return errors.Wrap(err, "problem creating buildlogger sender")
 		}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9709

`go build ./benchmarks` was failing.