### PR TITLE
EVG-13127: add service user to get historical stats project settings

### DIFF
--- a/cost/evg_client.go
+++ b/cost/evg_client.go
@@ -197,9 +197,9 @@ func (c *EvergreenClient) getPath(link string) (string, error) {
 	return path, nil
 }
 
-// get performs a GET request for path, transforms the response body to JSON,
-//and parses the link for the next page (this is empty if there is no next page)
-func (c *EvergreenClient) get(ctx context.Context, path string) ([]byte, string, error) {
+// Get performs a GET request for path, transforms the response body to JSON,
+// and parses the link for the next page (this is empty if there is no next page)
+func (c *EvergreenClient) Get(ctx context.Context, path string) ([]byte, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	link := ""

--- a/cost/evg_client_test.go
+++ b/cost/evg_client_test.go
@@ -32,11 +32,9 @@ func (s *ClientSuite) SetupSuite() {
 }
 
 func (s *ClientSuite) TestDoReqFunction() {
-	//Construct Client
+	client := NewEvergreenClient(s.client, s.info)
 
-	Client := NewEvergreenClient(s.client, s.info)
-
-	resp, err := Client.doReq(context.TODO(), "GET", "/hosts")
+	resp, err := client.doReq(context.TODO(), "GET", "/hosts")
 	s.NoError(err)
 	if s.NotNil(resp) {
 		s.Equal(resp.StatusCode, 200)
@@ -58,19 +56,15 @@ func (s *ClientSuite) TestGetRelFunction() {
 }
 
 func (s *ClientSuite) TestGetPathFunction() {
-	Client := NewEvergreenClient(s.client, s.info)
+	client := NewEvergreenClient(s.client, s.info)
 	link := "<https://evergreen.mongodb.com/rest/v2/hosts?limit=100>; rel=\"next\""
-	path, err := Client.getPath(link)
+	path, err := client.getPath(link)
 	s.Nil(err)
 	s.Equal(path, "/rest/v2/hosts?limit=100")
-	// TODO: ADD THIS BACK IN FOR PRODUCTION EVERGREEN.
-	// link = "<https://thisiswrong.com/limit=100>; rel=\"next\""
-	// _, err = Client.getPath(link)
-	// s.NotNil(err)
 }
 
 func (s *ClientSuite) TestGetFunction() {
-	Client := NewEvergreenClient(s.client, s.info)
-	_, _, err := Client.get(context.Background(), "/hosts")
+	client := NewEvergreenClient(s.client, s.info)
+	_, _, err := client.Get(context.Background(), "/hosts")
 	s.Nil(err)
 }

--- a/cost/evg_distros.go
+++ b/cost/evg_distros.go
@@ -32,7 +32,7 @@ type EvergreenDistroCost struct {
 // GetDistros returns a slice of the names of all distros from the
 // Evergreen API.
 func (c *EvergreenClient) GetDistros(ctx context.Context) ([]string, error) {
-	data, link, err := c.get(ctx, "/distros")
+	data, link, err := c.Get(ctx, "/distros")
 	if err != nil {
 		if c.allowIncompleteResults {
 			return []string{}, nil
@@ -123,7 +123,7 @@ func (c *EvergreenClient) GetDistroCost(ctx context.Context, distroID string, st
 	st := startAt.Format("2006-01-02T15:04:05Z07:00")
 	dur := strings.TrimRight(fmt.Sprintf("%s ", duration), "0s ")
 
-	data, link, err := c.get(ctx, "/cost/distro/"+distroID+"?starttime="+st+"&duration="+dur)
+	data, link, err := c.Get(ctx, "/cost/distro/"+distroID+"?starttime="+st+"&duration="+dur)
 	if link != "" {
 		return nil, errors.New("/cost/distro should not be a paginated route")
 	}

--- a/cost/evg_projects.go
+++ b/cost/evg_projects.go
@@ -53,7 +53,7 @@ func (c *EvergreenClient) getProjects(ctx context.Context) <-chan projectWorkUni
 	go func() {
 		path := "projects"
 		for {
-			data, link, err := c.get(ctx, path)
+			data, link, err := c.Get(ctx, path)
 			if err != nil {
 				output <- projectWorkUnit{
 					err: err,
@@ -96,7 +96,7 @@ func (c *EvergreenClient) getTaskCostsByProject(ctx context.Context, projectID, 
 		path := "cost/project/" + projectID + "/tasks?starttime=" + starttime +
 			"&limit=20&duration=" + duration
 		for {
-			data, link, err := c.get(ctx, path)
+			data, link, err := c.Get(ctx, path)
 			if err != nil {
 				output <- taskWorkUnit{
 					err: err,

--- a/model/config.go
+++ b/model/config.go
@@ -61,16 +61,23 @@ var (
 )
 
 type EvergreenConfig struct {
-	URL             string `bson:"url" json:"url" yaml:"url"`
-	AuthTokenCookie string `bson:"auth_token_cookie" json:"auth_token_cookie" yaml:"auth_token_cookie"`
-	HeaderKeyName   string `bson:"header_key_name" json:"header_key_name" yaml:"header_key_name"`
-	HeaderUserName  string `bson:"header_user_name" json:"header_user_name" yaml:"header_user_name"`
-	Domain          string `bson:"domain" json:"domain" yaml:"domain"`
+	URL               string `bson:"url" json:"url" yaml:"url"`
+	AuthTokenCookie   string `bson:"auth_token_cookie" json:"auth_token_cookie" yaml:"auth_token_cookie"`
+	HeaderKeyName     string `bson:"header_key_name" json:"header_key_name" yaml:"header_key_name"`
+	HeaderUserName    string `bson:"header_user_name" json:"header_user_name" yaml:"header_user_name"`
+	Domain            string `bson:"domain" json:"domain" yaml:"domain"`
+	ServiceUserName   string `bson:"service_user_name" json:"service_user_name" yaml:"service_user_name"`
+	ServiceUserAPIKey string `bson:"service_user_api_key" json:"service_user_api_key" yaml:"service_user_api_key"`
 }
 
 var (
 	cedarEvergreenConfigURLKey             = bsonutil.MustHaveTag(EvergreenConfig{}, "URL")
 	cedarEvergreenConfigAuthTokenCookieKey = bsonutil.MustHaveTag(EvergreenConfig{}, "AuthTokenCookie")
+	cedarEvergreenConfigHeaderKeyName      = bsonutil.MustHaveTag(EvergreenConfig{}, "HeaderKeyName")
+	cedarEvergreenConfigHeaderUserName     = bsonutil.MustHaveTag(EvergreenConfig{}, "HeaderUserName")
+	cedarEvergreenConfigDomain             = bsonutil.MustHaveTag(EvergreenConfig{}, "Domain")
+	cedarEvergreenConfigServiceUserName    = bsonutil.MustHaveTag(EvergreenConfig{}, "ServiceUserName")
+	cedarEvergreenConfigServiceUserAPIKey  = bsonutil.MustHaveTag(EvergreenConfig{}, "ServiceUserAPIKey")
 )
 
 type ChangeDetectorConfig struct {

--- a/model/config_flags.go
+++ b/model/config_flags.go
@@ -11,6 +11,7 @@ type OperationalFlags struct {
 	DisableCostReportingJob         bool `bson:"disable_cost_reporting" json:"disable_cost_reporting" yaml:"disable_cost_reporting"`
 	DisableInternalMetricsReporting bool `bson:"disable_internal_metrics_reporting" json:"disable_internal_metrics_reporting" yaml:"disable_internal_metrics_reporting"`
 	DisableSignalProcessing         bool `bson:"disable_signal_processing" json:"disable_signal_processing" yaml:"disable_signal_processing"`
+	DisableHistoricalStats          bool `bson:"disable_historical_stats" json:"disable_historical_stats" yaml:"disable_historical_stats"`
 
 	env cedar.Environment
 }

--- a/units/historical_stats.go
+++ b/units/historical_stats.go
@@ -1,0 +1,102 @@
+package units
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/cost"
+	"github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/pkg/errors"
+)
+
+const historicalStatsJobName = "historical-stats"
+
+type historicalStatsJob struct {
+	job.Base    `bson:"job_base" json:"job_base" yaml:"job_base"`
+	ProjectID   string `bson:"project_id" json:"project_id" yaml:"project_id"`
+	RequestType string `bson:"request_type" json:"request_type" yaml:"request_type"`
+
+	env      cedar.Environment
+	settings historicalStatsProjectSettings
+}
+
+func NewHistoricalStatsJob(env cedar.Environment, projectID, requestType string) amboy.Job {
+	j := makeHistoricalStatsJob()
+	j.env = env
+	j.ProjectID = projectID
+	j.RequestType = requestType
+	return j
+}
+func makeHistoricalStatsJob() *historicalStatsJob {
+	j := &historicalStatsJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    historicalStatsJobName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+func (j *historicalStatsJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = cedar.GetEnvironment()
+	}
+
+	conf := model.NewCedarConfig(j.env)
+	if err := conf.Find(); err != nil {
+		j.AddError(errors.Wrap(err, "finding cedar configuration"))
+		return
+	}
+	if conf.Flags.DisableHistoricalStats {
+		return
+	}
+
+	if err := j.getHistoricalStatsSettings(ctx, conf); err != nil {
+		j.AddError(errors.Wrapf(err, "getting historical stats settings for project '%s'", j.ProjectID))
+		return
+	}
+	if j.settings.DisabledStatsCache {
+		return
+	}
+
+	// TODO (EVG-8914): implement historical stats job
+}
+
+// getHistoricalStatsSettings gets the project settings from Evergreen.
+func (j *historicalStatsJob) getHistoricalStatsSettings(ctx context.Context, conf *model.CedarConfig) error {
+	client := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(client)
+	connInfo := &model.EvergreenConnectionInfo{
+		RootURL: conf.Evergreen.URL,
+		User:    conf.Evergreen.ServiceUserName,
+		Key:     conf.Evergreen.ServiceUserAPIKey,
+	}
+	evgClient := cost.NewEvergreenClient(client, connInfo)
+
+	resp, _, err := evgClient.Get(ctx, fmt.Sprintf("/projects/%s", j.ProjectID))
+	if err != nil {
+		return errors.Wrap(err, "requesting project settings")
+	}
+	var settings historicalStatsProjectSettings
+	if err := json.Unmarshal(resp, &settings); err != nil {
+		return errors.Wrapf(err, "reading historical stats settings from project '%s'", j.ProjectID)
+	}
+	j.settings = settings
+	return nil
+}
+
+type historicalStatsProjectSettings struct {
+	DisabledStatsCache    bool     `json:"disabled_stats_cache"`
+	FilesIgnoredFromCache []string `json:"files_ignored_from_cache"`
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13127

* Add service user to Cedar global configuration to auth into Evergreen's REST API and get historical stats settings for the project.
    * I'm going to add a service user in Evergreen with permission to read the project settings.
* Write stub of historical stats job that only gets project settings.