### PR TITLE
EVG-9080: use virtual hosted-style S3 URLs

### DIFF
--- a/units/simple_log_save.go
+++ b/units/simple_log_save.go
@@ -105,7 +105,7 @@ func (j *saveSimpleLogToDBJob) Run(ctx context.Context) {
 	doc := &model.LogSegment{
 		LogID:   j.LogID,
 		Segment: j.Increment,
-		URL:     fmt.Sprintf("https://%s.s3.amazonaws.com/%s", conf.BucketName, s3Key),
+		URL:     fmt.Sprintf("http://%s.s3.amazonaws.com/%s", conf.BucketName, s3Key),
 		Bucket:  conf.BucketName,
 		KeyName: s3Key,
 		Metrics: model.LogMetrics{

--- a/units/simple_log_save.go
+++ b/units/simple_log_save.go
@@ -105,7 +105,7 @@ func (j *saveSimpleLogToDBJob) Run(ctx context.Context) {
 	doc := &model.LogSegment{
 		LogID:   j.LogID,
 		Segment: j.Increment,
-		URL:     fmt.Sprintf("http://s3.amazonaws.com/%s/%s", bucket, s3Key),
+		URL:     fmt.Sprintf("https://%s.s3.amazonaws.com/%s", conf.BucketName, s3Key),
 		Bucket:  conf.BucketName,
 		KeyName: s3Key,
 		Metrics: model.LogMetrics{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9080

It seems like most of the URLs already use virtual hosted-style URLs except for this one. Virtual hosted-style URLs won't work well for bucket names with dots unless you use HTTP (which this URL does for some reason) or write your own SSL certificate verification.