### PR TITLE
EVG-12752: System metrics reader should be a read closer

### DIFF
--- a/model/system_metrics_test.go
+++ b/model/system_metrics_test.go
@@ -39,6 +39,7 @@ func TestSystemMetricsFind(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()

--- a/model/system_metrics_test.go
+++ b/model/system_metrics_test.go
@@ -538,7 +538,7 @@ func TestSystemMetricsDownload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		rawReader, ok := reader.(*systemMetricsReader)
+		rawReader, ok := reader.(*systemMetricsReadCloser)
 		require.True(t, ok)
 		assert.Equal(t, expectedBucket, rawReader.bucket)
 		assert.Equal(t, systemMetrics2.Artifact.MetricChunks["TestType1"].Chunks, rawReader.chunks)
@@ -563,7 +563,7 @@ func TestSystemMetricsDownload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		rawReader, ok := reader.(*systemMetricsReader)
+		rawReader, ok := reader.(*systemMetricsReadCloser)
 		require.True(t, ok)
 		assert.Equal(t, expectedBucket, rawReader.bucket)
 		assert.Equal(t, systemMetrics2.Artifact.MetricChunks["TestType1"].Chunks, rawReader.chunks)
@@ -631,7 +631,7 @@ func TestSystemMetricsClose(t *testing.T) {
 	})
 }
 
-func TestSystemMetricsReader(t *testing.T) {
+func TestSystemMetricsReadCloser(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tmpDir, err := ioutil.TempDir(".", "system-metrics-reader-test")
@@ -651,7 +651,7 @@ func TestSystemMetricsReader(t *testing.T) {
 
 	t.Run("Read", func(t *testing.T) {
 
-		r := &systemMetricsReader{
+		r := &systemMetricsReadCloser{
 			ctx:       ctx,
 			bucket:    bucket,
 			batchSize: 2,
@@ -678,12 +678,13 @@ func TestSystemMetricsReader(t *testing.T) {
 		n, err := r.Read(p)
 		assert.Zero(t, n)
 		assert.Error(t, err)
+		assert.NoError(t, r.Close())
 	})
 	t.Run("ContextError", func(t *testing.T) {
 		errCtx, errCancel := context.WithCancel(context.Background())
 		errCancel()
 
-		r := NewSystemMetricsReader(errCtx, bucket, MetricChunks{
+		r := NewSystemMetricsReadCloser(errCtx, bucket, MetricChunks{
 			Chunks: keys,
 			Format: FileText,
 		}, 2)
@@ -691,6 +692,7 @@ func TestSystemMetricsReader(t *testing.T) {
 		n, err := r.Read(p)
 		assert.Zero(t, n)
 		assert.Error(t, err)
+		assert.NoError(t, r.Close())
 	})
 }
 

--- a/rest/service.go
+++ b/rest/service.go
@@ -328,5 +328,6 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/buildlogger/test_name/{task_id}/{test_name}/meta").Version(1).Get().Wrap(evgAuthReadLogByTaskID).RouteHandler(makeGetLogMetaByTestName(s.sc))
 	s.app.AddRoute("/buildlogger/test_name/{task_id}/{test_name}/group/{group_id}").Version(1).Get().Wrap(evgAuthReadLogByTaskID).RouteHandler(makeGetLogGroup(s.sc))
 
+	s.app.AddRoute("/testresults/test_name/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskId(s.sc))
 	s.app.AddRoute("/testresults/test_name/{task_id}/{test_name}").Version(1).Get().RouteHandler(makeGetTestResultByTestName(s.sc))
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12752

This PR simply changes the system metrics reader in the `model` package to a read closer; there is an edge case where some of the underlying `io.ReadCloser` objects returned from `pail` are not closed.