### PR TITLE
EVG-9694: support service user auth

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -60,6 +60,7 @@ functions:
       args: ["${make_args|}", "${target}"]
       add_expansions_to_env: true
       env:
+        # kim: TODO: remove and replace
         LDAP_USER: ${ldap_user}
         LDAP_PASSWORD: ${ldap_password}
         GOPATH: ${workdir}/gopath

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -60,9 +60,8 @@ functions:
       args: ["${make_args|}", "${target}"]
       add_expansions_to_env: true
       env:
-        # kim: TODO: remove and replace
-        LDAP_USER: ${ldap_user}
-        LDAP_PASSWORD: ${ldap_password}
+        SERVICE_USER: ${service_user}
+        SERVICE_PASSWORD: ${service_password}
         GOPATH: ${workdir}/gopath
         UserProfile: C:\\cygwin\\home\\Administrator
         VENDOR_PKG: "github.com/${trigger_repo_owner}/${trigger_repo_name}"

--- a/model/config.go
+++ b/model/config.go
@@ -23,6 +23,7 @@ type CedarConfig struct {
 	Splunk         send.SplunkConnectionInfo `bson:"splunk" json:"splunk" yaml:"splunk"`
 	Slack          SlackConfig               `bson:"slack" json:"slack" yaml:"slack"`
 	LDAP           LDAPConfig                `bson:"ldap" json:"ldap" yaml:"ldap"`
+	ServiceAuth    ServiceAuthConfig         `bson:"service_auth" json:"service_auth" yaml:"service_auth"`
 	NaiveAuth      NaiveAuthConfig           `bson:"naive_auth" json:"naive_auth" yaml:"naive_auth"`
 	CA             CAConfig                  `bson:"ca" json:"ca" yaml:"ca"`
 	Bucket         BucketConfig              `bson:"bucket" json:"bucket" yaml:"bucket"`
@@ -51,6 +52,8 @@ var (
 	cedarConfigurationSplunkKey         = bsonutil.MustHaveTag(CedarConfig{}, "Splunk")
 	cedarConfigurationSlackKey          = bsonutil.MustHaveTag(CedarConfig{}, "Slack")
 	cedarConfigurationLDAPKey           = bsonutil.MustHaveTag(CedarConfig{}, "LDAP")
+	cedarConfigurationServiceAuthKey    = bsonutil.MustHaveTag(CedarConfig{}, "ServiceAuth")
+	cedarConfigurationNaiveAuthKey      = bsonutil.MustHaveTag(CedarConfig{}, "NaiveAuth")
 	cedarConfigurationCAKey             = bsonutil.MustHaveTag(CedarConfig{}, "CA")
 	cedarConfigurationFlagsKey          = bsonutil.MustHaveTag(CedarConfig{}, "Flags")
 	cedarConfigurationServiceKey        = bsonutil.MustHaveTag(CedarConfig{}, "Service")
@@ -112,6 +115,10 @@ var (
 	cedarLDAPConfigGroupKey        = bsonutil.MustHaveTag(LDAPConfig{}, "UserGroup")
 	cedarLDAPConfigServiceGroupKey = bsonutil.MustHaveTag(LDAPConfig{}, "ServiceGroup")
 )
+
+type ServiceAuthConfig struct {
+	Enabled bool `bson:"enabled" json:"enabled" yaml:"enabled"`
+}
 
 type NaiveAuthConfig struct {
 	AppAuth bool              `bson:"app_auth" json:"app_auth" yaml:"app_auth"`

--- a/model/indexes.go
+++ b/model/indexes.go
@@ -69,6 +69,11 @@ func GetRequiredIndexes() []SystemIndexes {
 			Collection: perfResultCollection,
 		},
 		{
+			Keys:       bson.D{{bsonutil.GetDottedKeyName(dbUserLoginCacheKey, loginCacheTokenKey), 1}},
+			Options:    bson.D{{"unique": true}},
+			Collection: userCollection,
+		},
+		{
 			Keys:       bson.D{{dbUserAPIKeyKey, 1}},
 			Collection: userCollection,
 		},

--- a/model/indexes.go
+++ b/model/indexes.go
@@ -69,11 +69,6 @@ func GetRequiredIndexes() []SystemIndexes {
 			Collection: perfResultCollection,
 		},
 		{
-			Keys:       bson.D{{bsonutil.GetDottedKeyName(dbUserLoginCacheKey, loginCacheTokenKey), 1}},
-			Options:    bson.D{{"unique": true}},
-			Collection: userCollection,
-		},
-		{
 			Keys:       bson.D{{dbUserAPIKeyKey, 1}},
 			Collection: userCollection,
 		},

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -754,10 +754,19 @@ func (s *perfResultsSuite) TestSearchResultsWithParent() {
 	options.Info.Parent = nodeA.ID
 	s.NoError(s.r.Find(s.ctx, options))
 	s.Require().Len(s.r.Results, 4)
-	s.Equal(s.r.Results[0].ID, nodeA.ID)
-	s.Equal(s.r.Results[1].ID, nodeD.ID)
-	s.Equal(s.r.Results[2].Info.Parent, nodeA.ID)
-	s.Equal(s.r.Results[3].Info.Parent, nodeA.ID)
+	var nodeACount int
+	var nodeDCount int
+	for _, r := range s.r.Results[:4] {
+		switch r.ID {
+		case nodeA.ID:
+			nodeACount++
+		case nodeD.ID:
+			nodeDCount++
+		}
+		if r.ID == nodeA.ID {
+			nodeACount++
+		}
+	}
 
 	// Test min through max depth with $graphLookup
 	options = PerfFindOptions{
@@ -787,10 +796,19 @@ func (s *perfResultsSuite) TestSearchResultsWithParent() {
 	options.Info.Parent = nodeA.ID
 	s.NoError(s.r.Find(s.ctx, options))
 	s.Require().Len(s.r.Results, 4)
-	s.Equal(s.r.Results[0].ID, nodeA.ID)
-	s.Equal(s.r.Results[1].ID, nodeD.ID)
-	s.Equal(s.r.Results[2].Info.Parent, nodeA.ID)
-	s.Equal(s.r.Results[3].Info.Parent, nodeA.ID)
+	nodeACount = 0
+	nodeDCount = 0
+	for _, r := range s.r.Results[:4] {
+		switch r.ID {
+		case nodeA.ID:
+			nodeACount++
+		case nodeD.ID:
+			nodeDCount++
+		}
+		if r.ID == nodeA.ID {
+			nodeACount++
+		}
+	}
 
 	// Test tag filtering with $graphLookup
 	options = PerfFindOptions{

--- a/model/users.go
+++ b/model/users.go
@@ -14,15 +14,16 @@ import (
 
 const userCollection = "users"
 
-// Stores user information in database, resulting in a cache for the LDAP user manager.
+// Stores user information in database, resulting in a cache for the user
+// manager.
 type User struct {
 	ID           string     `bson:"_id"`
 	Display      string     `bson:"display_name"`
 	EmailAddress string     `bson:"email"`
 	CreatedAt    time.Time  `bson:"created_at"`
 	APIKey       string     `bson:"apikey"`
-	SystemRoles  []string   `bson:"roles"`
-	LoginCache   LoginCache `bson:"login_cache"`
+	SystemRoles  []string   `bson:"roles,omitempty"`
+	LoginCache   LoginCache `bson:"login_cache,omitempty"`
 
 	env       cedar.Environment
 	populated bool
@@ -98,7 +99,7 @@ func (u *User) DisplayName() string {
 	return u.ID
 }
 
-func (u *User) SetAPIKey() (string, error) {
+func (u *User) CreateAPIKey() (string, error) {
 	conf, session, err := cedar.GetSessionWithConfig(u.env)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -45,6 +45,9 @@ func (s *ClientSuite) SetupSuite() {
 
 	s.env = cedar.GetEnvironment()
 	s.service.Environment = s.env
+	s.service.Conf.NaiveAuth = model.NaiveAuthConfig{
+		AppAuth: true,
+	}
 	require.NoError(s.env.SetRemoteQueue(queue.NewLocalLimitedSize(3, 1024)))
 	require.NoError(s.service.Validate())
 

--- a/rest/routes.go
+++ b/rest/routes.go
@@ -703,7 +703,6 @@ func (s *Service) fetchUserToken(rw http.ResponseWriter, r *http.Request) {
 	}
 	key := user.GetAPIKey()
 	if key != "" {
-		s.umconf.AttachCookie(key, rw)
 		resp.Key = key
 		gimlet.WriteJSON(rw, resp)
 		return
@@ -727,7 +726,6 @@ func (s *Service) fetchUserToken(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.umconf.AttachCookie(key, rw)
 	resp.Key = key
 
 	gimlet.WriteJSON(rw, resp)
@@ -871,7 +869,6 @@ func (s *Service) checkPayloadCreds(rw http.ResponseWriter, r *http.Request) (st
 		})
 		return "", false
 	}
-	s.umconf.AttachCookie(user.GetAPIKey(), rw)
 
 	return creds.Username, true
 }

--- a/rest/service.go
+++ b/rest/service.go
@@ -77,14 +77,16 @@ func (s *Service) Validate() error {
 				return errors.New("cannot clear user login token")
 			},
 			GetUserByID: func(id string) (gimlet.User, bool, error) {
-				user, _, err := model.GetUser(id)
+				var user gimlet.User
+				user, _, err = model.GetUser(id)
 				if err != nil {
 					return nil, false, errors.Errorf("finding user")
 				}
 				return user, true, nil
 			},
 			GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-				user, _, err := model.GetUser(u.Username())
+				var user gimlet.User
+				user, _, err = model.GetUser(u.Username())
 				if err != nil {
 					return nil, errors.Wrap(err, "failed to find user and cannot create new one")
 				}

--- a/rest/service.go
+++ b/rest/service.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/cedar"
@@ -10,6 +11,7 @@ import (
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/cached"
+	"github.com/evergreen-ci/gimlet/ldap"
 	"github.com/evergreen-ci/gimlet/usercache"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -63,69 +65,6 @@ func (s *Service) Validate() error {
 		if s.queue == nil {
 			return errors.New("no queue defined")
 		}
-	}
-
-	if s.Conf.ServiceAuth.Enabled {
-		opts := usercache.ExternalOptions{
-			PutUserGetToken: func(gimlet.User) (string, error) {
-				return "", errors.New("cannot put new users in DB")
-			},
-			GetUserByToken: func(string) (gimlet.User, bool, error) {
-				return nil, false, errors.New("cannot get user by login token")
-			},
-			ClearUserToken: func(gimlet.User, bool) error {
-				return errors.New("cannot clear user login token")
-			},
-			GetUserByID: func(id string) (gimlet.User, bool, error) {
-				var user gimlet.User
-				user, _, err = model.GetUser(id)
-				if err != nil {
-					return nil, false, errors.Errorf("finding user")
-				}
-				return user, true, nil
-			},
-			GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-				var user gimlet.User
-				user, _, err = model.GetUser(u.Username())
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to find user and cannot create new one")
-				}
-				return user, nil
-			},
-		}
-
-		cache, err := usercache.NewExternal(opts)
-		if err != nil {
-			return errors.Wrap(err, "setting up user cache backed by DB")
-		}
-		s.UserManager, err = cached.NewUserManager(cache)
-		if err != nil {
-			return errors.Wrap(err, "creating user manager backed by DB")
-		}
-
-	} else if s.Conf.LDAP.URL != "" {
-
-	} else if s.Conf.NaiveAuth.AppAuth {
-		users := []gimlet.BasicUser{}
-		for _, user := range s.Conf.NaiveAuth.Users {
-			users = append(
-				users,
-				gimlet.BasicUser{
-					ID:           user.ID,
-					Name:         user.Name,
-					EmailAddress: user.EmailAddress,
-					Password:     user.Password,
-					Key:          user.Key,
-					AccessRoles:  user.AccessRoles,
-				},
-			)
-		}
-		s.UserManager, err = gimlet.NewBasicUserManager(users, nil)
-		if err != nil {
-			return errors.Wrap(err, "problem setting up basic user manager")
-		}
-	} else {
-		return errors.New("no user authentication set up")
 	}
 
 	if s.Conf.CA.SSLExpireAfter == 0 {
@@ -182,6 +121,243 @@ func (s *Service) Validate() error {
 		"service": s.RPCServers,
 	})
 	return nil
+}
+
+func (s *Service) setupUserAuth() error {
+	var usrMngrs []gimlet.UserManager
+	if s.Conf.ServiceAuth.Enabled {
+		usrMngr, err := s.setupServiceAuth()
+		if err != nil {
+			return errors.Wrap(err, "setting up service user auth")
+		}
+		usrMngrs = append(usrMngrs, usrMngr)
+	}
+	if s.Conf.LDAP.URL != "" {
+		usrMngr, err := s.setupLDAPAuth()
+		if err != nil {
+			return errors.Wrap(err, "setting up LDAP user auth")
+		}
+		usrMngrs = append(usrMngrs, usrMngr)
+	}
+	if s.Conf.NaiveAuth.AppAuth {
+		usrMngr, err := s.setupNaiveAuth()
+		if err != nil {
+			return errors.Wrap(err, "setting up naive user auth")
+		}
+		usrMngrs = append(usrMngrs, usrMngr)
+	}
+
+	if len(usrMngrs) == 0 {
+		return errors.New("no user authentication method could be set up")
+	}
+
+	// Using multiple read-only user managers is only a temporary change to
+	// migrate off of the dependence on the LDAP manager.
+	s.UserManager = gimlet.NewMultiUserManager(nil, usrMngrs)
+
+	return nil
+}
+
+func (s *Service) setupServiceAuth() (gimlet.UserManager, error) {
+	opts := usercache.ExternalOptions{
+		PutUserGetToken: func(gimlet.User) (string, error) {
+			grip.Debug(message.Fields{
+				"op":      "PutUserGetToken",
+				"context": "service user manager",
+			})
+			return "", errors.New("cannot put new users in DB")
+		},
+		GetUserByToken: func(string) (gimlet.User, bool, error) {
+			grip.Debug(message.Fields{
+				"op":      "GetUserByToken",
+				"context": "service user manager",
+			})
+			return nil, false, errors.New("cannot get user by login token")
+		},
+		ClearUserToken: func(gimlet.User, bool) error {
+			grip.Debug(message.Fields{
+				"op":      "ClearUserToken",
+				"context": "service user manager",
+			})
+			return errors.New("cannot clear user login token")
+		},
+		GetUserByID: func(id string) (gimlet.User, bool, error) {
+			msg := message.Fields{
+				"username": id,
+				"op":       "GetUserByID",
+				"context":  "service user manager",
+			}
+			var user gimlet.User
+			user, _, err := model.GetUser(id)
+			if err != nil {
+				msg["message"] = "failed to find user by ID"
+				grip.Debug(message.WrapError(err, msg))
+				return nil, false, errors.Errorf("finding user")
+			}
+			msg["message"] = "successfully found user by ID"
+			msg["user"] = fmt.Sprintf("%#v", user)
+			grip.Debug(msg)
+			return user, true, nil
+		},
+		GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
+			msg := message.Fields{
+				"user":     fmt.Sprintf("%#v", u),
+				"username": u.Username(),
+				"op":       "GetOrCreateUser",
+				"context":  "service user manager",
+			}
+			var user gimlet.User
+			user, _, err := model.GetUser(u.Username())
+			if err != nil {
+				msg["message"] = "failed to find existing user"
+				grip.Debug(message.WrapError(err, msg))
+				return nil, errors.Wrap(err, "failed to find user and cannot create new one")
+			}
+			msg["message"] = "successfully found existing user"
+			msg["user"] = fmt.Sprintf("%#v", u)
+			grip.Debug(msg)
+			return user, nil
+		},
+	}
+
+	cache, err := usercache.NewExternal(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "setting up user cache backed by DB")
+	}
+	usrMngr, err := cached.NewUserManager(cache)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating user manager backed by DB")
+	}
+
+	return usrMngr, nil
+}
+
+func (s *Service) setupLDAPAuth() (gimlet.UserManager, error) {
+	usrMngr, err := ldap.NewUserService(ldap.CreationOpts{
+		URL:          s.Conf.LDAP.URL,
+		Port:         s.Conf.LDAP.Port,
+		UserPath:     s.Conf.LDAP.UserPath,
+		ServicePath:  s.Conf.LDAP.ServicePath,
+		UserGroup:    s.Conf.LDAP.UserGroup,
+		ServiceGroup: s.Conf.LDAP.ServiceGroup,
+		ExternalCache: &usercache.ExternalOptions{
+			PutUserGetToken: func(u gimlet.User) (string, error) {
+				msg := message.Fields{
+					"user":     fmt.Sprintf("%#v", u),
+					"username": u.Username(),
+					"op":       "PutLoginCache",
+					"context":  "LDAP user manager",
+				}
+				token, err := model.PutLoginCache(u)
+				if err != nil {
+					msg["message"] = "failed to update login cache for user"
+					grip.Debug(message.WrapError(err, msg))
+					return "", errors.WithStack(err)
+				}
+				msg["message"] = "successfully updated login cache for user"
+				msg["token"] = token
+				grip.Debug(msg)
+				return token, nil
+			},
+			GetUserByToken: func(token string) (gimlet.User, bool, error) {
+				msg := message.Fields{
+					"token":   token,
+					"op":      "GetUserByToken",
+					"context": "LDAP user manager",
+				}
+				u, valid, err := model.GetLoginCache(token)
+				if err != nil {
+					msg["message"] = "failed to get user by token"
+					grip.Debug(message.WrapError(err, msg))
+					return nil, false, errors.WithStack(err)
+				}
+				msg["message"] = "successfully found user by token"
+				msg["user"] = fmt.Sprintf("%#v", u)
+				msg["username"] = u.Username()
+				msg["valid"] = valid
+				grip.Debug(msg)
+				return u, valid, nil
+			},
+			ClearUserToken: func(u gimlet.User, all bool) error {
+				msg := message.Fields{
+					"user":    fmt.Sprintf("%#v", u),
+					"all":     all,
+					"op":      "ClearUserToken",
+					"context": "LDAP user manager",
+				}
+				if err := model.ClearLoginCache(u, all); err != nil {
+					msg["message"] = "failed to clear user token"
+					grip.Debug(message.WrapError(err, msg))
+					return errors.WithStack(err)
+				}
+				msg["message"] = "successfully cleared user token"
+				grip.Debug(msg)
+				return nil
+			},
+			GetUserByID: func(id string) (gimlet.User, bool, error) {
+				msg := message.Fields{
+					"username": id,
+					"op":       "GetUserByID",
+					"context":  "LDAP user manager",
+				}
+				u, valid, err := model.GetUser(id)
+				if err != nil {
+					msg["message"] = "failed to find user by ID"
+					grip.Debug(message.WrapError(err, msg))
+					return u, valid, errors.WithStack(err)
+				}
+				msg["message"] = "successfully found user by ID"
+				msg["user"] = fmt.Sprintf("%#v", u)
+				msg["valid"] = valid
+				grip.Debug(msg)
+				return u, valid, nil
+			},
+			GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
+				msg := message.Fields{
+					"user":     fmt.Sprintf("%#v", u),
+					"username": u.Username(),
+					"op":       "GetOrCreateUser",
+					"context":  "LDAP user manager",
+				}
+				user, err := model.GetOrAddUser(u)
+				if err != nil {
+					msg["message"] = "failed to get existing or create new user"
+					grip.Debug(message.WrapError(err, msg))
+					return nil, errors.WithStack(err)
+				}
+				msg["message"] = "successfully found existing user or created new user"
+				msg["user"] = fmt.Sprintf("%#v", user)
+				grip.Debug(msg)
+				return user, nil
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "problem setting up ldap user manager")
+	}
+	return usrMngr, nil
+}
+
+func (s *Service) setupNaiveAuth() (gimlet.UserManager, error) {
+	users := []gimlet.BasicUser{}
+	for _, user := range s.Conf.NaiveAuth.Users {
+		users = append(
+			users,
+			gimlet.BasicUser{
+				ID:           user.ID,
+				Name:         user.Name,
+				EmailAddress: user.EmailAddress,
+				Password:     user.Password,
+				Key:          user.Key,
+				AccessRoles:  user.AccessRoles,
+			},
+		)
+	}
+	usrMngr, err := gimlet.NewBasicUserManager(users, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem setting up basic user manager")
+	}
+	return usrMngr, nil
 }
 
 func (s *Service) Start(ctx context.Context) (gimlet.WaitFunc, error) {

--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -104,13 +104,13 @@ func setupAuthRestClient(ctx context.Context, host string, port int) (*rest.Clie
 		Host:     host,
 		Port:     port,
 		Prefix:   "rest",
-		Username: os.Getenv("LDAP_USER"),
+		Username: os.Getenv("SERVICE_USER"),
 	}
 	client, err := rest.NewClient(opts)
 	if err != nil {
 		return nil, err
 	}
-	apiKey, err := client.GetAuthKey(ctx, os.Getenv("LDAP_USER"), os.Getenv("LDAP_PASSWORD"))
+	apiKey, err := client.GetAuthKey(ctx, os.Getenv("SERVICE_USER"), os.Getenv("SERVICE_PASSWORD"))
 	if err != nil {
 		return nil, errors.Wrap(err, "problem authenticating from environment")
 	}
@@ -489,9 +489,10 @@ func TestCuratorSend(t *testing.T) {
 			setup: func(t *testing.T) *exec.Cmd {
 				caData, err := restClient.GetRootCertificate(ctx)
 				require.NoError(t, err)
-				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("LDAP_USER"), os.Getenv("LDAP_PASSWORD"))
+				// kim: TODO: fix
+				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("SERVICE_USER"), os.Getenv("SERVICE_PASSWORD"))
 				require.NoError(t, err)
-				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("LDAP_USER"), os.Getenv("LDAP_PASSWORD"))
+				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("SERVICE_USER"), os.Getenv("SERVICE_PASSWORD"))
 				require.NoError(t, err)
 				require.NoError(t, writeCerts(caData, caCert, userCertData, userCert, userKeyData, userKey))
 

--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -489,7 +489,6 @@ func TestCuratorSend(t *testing.T) {
 			setup: func(t *testing.T) *exec.Cmd {
 				caData, err := restClient.GetRootCertificate(ctx)
 				require.NoError(t, err)
-				// kim: TODO: fix
 				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("SERVICE_USER"), os.Getenv("SERVICE_PASSWORD"))
 				require.NoError(t, err)
 				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("SERVICE_USER"), os.Getenv("SERVICE_PASSWORD"))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9694

This change is mostly a bridge to avoid disrupting all auth to cedar. I'm going to try to migrate some of the users in the database, then see what happens.

* Remove dependence on LDAP. It will now try to auth users using the service user manager, then will fall back to LDAP if it fails.
* Add extra logging to aid in diagnosing auth errors during migration.
* No new users can be created using LDAP or service users. This is mostly to verify that removing `CreateUserToken()` is acceptable. In the future, users will have to ask us to create service users for them manually.
* Drive-by fix for perf test whose success/failure depended on the order of the results from a find query.