### PR TITLE
EVG-12649: allow cross-compilation using GOOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ generate-points:$(buildDir)/generate-points
 	./$<
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
 	@mkdir -p $(buildDir)
-	@$(goEnv) $(gobin) build -o $@ $<
+	@GOOS=$(go env GOOS) $(goEnv) $(gobin) build -o $@ $<
 # end dependency installation tools
 
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12649

`make-tarball` will compile to the native GOOS so that it can run, but the cedar binary compiles to the target GOOS (if it's set).