### PR TITLE
EVG-9700: Test Buildlogger grouping with disjoint times

### DIFF
--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -432,7 +432,7 @@ func (l *Logs) Find(ctx context.Context, opts LogFindOptions) error {
 		findOpts.SetLimit(opts.Limit)
 	}
 	findOpts.SetSort(bson.D{
-		{Key: logInfoExecutionKey, Value: -1},
+		{Key: bsonutil.GetDottedKeyName(logInfoKey, logInfoExecutionKey), Value: -1},
 		{Key: logCreatedAtKey, Value: -1},
 	})
 	it, err := l.env.GetDB().Collection(buildloggerCollection).Find(ctx, createFindQuery(opts), findOpts)


### PR DESCRIPTION
This is part of [EVG-9700](https://jira.mongodb.org/browse/EVG-9700).
This adds more robust testing for the buildlogger grouping functionality, specifically for grouped logs that have disjoint time ranges. The changes here also fix a bug where the sort field for execution was incorrect.