### PR TITLE
EVG-12752: Add FindByTaskID method to system metrics model

### DIFF
--- a/model/system_metrics.go
+++ b/model/system_metrics.go
@@ -121,7 +121,8 @@ func (sm *SystemMetrics) Find(ctx context.Context) error {
 	return nil
 }
 
-// SystemMetricsFindOptions allows for querying with or without execution val.
+// SystemMetricsFindOptions allows for querying by task id with or without an
+// execution value.
 type SystemMetricsFindOptions struct {
 	TaskID         string
 	Execution      int

--- a/model/system_metrics_test.go
+++ b/model/system_metrics_test.go
@@ -86,6 +86,7 @@ func TestSystemMetricsFindByTaskID(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -89,7 +89,8 @@ func (t *TestResults) Find(ctx context.Context) error {
 	return nil
 }
 
-// TestResultsFindOptions allows for querying with or without execution val.
+// TestResultsFindOptions allows for querying by task id  with or without an
+// execution value.
 type TestResultsFindOptions struct {
 	TaskID         string
 	Execution      int

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -115,19 +115,17 @@ func TestTestResultsFindByTaskID(t *testing.T) {
 	t.Run("NoEnv", func(t *testing.T) {
 		tr := TestResults{}
 		tropts := TestResultsFindOptions{
-			TaskID:         tr1.Info.TaskID,
-			Execution:      tr1.Info.Execution,
-			EmptyExecution: false,
+			TaskID:    tr1.Info.TaskID,
+			Execution: tr1.Info.Execution,
 		}
 		assert.Error(t, tr.FindByTaskID(ctx, tropts))
 		assert.False(t, tr.populated)
 	})
-	t.Run("WithTaskIDandExecution", func(t *testing.T) {
+	t.Run("WithTaskIDAndExecution", func(t *testing.T) {
 		tr := TestResults{}
 		tropts := TestResultsFindOptions{
-			TaskID:         tr1.Info.TaskID,
-			Execution:      tr1.Info.Execution,
-			EmptyExecution: false,
+			TaskID:    tr1.Info.TaskID,
+			Execution: tr1.Info.Execution,
 		}
 		tr.Setup(env)
 		require.NoError(t, tr.FindByTaskID(ctx, tropts))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12752

This is the first of a series of tickets to add the rest route to fetch system metrics data. This ticket:
1.) Adds a `FindByTaskID` method on the `SystemMetrics` struct in the `model` package.
2.) Cleans up some tests and comments.