### PR TITLE
EVG-9700: Correctly filter groups

### DIFF
--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -519,6 +519,8 @@ func createFindQuery(opts LogFindOptions) map[string]interface{} {
 			bson.M{bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): opts.Group},
 			bson.M{bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): bson.M{"$in": opts.Info.Tags}},
 		}
+	} else if opts.Group != "" {
+		search[bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey)] = opts.Group
 	} else if len(opts.Info.Tags) > 0 {
 		search[bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey)] = bson.M{"$in": opts.Info.Tags}
 	}

--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+
 	"fmt"
 	"hash"
 	"io"
@@ -513,10 +514,12 @@ func createFindQuery(opts LogFindOptions) map[string]interface{} {
 	if opts.Info.Format != "" {
 		search[bsonutil.GetDottedKeyName(logInfoKey, logInfoFormatKey)] = opts.Info.Format
 	}
-	if opts.Group != "" {
-		search[bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey)] = opts.Group
-	}
-	if len(opts.Info.Tags) > 0 {
+	if opts.Group != "" && len(opts.Info.Tags) > 0 {
+		search["$and"] = []bson.M{
+			bson.M{bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): opts.Group},
+			bson.M{bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): bson.M{"$in": opts.Info.Tags}},
+		}
+	} else if len(opts.Info.Tags) > 0 {
 		search[bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey)] = bson.M{"$in": opts.Info.Tags}
 	}
 	if len(opts.Info.Arguments) > 0 {

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -597,19 +597,21 @@ func TestBuildloggerFindLogs(t *testing.T) {
 	log1.ID = log1.Info.ID()
 	log2.Info.Tags = []string{"group", "tag1"}
 	log2.ID = log2.Info.ID()
-	log3, _ := getTestLogs(time.Now().Add(time.Minute))
+	log3, log4 := getTestLogs(time.Now().Add(time.Minute))
 	log3.Info.TestName = "test2"
 	log3.Info.Tags = []string{"group"}
 	log3.ID = log3.Info.ID()
-	log4, _ := getTestLogs(time.Now().Add(2 * time.Minute))
-	log4.Info.Execution = 1
+	log4.Info.Tags = []string{"tag1"}
 	log4.ID = log4.Info.ID()
-	log5, _ := getTestLogs(time.Now().Add(3 * time.Minute))
-	log5.Info.TestName = "test2"
+	log5, _ := getTestLogs(time.Now().Add(2 * time.Minute))
 	log5.Info.Execution = 1
 	log5.ID = log5.Info.ID()
+	log6, _ := getTestLogs(time.Now().Add(3 * time.Minute))
+	log6.Info.TestName = "test2"
+	log6.Info.Execution = 1
+	log6.ID = log6.Info.ID()
 
-	_, err := db.Collection(buildloggerCollection).InsertMany(ctx, []interface{}{log1, log2, log3, log4, log5})
+	_, err := db.Collection(buildloggerCollection).InsertMany(ctx, []interface{}{log1, log2, log3, log4, log5, log6})
 	require.NoError(t, err)
 
 	t.Run("NoEnv", func(t *testing.T) {
@@ -667,10 +669,11 @@ func TestBuildloggerFindLogs(t *testing.T) {
 			Info: LogInfo{Project: log1.Info.Project},
 		}
 		require.NoError(t, logs.Find(ctx, opts))
-		require.Len(t, logs.Logs, 3)
-		assert.Equal(t, log2.ID, logs.Logs[0].ID)
-		assert.Equal(t, log3.ID, logs.Logs[1].ID)
-		assert.Equal(t, log1.ID, logs.Logs[2].ID)
+		require.Len(t, logs.Logs, 4)
+		assert.Equal(t, log4.ID, logs.Logs[0].ID)
+		assert.Equal(t, log2.ID, logs.Logs[1].ID)
+		assert.Equal(t, log3.ID, logs.Logs[2].ID)
+		assert.Equal(t, log1.ID, logs.Logs[3].ID)
 		assert.True(t, logs.populated)
 		assert.Equal(t, opts.TimeRange, logs.timeRange)
 	})
@@ -687,8 +690,8 @@ func TestBuildloggerFindLogs(t *testing.T) {
 		}
 		require.NoError(t, logs.Find(ctx, opts))
 		require.Len(t, logs.Logs, 2)
-		assert.Equal(t, log2.ID, logs.Logs[0].ID)
-		assert.Equal(t, log3.ID, logs.Logs[1].ID)
+		assert.Equal(t, log4.ID, logs.Logs[0].ID)
+		assert.Equal(t, log2.ID, logs.Logs[1].ID)
 		assert.True(t, logs.populated)
 		assert.Equal(t, opts.TimeRange, logs.timeRange)
 	})
