### PR TITLE
EVG-13132: set task ID and execution number for test result

### DIFF
--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -428,6 +429,10 @@ func TestAttachResultData(t *testing.T) {
 }
 
 func TestCuratorSend(t *testing.T) {
+	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_INTEGRATION_TESTS")); skip {
+		t.Skip("SKIP_INTEGRATION_TESTS is set, skipping integration test with Curator")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/rpc/internal/test_results_service.go
+++ b/rpc/internal/test_results_service.go
@@ -60,6 +60,8 @@ func (s *testResultsService) AddTestResults(ctx context.Context, results *TestRe
 		if err != nil {
 			return nil, newRPCError(codes.InvalidArgument, errors.Wrapf(err, "problem exporting test result"))
 		}
+		exportedResult.TaskID = record.Info.TaskID
+		exportedResult.Execution = record.Info.Execution
 		exportedResults[i] = exportedResult
 	}
 

--- a/rpc/internal/test_results_service_test.go
+++ b/rpc/internal/test_results_service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"gopkg.in/mgo.v2/bson"
 )
 
 func TestCreateTestResultsRecord(t *testing.T) {
@@ -209,6 +210,18 @@ func TestAddTestResults(t *testing.T) {
 				require.NoError(t, err)
 				count := 0
 				for it.Next(ctx) {
+					reader, err := it.Item().Get(ctx)
+					require.NoError(t, err)
+					defer func() {
+						assert.NoError(t, reader.Close())
+					}()
+					b, err := ioutil.ReadAll(reader)
+					require.NoError(t, err)
+					var tr model.TestResult
+					require.NoError(t, bson.Unmarshal(b, &tr))
+					assert.Equal(t, r.Info.TaskID, tr.TaskID)
+					assert.Equal(t, r.Info.Execution, tr.Execution)
+
 					count++
 				}
 				assert.Equal(t, 3, count)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13132

The gRPC TestResult payload does not include the task ID and execution, so we have to pull this information from the DB's TestResults record to store it with the S3 test result.

I also added a flag like we use in Evergreen to skip integration tests, since they're difficult to test without CI.