### PR TITLE
EVG-12996: fix test results REST routes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
     - goimports
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - unconvert
 

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"path/filepath"
 	"time"
 
 	"github.com/evergreen-ci/cedar"
@@ -303,18 +302,11 @@ func (t *TestResults) GetBucket(ctx context.Context) (pail.Bucket, error) {
 		t.bucket = conf.Bucket.TestResultsBucket
 	}
 
-	var prefix string
-	if t.Artifact.Type == PailLocal {
-		prefix = filepath.Join(testResultsCollection, t.Artifact.Prefix)
-	} else {
-		prefix = fmt.Sprintf("%s/%s", testResultsCollection, t.Artifact.Prefix)
-	}
-
 	bucket, err := t.Artifact.Type.Create(
 		ctx,
 		t.env,
 		t.bucket,
-		prefix,
+		t.Artifact.Prefix,
 		string(pail.S3PermissionsPrivate),
 		true,
 	)

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -385,7 +384,7 @@ func TestTestResultsDownload(t *testing.T) {
 	}()
 
 	tr := getTestResults()
-	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: filepath.Join(testResultsCollection, tr.ID)})
+	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr.ID})
 	require.NoError(t, err)
 
 	resultsMap := map[string]TestResult{}

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -94,7 +94,7 @@ type Connector interface {
 	// FindTestResultsByTaskId queries the database to find all test
 	// results with the given options.
 	FindTestResultsByTaskId(context.Context, dbModel.TestResultsFindOptions) ([]model.APITestResult, error)
-	// FindTestResultsByTestName finds the test result of a single test, specified
+	// FindTestResultByTestName finds the test result of a single test, specified
 	// by the given options.
 	// If execution is not specified, this will return the test result from the most
 	// recent.

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 
 	dbModel "github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/rest/model"
@@ -125,7 +124,7 @@ func (mc *MockConnector) FindTestResultsByTaskId(ctx context.Context, opts dbMod
 
 	bucketOpts := pail.LocalOptions{
 		Path:   mc.Bucket,
-		Prefix: filepath.Join("test_results", testResults.Artifact.Prefix),
+		Prefix: testResults.Artifact.Prefix,
 	}
 	bucket, err := pail.NewLocalBucket(bucketOpts)
 	if err != nil {
@@ -191,7 +190,7 @@ func (mc *MockConnector) FindTestResultByTestName(ctx context.Context, opts Test
 
 	bucketOpts := pail.LocalOptions{
 		Path:   mc.Bucket,
-		Prefix: filepath.Join("test_results", testResults.Artifact.Prefix),
+		Prefix: testResults.Artifact.Prefix,
 	}
 	bucket, err := pail.NewLocalBucket(bucketOpts)
 	if err != nil {

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -52,6 +52,12 @@ func (dbc *DBConnector) FindTestResultsByTaskId(ctx context.Context, options dbM
 		}
 		apiResults = append(apiResults, apiResult)
 	}
+	if err := it.Err(); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "iterating through test results").Error(),
+		}
+	}
 
 	return apiResults, nil
 }
@@ -142,7 +148,12 @@ func (mc *MockConnector) FindTestResultsByTaskId(ctx context.Context, opts dbMod
 			}
 		}
 		apiResults = append(apiResults, apiResult)
-
+	}
+	if err := it.Err(); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "iterating through test results").Error(),
+		}
 	}
 
 	if len(apiResults) == 0 {

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -103,7 +102,7 @@ func (s *testResultsConnectorSuite) setup() {
 
 		opts := pail.LocalOptions{
 			Path:   s.tempDir,
-			Prefix: filepath.Join("test_results", testResults.Artifact.Prefix),
+			Prefix: testResults.Artifact.Prefix,
 		}
 		bucket, err := pail.NewLocalBucket(opts)
 		s.Require().NoError(err)

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -103,7 +102,7 @@ func (s *TestResultsHandlerSuite) setup(tempDir string) {
 		var err error
 		opts := pail.LocalOptions{
 			Path:   s.sc.Bucket,
-			Prefix: filepath.Join("test_results", testResults.Artifact.Prefix),
+			Prefix: testResults.Artifact.Prefix,
 		}
 
 		s.buckets[key], err = pail.NewLocalBucket(opts)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12996

The bucket used for the test result iterator should not include the test results collection name in the prefix. I also added a check for errors after calling `(*TestResultsIterator).Next()`.