### PR TITLE
EVG-9694: migrate off of LDAP

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -61,7 +61,6 @@ functions:
       add_expansions_to_env: true
       env:
         AUTH_USER: ${auth_user}
-        AUTH_PASSWORD: ${auth_password}
         AUTH_API_KEY: ${auth_api_key}
         GOPATH: ${workdir}/gopath
         UserProfile: C:\\cygwin\\home\\Administrator

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -130,7 +130,7 @@ func getUserCert() cli.Command {
 				Usage: "specify to write certificate files to a file",
 			},
 		),
-		Before: mergeBeforeFuncs(requireStringFlag(userNameFlag), apiKeyFlag),
+		Before: requireStringFlag(userNameFlag),
 		Action: func(c *cli.Context) error {
 			user := c.String(userNameFlag)
 			apiKey := c.String(apiKeyFlag)

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -111,7 +111,6 @@ func unsetFeatureFlag() cli.Command {
 func getUserCert() cli.Command {
 	const (
 		userNameFlag    = "username"
-		passwordFlag    = "password"
 		apiKeyFlag      = "api_key"
 		writeToFileFlag = "dump"
 	)
@@ -124,9 +123,6 @@ func getUserCert() cli.Command {
 				Name: userNameFlag,
 			},
 			cli.StringFlag{
-				Name: passwordFlag,
-			},
-			cli.StringFlag{
 				Name: apiKeyFlag,
 			},
 			cli.BoolFlag{
@@ -134,10 +130,9 @@ func getUserCert() cli.Command {
 				Usage: "specify to write certificate files to a file",
 			},
 		),
-		Before: mergeBeforeFuncs(requireStringFlag(userNameFlag), requireOneFlag(passwordFlag, apiKeyFlag)),
+		Before: mergeBeforeFuncs(requireStringFlag(userNameFlag), apiKeyFlag),
 		Action: func(c *cli.Context) error {
 			user := c.String(userNameFlag)
-			pass := c.String(passwordFlag)
 			apiKey := c.String(apiKeyFlag)
 			host := c.String(clientHostFlag)
 			port := c.Int(clientPortFlag)
@@ -174,7 +169,7 @@ func getUserCert() cli.Command {
 				fmt.Println(ca)
 			}
 
-			cert, err := client.GetUserCertificate(ctx, user, pass, apiKey)
+			cert, err := client.GetUserCertificate(ctx, user, apiKey)
 			if err != nil {
 				return errors.Wrap(err, "problem resolving certificate")
 			}
@@ -196,7 +191,7 @@ func getUserCert() cli.Command {
 				fmt.Println(cert)
 			}
 
-			key, err := client.GetUserCertificateKey(ctx, user, pass, apiKey)
+			key, err := client.GetUserCertificateKey(ctx, user, apiKey)
 			if err != nil {
 				return errors.Wrap(err, "problem resolving certificate key")
 			}

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -169,7 +169,7 @@ func getUserCert() cli.Command {
 				fmt.Println(ca)
 			}
 
-			cert, err := client.GetUserCertificate(ctx, user, apiKey)
+			cert, err := client.GetUserCertificate(ctx, user, "", apiKey)
 			if err != nil {
 				return errors.Wrap(err, "problem resolving certificate")
 			}
@@ -191,7 +191,7 @@ func getUserCert() cli.Command {
 				fmt.Println(cert)
 			}
 
-			key, err := client.GetUserCertificateKey(ctx, user, apiKey)
+			key, err := client.GetUserCertificateKey(ctx, user, "", apiKey)
 			if err != nil {
 				return errors.Wrap(err, "problem resolving certificate key")
 			}

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -108,57 +108,6 @@ func unsetFeatureFlag() cli.Command {
 	}
 }
 
-// TODO (EVG-9694): delete this command
-func getAPIKey() cli.Command {
-	const (
-		userNameFlag = "username"
-		passwordFlag = "password"
-	)
-
-	return cli.Command{
-		Name:  "key",
-		Usage: "get an api key for a given username/password",
-		Flags: restServiceFlags(
-			cli.StringFlag{
-				Name: userNameFlag,
-			},
-			cli.StringFlag{
-				Name: passwordFlag,
-			},
-		),
-		Before: mergeBeforeFuncs(requireStringFlag(userNameFlag), requireStringFlag(passwordFlag)),
-		Action: func(c *cli.Context) error {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			opts := rest.ClientOptions{
-				Host:   c.String(clientHostFlag),
-				Port:   c.Int(clientPortFlag),
-				Prefix: "rest",
-			}
-			client, err := rest.NewClient(opts)
-			if err != nil {
-				return errors.Wrap(err, "problem creating REST client")
-			}
-
-			user := c.String(userNameFlag)
-			pass := c.String(passwordFlag)
-
-			key, err := client.GetAuthKey(ctx, user, pass)
-			if err != nil {
-				return errors.Wrap(err, "problem generating token")
-			}
-
-			grip.Notice(message.Fields{
-				"op":   "generated api token",
-				"user": user,
-				"key":  key,
-			})
-			return nil
-		},
-	}
-}
-
 func getUserCert() cli.Command {
 	const (
 		userNameFlag    = "username"

--- a/rest/client.go
+++ b/rest/client.go
@@ -545,7 +545,8 @@ func (c *Client) authCredRequest(ctx context.Context, url, username, password, a
 		req.Header.Set(cedar.APIKeyHeader, apiKey)
 	} else if password != "" {
 		creds := userCredentials{Username: username, Password: password}
-		payload, err := json.Marshal(creds)
+		var payload []byte
+		payload, err = json.Marshal(creds)
 		if err != nil {
 			return "", errors.Wrap(err, "marshalling user credentials")
 		}
@@ -559,7 +560,8 @@ func (c *Client) authCredRequest(ctx context.Context, url, username, password, a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		var body []byte
+		body, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "reading response body")
 		}

--- a/rest/client.go
+++ b/rest/client.go
@@ -534,16 +534,13 @@ func (c *Client) GetRootCertificate(ctx context.Context) (string, error) {
 	return string(out), nil
 }
 
-func (c *Client) authCredRequest(ctx context.Context, url string, creds *userCredentials) (string, error) {
-	payload, err := json.Marshal(creds)
-	if err != nil {
-		return "", errors.Wrap(err, "problem building payload")
-	}
-
-	req, err := c.makeRequest(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
+func (c *Client) authCredRequest(ctx context.Context, url, username, apiKey string) (string, error) {
+	req, err := c.makeRequest(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "problem building request")
 	}
+	req.Header.Set(cedar.APIUserHeader, username)
+	req.Header.Set(cedar.APIKeyHeader, apiKey)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -568,12 +565,12 @@ func (c *Client) authCredRequest(ctx context.Context, url string, creds *userCre
 	return string(out), nil
 }
 
-func (c *Client) GetUserCertificate(ctx context.Context, username, password, apiKey string) (string, error) {
-	return c.authCredRequest(ctx, c.getURL("/v1/admin/users/certificate"), &userCredentials{Username: username, Password: password, APIKey: apiKey})
+func (c *Client) GetUserCertificate(ctx context.Context, username, apiKey string) (string, error) {
+	return c.authCredRequest(ctx, c.getURL("/v1/admin/users/certificate"), username, apiKey)
 }
 
-func (c *Client) GetUserCertificateKey(ctx context.Context, username, password, apiKey string) (string, error) {
-	return c.authCredRequest(ctx, c.getURL("/v1/admin/users/certificate/key"), &userCredentials{Username: username, Password: password, APIKey: apiKey})
+func (c *Client) GetUserCertificateKey(ctx context.Context, username, apiKey string) (string, error) {
+	return c.authCredRequest(ctx, c.getURL("/v1/admin/users/certificate/key"), username, apiKey)
 }
 
 func (c *Client) FindPerformanceResultById(ctx context.Context, id string) (*model.APIPerformanceResult, error) {

--- a/rest/client.go
+++ b/rest/client.go
@@ -505,48 +505,6 @@ func (c *Client) DisableFeatureFlag(ctx context.Context, name string) (bool, err
 	return out.State, nil
 }
 
-// TODO (EVG-9694): delete this method
-func (c *Client) GetAuthKey(ctx context.Context, username, password string) (string, error) {
-	url := c.getURL("/v1/admin/users/key")
-
-	creds := &userCredentials{Username: username, Password: password}
-	payload, err := json.Marshal(creds)
-	if err != nil {
-		return "", errors.Wrap(err, "problem building payload")
-	}
-
-	req, err := c.makeRequest(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
-	if err != nil {
-		return "", errors.Wrap(err, "problem building request")
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return "", errors.Wrap(err, "problem with request")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		srverr := gimlet.ErrorResponse{}
-		if err := gimlet.GetJSON(resp.Body, &srverr); err != nil {
-			return "", errors.Wrap(err, "problem parsing error message")
-		}
-
-		return "", srverr
-	}
-
-	out := &userAPIKeyResponse{}
-	if err := gimlet.GetJSON(resp.Body, out); err != nil {
-		return "", errors.Wrap(err, "problem parsing response")
-	}
-
-	if username != out.Username {
-		return "", errors.New("service error: mismatched usernames")
-	}
-
-	return out.Key, nil
-}
-
 func (c *Client) GetRootCertificate(ctx context.Context) (string, error) {
 	req, err := c.makeRequest(ctx, http.MethodGet, c.getURL("/v1/admin/ca"), nil)
 	if err != nil {

--- a/rest/routes.go
+++ b/rest/routes.go
@@ -765,7 +765,10 @@ func (s *Service) fetchUserCert(rw http.ResponseWriter, r *http.Request) {
 		})
 	} else {
 		if usr, err = s.checkPayloadCreds(rw, r); err != nil {
-			gimlet.WriteTextResponse(rw, http.StatusUnauthorized, "payload credentials were invalid")
+			gimlet.WriteJSONResponse(rw, http.StatusUnauthorized, gimlet.ErrorResponse{
+				Message:    "payload credentials were invalid",
+				StatusCode: http.StatusUnauthorized,
+			})
 			return
 		}
 		grip.Info(message.Fields{
@@ -834,7 +837,10 @@ func (s *Service) fetchUserCertKey(rw http.ResponseWriter, r *http.Request) {
 		usr = u.Username()
 	} else {
 		if usr, err = s.checkPayloadCreds(rw, r); err != nil {
-			gimlet.WriteTextResponse(rw, http.StatusUnauthorized, "payload credentials were invalid")
+			gimlet.WriteJSONResponse(rw, http.StatusUnauthorized, gimlet.ErrorResponse{
+				Message:    "payload credentials were invalid",
+				StatusCode: http.StatusUnauthorized,
+			})
 			return
 		}
 	}

--- a/rest/service.go
+++ b/rest/service.go
@@ -296,7 +296,6 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/admin/service/flag/{flagName}/enabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagEnabled)
 	s.app.AddRoute("/admin/service/flag/{flagName}/disabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagDisabled)
 	s.app.AddRoute("/admin/ca").Version(1).Get().Handler(s.fetchRootCert)
-	s.app.AddRoute("/admin/users/key").Version(1).Post().Get().Handler(s.fetchUserToken)
 	s.app.AddRoute("/admin/users/certificate").Version(1).Post().Get().Handler(s.fetchUserCert)
 	s.app.AddRoute("/admin/users/certificate/key").Version(1).Post().Get().Handler(s.fetchUserCertKey)
 	s.app.AddRoute("/admin/perf/change_points").Version(1).Post().Wrap(checkUser).RouteHandler(makePerfSignalProcessingRecalculate(s.sc))

--- a/rest/service.go
+++ b/rest/service.go
@@ -296,7 +296,6 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/admin/service/flag/{flagName}/enabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagEnabled)
 	s.app.AddRoute("/admin/service/flag/{flagName}/disabled").Version(1).Post().Wrap(checkUser).Handler(s.setServiceFlagDisabled)
 	s.app.AddRoute("/admin/ca").Version(1).Get().Handler(s.fetchRootCert)
-	// TODO (EVG-9694): delete this route
 	s.app.AddRoute("/admin/users/key").Version(1).Post().Get().Handler(s.fetchUserToken)
 	s.app.AddRoute("/admin/users/certificate").Version(1).Post().Get().Handler(s.fetchUserCert)
 	s.app.AddRoute("/admin/users/certificate/key").Version(1).Post().Get().Handler(s.fetchUserCertKey)

--- a/rest/service.go
+++ b/rest/service.go
@@ -165,58 +165,28 @@ func (s *Service) setupUserAuth() error {
 func (s *Service) setupServiceAuth() (gimlet.UserManager, error) {
 	opts := usercache.ExternalOptions{
 		PutUserGetToken: func(gimlet.User) (string, error) {
-			grip.Debug(message.Fields{
-				"op":      "PutUserGetToken",
-				"context": "service user manager",
-			})
 			return "", errors.New("cannot put new users in DB")
 		},
 		GetUserByToken: func(string) (gimlet.User, bool, error) {
-			grip.Debug(message.Fields{
-				"op":      "GetUserByToken",
-				"context": "service user manager",
-			})
 			return nil, false, errors.New("cannot get user by login token")
 		},
 		ClearUserToken: func(gimlet.User, bool) error {
-			grip.Debug(message.Fields{
-				"op":      "ClearUserToken",
-				"context": "service user manager",
-			})
 			return errors.New("cannot clear user login token")
 		},
 		GetUserByID: func(id string) (gimlet.User, bool, error) {
-			msg := message.Fields{
-				"username": id,
-				"op":       "GetUserByID",
-				"context":  "service user manager",
-			}
 			var user gimlet.User
 			user, _, err := model.GetUser(id)
 			if err != nil {
-				msg["message"] = "failed to find user by ID"
-				grip.Debug(message.WrapError(err, msg))
 				return nil, false, errors.Errorf("finding user")
 			}
-			msg["message"] = "successfully found user by ID"
-			grip.Debug(msg)
 			return user, true, nil
 		},
 		GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-			msg := message.Fields{
-				"username": u.Username(),
-				"op":       "GetOrCreateUser",
-				"context":  "service user manager",
-			}
 			var user gimlet.User
 			user, _, err := model.GetUser(u.Username())
 			if err != nil {
-				msg["message"] = "failed to find existing user"
-				grip.Debug(message.WrapError(err, msg))
 				return nil, errors.Wrap(err, "failed to find user and cannot create new one")
 			}
-			msg["message"] = "successfully found existing user"
-			grip.Debug(msg)
 			return user, nil
 		},
 	}
@@ -242,89 +212,11 @@ func (s *Service) setupLDAPAuth() (gimlet.UserManager, error) {
 		UserGroup:    s.Conf.LDAP.UserGroup,
 		ServiceGroup: s.Conf.LDAP.ServiceGroup,
 		ExternalCache: &usercache.ExternalOptions{
-			PutUserGetToken: func(u gimlet.User) (string, error) {
-				msg := message.Fields{
-					"username": u.Username(),
-					"op":       "PutLoginCache",
-					"context":  "LDAP user manager",
-				}
-				token, err := model.PutLoginCache(u)
-				if err != nil {
-					msg["message"] = "failed to update login cache for user"
-					grip.Debug(message.WrapError(err, msg))
-					return "", errors.WithStack(err)
-				}
-				msg["message"] = "successfully updated login cache for user"
-				msg["token"] = token
-				grip.Debug(msg)
-				return token, nil
-			},
-			GetUserByToken: func(token string) (gimlet.User, bool, error) {
-				msg := message.Fields{
-					"token":   token,
-					"op":      "GetUserByToken",
-					"context": "LDAP user manager",
-				}
-				u, valid, err := model.GetLoginCache(token)
-				if err != nil {
-					msg["message"] = "failed to get user by token"
-					grip.Debug(message.WrapError(err, msg))
-					return nil, false, errors.WithStack(err)
-				}
-				msg["message"] = "successfully found user by token"
-				msg["username"] = u.Username()
-				msg["valid"] = valid
-				grip.Debug(msg)
-				return u, valid, nil
-			},
-			ClearUserToken: func(u gimlet.User, all bool) error {
-				msg := message.Fields{
-					"all":     all,
-					"op":      "ClearUserToken",
-					"context": "LDAP user manager",
-				}
-				if err := model.ClearLoginCache(u, all); err != nil {
-					msg["message"] = "failed to clear user token"
-					grip.Debug(message.WrapError(err, msg))
-					return errors.WithStack(err)
-				}
-				msg["message"] = "successfully cleared user token"
-				grip.Debug(msg)
-				return nil
-			},
-			GetUserByID: func(id string) (gimlet.User, bool, error) {
-				msg := message.Fields{
-					"username": id,
-					"op":       "GetUserByID",
-					"context":  "LDAP user manager",
-				}
-				u, valid, err := model.GetUser(id)
-				if err != nil {
-					msg["message"] = "failed to find user by ID"
-					grip.Debug(message.WrapError(err, msg))
-					return u, valid, errors.WithStack(err)
-				}
-				msg["message"] = "successfully found user by ID"
-				msg["valid"] = valid
-				grip.Debug(msg)
-				return u, valid, nil
-			},
-			GetOrCreateUser: func(u gimlet.User) (gimlet.User, error) {
-				msg := message.Fields{
-					"username": u.Username(),
-					"op":       "GetOrCreateUser",
-					"context":  "LDAP user manager",
-				}
-				user, err := model.GetOrAddUser(u)
-				if err != nil {
-					msg["message"] = "failed to get existing or create new user"
-					grip.Debug(message.WrapError(err, msg))
-					return nil, errors.WithStack(err)
-				}
-				msg["message"] = "successfully found existing user or created new user"
-				grip.Debug(msg)
-				return user, nil
-			},
+			PutUserGetToken: model.PutLoginCache,
+			GetUserByToken:  model.GetLoginCache,
+			ClearUserToken:  model.ClearLoginCache,
+			GetUserByID:     model.GetUser,
+			GetOrCreateUser: model.GetOrAddUser,
 		},
 	})
 	if err != nil {

--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -105,20 +105,11 @@ func setupAuthRestClient(ctx context.Context, host string, port int) (*rest.Clie
 		Port:     port,
 		Prefix:   "rest",
 		Username: os.Getenv("AUTH_USER"),
+		ApiKey:   os.Getenv("AUTH_API_KEY"),
 	}
 	client, err := rest.NewClient(opts)
 	if err != nil {
 		return nil, err
-	}
-	if apiKey := os.Getenv("AUTH_API_KEY"); apiKey != "" {
-		opts.ApiKey = os.Getenv("AUTH_API_KEY")
-	} else {
-		var apiKey string
-		apiKey, err = client.GetAuthKey(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_PASSWORD"))
-		if err != nil {
-			return nil, errors.Wrap(err, "problem authenticating from environment")
-		}
-		opts.ApiKey = apiKey
 	}
 
 	client, err = rest.NewClientFromExisting(client.Client(), opts)
@@ -494,9 +485,9 @@ func TestCuratorSend(t *testing.T) {
 			setup: func(t *testing.T) *exec.Cmd {
 				caData, err := restClient.GetRootCertificate(ctx)
 				require.NoError(t, err)
-				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_PASSWORD"), os.Getenv("AUTH_API_KEY"))
+				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_API_KEY"))
 				require.NoError(t, err)
-				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_PASSWORD"), os.Getenv("AUTH_API_KEY"))
+				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_API_KEY"))
 				require.NoError(t, err)
 				require.NoError(t, writeCerts(caData, caCert, userCertData, userCert, userKeyData, userKey))
 
@@ -540,7 +531,6 @@ func TestCertificateGeneration(t *testing.T) {
 
 	user := "evergreen"
 	invalidUser := "invalid"
-	pass := "password"
 	apiKey := "apikey"
 	certDB := "certDepot"
 	collName := "depot"
@@ -610,7 +600,7 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.NotEmpty(t, u.CertReq)
 	})
 	t.Run("CertificateGeneration", func(t *testing.T) {
-		crt, err := restClient.GetUserCertificate(ctx, user, pass, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, crt)
 		u := &certdepot.User{}
@@ -619,14 +609,14 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.NotEmpty(t, u.PrivateKey)
 		assert.NotEmpty(t, u.CertReq)
 
-		key, err := restClient.GetUserCertificateKey(ctx, user, pass, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
 		assert.NoError(t, err)
 		assert.Equal(t, u.PrivateKey, key)
 
 		require.NoError(t, session.DB(certDB).C(collName).RemoveId(user))
 	})
 	t.Run("KeyGeneration", func(t *testing.T) {
-		key, err := restClient.GetUserCertificateKey(ctx, user, pass, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
 		assert.NoError(t, err)
 		u := &certdepot.User{}
 		require.NoError(t, session.DB(certDB).C(collName).FindId(user).One(u))
@@ -634,7 +624,7 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.Equal(t, u.PrivateKey, key)
 		assert.NotEmpty(t, u.CertReq)
 
-		crt, err := restClient.GetUserCertificate(ctx, user, pass, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
 		assert.NoError(t, err)
 		assert.Equal(t, u.Cert, crt)
 	})
@@ -662,7 +652,7 @@ func TestCertificateGeneration(t *testing.T) {
 		oldCrtPayload, err := oldCrt.Export()
 		require.NoError(t, err)
 
-		crtPayload, err := restClient.GetUserCertificate(ctx, user, pass, apiKey)
+		crtPayload, err := restClient.GetUserCertificate(ctx, user, apiKey)
 		assert.NoError(t, err)
 		assert.NotEqual(t, oldCrtPayload, crtPayload)
 
@@ -676,9 +666,9 @@ func TestCertificateGeneration(t *testing.T) {
 	t.Run("CertificateHandshakeValidUser", func(t *testing.T) {
 		ca, err := restClient.GetRootCertificate(ctx)
 		require.NoError(t, err)
-		crt, err := restClient.GetUserCertificate(ctx, user, pass, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
 		require.NoError(t, err)
-		key, err := restClient.GetUserCertificateKey(ctx, user, pass, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
 		require.NoError(t, err)
 		grpcClient, err := getTLSGRPCClient(ctx, localAddress, []byte(ca), []byte(crt), []byte(key))
 		require.NoError(t, err)
@@ -696,9 +686,9 @@ func TestCertificateGeneration(t *testing.T) {
 	t.Run("CertficiateHandshakeInvalidUser", func(t *testing.T) {
 		ca, err := restClient.GetRootCertificate(ctx)
 		require.NoError(t, err)
-		crt, err := restClient.GetUserCertificate(ctx, invalidUser, pass, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, invalidUser, apiKey)
 		require.NoError(t, err)
-		key, err := restClient.GetUserCertificateKey(ctx, invalidUser, pass, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, invalidUser, apiKey)
 		require.NoError(t, err)
 		grpcClient, err := getTLSGRPCClient(ctx, localAddress, []byte(ca), []byte(crt), []byte(key))
 		require.NoError(t, err)

--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -485,9 +485,9 @@ func TestCuratorSend(t *testing.T) {
 			setup: func(t *testing.T) *exec.Cmd {
 				caData, err := restClient.GetRootCertificate(ctx)
 				require.NoError(t, err)
-				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_API_KEY"))
+				userCertData, err := restClient.GetUserCertificate(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_PASSWORD"), os.Getenv("AUTH_API_KEY"))
 				require.NoError(t, err)
-				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_API_KEY"))
+				userKeyData, err := restClient.GetUserCertificateKey(ctx, os.Getenv("AUTH_USER"), os.Getenv("AUTH_PASSWORD"), os.Getenv("AUTH_API_KEY"))
 				require.NoError(t, err)
 				require.NoError(t, writeCerts(caData, caCert, userCertData, userCert, userKeyData, userKey))
 
@@ -531,7 +531,7 @@ func TestCertificateGeneration(t *testing.T) {
 
 	user := "evergreen"
 	invalidUser := "invalid"
-	apiKey := "apikey"
+	pass := "password"
 	certDB := "certDepot"
 	collName := "depot"
 	env := cedar.GetEnvironment()
@@ -600,7 +600,7 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.NotEmpty(t, u.CertReq)
 	})
 	t.Run("CertificateGeneration", func(t *testing.T) {
-		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, pass, "")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, crt)
 		u := &certdepot.User{}
@@ -609,14 +609,14 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.NotEmpty(t, u.PrivateKey)
 		assert.NotEmpty(t, u.CertReq)
 
-		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, pass, "")
 		assert.NoError(t, err)
 		assert.Equal(t, u.PrivateKey, key)
 
 		require.NoError(t, session.DB(certDB).C(collName).RemoveId(user))
 	})
 	t.Run("KeyGeneration", func(t *testing.T) {
-		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, pass, "")
 		assert.NoError(t, err)
 		u := &certdepot.User{}
 		require.NoError(t, session.DB(certDB).C(collName).FindId(user).One(u))
@@ -624,7 +624,7 @@ func TestCertificateGeneration(t *testing.T) {
 		assert.Equal(t, u.PrivateKey, key)
 		assert.NotEmpty(t, u.CertReq)
 
-		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, pass, "")
 		assert.NoError(t, err)
 		assert.Equal(t, u.Cert, crt)
 	})
@@ -652,7 +652,7 @@ func TestCertificateGeneration(t *testing.T) {
 		oldCrtPayload, err := oldCrt.Export()
 		require.NoError(t, err)
 
-		crtPayload, err := restClient.GetUserCertificate(ctx, user, apiKey)
+		crtPayload, err := restClient.GetUserCertificate(ctx, user, pass, "")
 		assert.NoError(t, err)
 		assert.NotEqual(t, oldCrtPayload, crtPayload)
 
@@ -666,9 +666,9 @@ func TestCertificateGeneration(t *testing.T) {
 	t.Run("CertificateHandshakeValidUser", func(t *testing.T) {
 		ca, err := restClient.GetRootCertificate(ctx)
 		require.NoError(t, err)
-		crt, err := restClient.GetUserCertificate(ctx, user, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, user, pass, "")
 		require.NoError(t, err)
-		key, err := restClient.GetUserCertificateKey(ctx, user, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, user, pass, "")
 		require.NoError(t, err)
 		grpcClient, err := getTLSGRPCClient(ctx, localAddress, []byte(ca), []byte(crt), []byte(key))
 		require.NoError(t, err)
@@ -686,9 +686,9 @@ func TestCertificateGeneration(t *testing.T) {
 	t.Run("CertficiateHandshakeInvalidUser", func(t *testing.T) {
 		ca, err := restClient.GetRootCertificate(ctx)
 		require.NoError(t, err)
-		crt, err := restClient.GetUserCertificate(ctx, invalidUser, apiKey)
+		crt, err := restClient.GetUserCertificate(ctx, invalidUser, pass, "")
 		require.NoError(t, err)
-		key, err := restClient.GetUserCertificateKey(ctx, invalidUser, apiKey)
+		key, err := restClient.GetUserCertificateKey(ctx, invalidUser, pass, "")
 		require.NoError(t, err)
 		grpcClient, err := getTLSGRPCClient(ctx, localAddress, []byte(ca), []byte(crt), []byte(key))
 		require.NoError(t, err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9694

I'm going to migrate the settings off of LDAP and deploy after this is merged.

* Remove REST routes and REST client methods that auth to retrieve the API key.
* Remove debug logs for migration.
* Remove all places that give password as credentials to server except where necessary to use naive auth in tests. For production, we don't use naive auth so it doesn't matter.