@@ -705,8 +708,8 @@ func TestBuildloggerFindLogs(t *testing.T) {
 		}
 		require.NoError(t, logs.Find(ctx, opts))
 		require.Len(t, logs.Logs, 2)
-		assert.Equal(t, log5.ID, logs.Logs[0].ID)
-		assert.Equal(t, log4.ID, logs.Logs[1].ID)
+		assert.Equal(t, log6.ID, logs.Logs[0].ID)
+		assert.Equal(t, log5.ID, logs.Logs[1].ID)
 		assert.True(t, logs.populated)
 		assert.Equal(t, opts.TimeRange, logs.timeRange)
 	})
@@ -737,14 +740,14 @@ func TestBuildloggerFindLogs(t *testing.T) {
 				EndAt:   time.Now(),
 			},
 			Info: LogInfo{
-				TaskID: log1.Info.TaskID,
+				TaskID: log2.Info.TaskID,
 				Tags:   []string{"tag1", "tag2"},
 			},
 			Group: "group",
 		}
 		require.NoError(t, logs.Find(ctx, opts))
 		require.Len(t, logs.Logs, 1)
-		assert.Equal(t, log1.ID, logs.Logs[0].ID)
+		assert.Equal(t, log2.ID, logs.Logs[0].ID)
 		assert.True(t, logs.populated)
 		assert.Equal(t, opts.TimeRange, logs.timeRange)
 	})

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -599,7 +599,6 @@ func TestBuildloggerFindLogs(t *testing.T) {
 	log2.ID = log2.Info.ID()
 	log3, log4 := getTestLogs(time.Now().Add(time.Minute))
 	log3.Info.TestName = "test2"
-	log3.Info.Tags = []string{"group"}
 	log3.ID = log3.Info.ID()
 	log4.Info.Tags = []string{"tag1"}
 	log4.ID = log4.Info.ID()
@@ -725,13 +724,12 @@ func TestBuildloggerFindLogs(t *testing.T) {
 			Group: "group",
 		}
 		require.NoError(t, logs.Find(ctx, opts))
-		require.Len(t, logs.Logs, 2)
-		assert.Equal(t, log3.ID, logs.Logs[0].ID)
-		assert.Equal(t, log1.ID, logs.Logs[1].ID)
+		require.Len(t, logs.Logs, 1)
+		assert.Equal(t, log1.ID, logs.Logs[0].ID)
 		assert.True(t, logs.populated)
 		assert.Equal(t, opts.TimeRange, logs.timeRange)
 	})
-	t.Run("GroupWithTags", func(t *testing.T) {
+	t.Run("GroupWithOverlappingTags", func(t *testing.T) {
 		logs := Logs{}
 		logs.Setup(env)
 		opts := LogFindOptions{

--- a/rest/buildlogger_routes_test.go
+++ b/rest/buildlogger_routes_test.go
@@ -719,7 +719,7 @@ func (s *LogHandlerSuite) TestLogGroupHandlerFound() {
 		rh := s.rh["group"]
 		rh.(*logGroupHandler).opts.TaskID = "task_id1"
 		rh.(*logGroupHandler).opts.TestName = "test1"
-		rh.(*logGroupHandler).groupID = "tag1"
+		rh.(*logGroupHandler).opts.Group = "tag1"
 		rh.(*logGroupHandler).opts.Tags = []string{"tag1"}
 		rh.(*logGroupHandler).opts.TimeRange = dbModel.TimeRange{
 			StartAt: time.Now().Add(-24 * time.Hour),
@@ -793,7 +793,7 @@ func (s *LogHandlerSuite) TestLogGroupHandlerFound() {
 
 		// only tests
 		rh.(*logGroupHandler).opts.TestName = "test2"
-		rh.(*logGroupHandler).groupID = "tag3"
+		rh.(*logGroupHandler).opts.Group = "tag3"
 		rh.(*logGroupHandler).opts.Tags = []string{"tag3"}
 		it = dbModel.NewBatchedLogIterator(
 			s.buckets["def"],
@@ -821,7 +821,7 @@ func (s *LogHandlerSuite) TestLogGroupHandlerNotFound() {
 	rh := s.rh["group"]
 	rh.(*logGroupHandler).opts.TaskID = "task_id1"
 	rh.(*logGroupHandler).opts.TestName = "DNE"
-	rh.(*logGroupHandler).groupID = "tag1"
+	rh.(*logGroupHandler).opts.Group = "tag1"
 	rh.(*logGroupHandler).opts.Tags = []string{"tag1"}
 	rh.(*logGroupHandler).opts.TimeRange = dbModel.TimeRange{
 		StartAt: time.Now().Add(-24 * time.Hour),
@@ -839,7 +839,7 @@ func (s *LogHandlerSuite) TestLogGroupHandlerCtxErr() {
 	rh := s.rh["group"]
 	rh.(*logGroupHandler).opts.TaskID = "task_id1"
 	rh.(*logGroupHandler).opts.TestName = "test1"
-	rh.(*logGroupHandler).groupID = "tag1"
+	rh.(*logGroupHandler).opts.Group = "tag1"
 	rh.(*logGroupHandler).opts.Tags = []string{"tag1"}
 	rh.(*logGroupHandler).opts.TimeRange = dbModel.TimeRange{
 		StartAt: time.Now().Add(-24 * time.Hour),
@@ -982,7 +982,7 @@ func getLogTags(rh gimlet.RouteHandler, handler string) []string {
 	case "test_name":
 		return rh.(*logGetByTestNameHandler).opts.Tags
 	case "group":
-		return rh.(*logGroupHandler).opts.Tags[0 : len(rh.(*logGroupHandler).opts.Tags)-1]
+		return rh.(*logGroupHandler).opts.Tags
 	default:
 		return []string{}
 	}

--- a/rest/data/buildlogger.go
+++ b/rest/data/buildlogger.go
@@ -188,6 +188,7 @@ func (dbc *DBConnector) FindLogsByTestName(ctx context.Context, opts Buildlogger
 		paginated bool
 	)
 
+	opts.Group = ""
 	it, err := dbc.findLogsByTestName(ctx, &opts)
 	if err != nil {
 		return data, time.Time{}, paginated, err
@@ -303,6 +304,7 @@ func (dbc *DBConnector) findLogsByTestName(ctx context.Context, opts *Buildlogge
 			Tags:        opts.Tags,
 		},
 		LatestExecution: opts.EmptyExecution,
+		Group:           opts.Group,
 	}
 	if opts.TestName != "" {
 		dbOpts.Info.TestName = opts.TestName
@@ -516,6 +518,7 @@ func (mc *MockConnector) FindLogsByTestName(ctx context.Context, opts Buildlogge
 		paginated bool
 	)
 
+	opts.Group = ""
 	it, err := mc.findLogsByTestName(ctx, &opts)
 	if err != nil {
 		return data, time.Time{}, paginated, err

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -107,6 +107,7 @@ type BuildloggerOptions struct {
 	Execution      int
 	EmptyExecution bool
 	ProcessName    string
+	Group          string
 	Tags           []string
 	TimeRange      dbModel.TimeRange
 	PrintTime      bool


### PR DESCRIPTION
This ticket is part of [EVG-9700](https://jira.mongodb.org/browse/EVG-9700). It corrects the filtering by "group", which is reality just a tag in the log metadata but needs to be filtered separately in cases where there is a group and tags as the `$in` filter in mongo returns an array with any of the matching fields (rather than all).