### PR TITLE
EVG-13051: fix flaky system metrics tests

### DIFF
--- a/model/system_metrics.go
+++ b/model/system_metrics.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/evergreen-ci/cedar"
 	"github.com/evergreen-ci/pail"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
@@ -243,7 +242,7 @@ func (sm *SystemMetrics) Append(ctx context.Context, metricType string, format F
 		return nil
 	}
 
-	key := fmt.Sprintf("%s-%v", metricType, utility.UnixMilli(time.Now()))
+	key := fmt.Sprintf("%s-%d", metricType, time.Now().UnixNano())
 
 	conf := &CedarConfig{}
 	conf.Setup(sm.env)

--- a/model/system_metrics_test.go
+++ b/model/system_metrics_test.go
@@ -214,14 +214,17 @@ func TestSystemMetricsAppend(t *testing.T) {
 		iter, err := testBucket.List(ctx, systemMetrics.ID)
 		require.NoError(t, err)
 		for iter.Next(ctx) {
-			key, err := filepath.Rel(systemMetrics.ID, iter.Item().Name())
+			var key string
+			key, err = filepath.Rel(systemMetrics.ID, iter.Item().Name())
 			require.NoError(t, err)
-			r, err := iter.Item().Get(ctx)
+			var r io.ReadCloser
+			r, err = iter.Item().Get(ctx)
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, r.Close())
 			}()
-			data, err := ioutil.ReadAll(r)
+			var data []byte
+			data, err = ioutil.ReadAll(r)
 			require.NoError(t, err)
 			keyCheck[string(data)] = key
 		}

--- a/model/system_metrics_test.go
+++ b/model/system_metrics_test.go
@@ -39,7 +39,7 @@ func TestSystemMetricsFind(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()
@@ -87,7 +87,7 @@ func TestSystemMetricsFindByTaskID(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()
@@ -162,6 +162,8 @@ func TestSystemMetricsAppend(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
+	require.NoError(t, db.Collection(configurationCollection).Drop(ctx))
 	tmpDir, err := ioutil.TempDir(".", "append-test")
 	require.NoError(t, err)
 	defer func() {
@@ -239,12 +241,15 @@ func TestSystemMetricsAppend(t *testing.T) {
 		}
 		chunk1Key, ok1 := keyCheck[string(chunk1)]
 		chunk2Key, ok2 := keyCheck[string(chunk2)]
-		assert.True(t, ok1 && ok2)
+		require.True(t, ok1 && ok2)
+		require.True(t, len(chunk1Key) > 5, "chunk 1 key length: %d", len(chunk1Key))
+		require.True(t, len(chunk2Key) > 5, "chunk 2 key length: %d", len(chunk2Key))
 		assert.Equal(t, "Test-", chunk1Key[:5])
 		assert.Equal(t, "Test-", chunk2Key[:5])
-		chunk1Nanos, err1 := strconv.ParseInt(chunk1Key[5:], 10, 64)
-		chunk2Nanos, err2 := strconv.ParseInt(chunk2Key[5:], 10, 64)
-		assert.NoError(t, err1, err2)
+		chunk1Nanos, err := strconv.ParseInt(chunk1Key[5:], 10, 64)
+		require.NoError(t, err)
+		chunk2Nanos, err := strconv.ParseInt(chunk2Key[5:], 10, 64)
+		require.NoError(t, err)
 		assert.True(t, chunk1Nanos < chunk2Nanos)
 
 		sm := &SystemMetrics{}
@@ -260,7 +265,7 @@ func TestSystemMetricsAppendChunkKey(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()
@@ -271,7 +276,7 @@ func TestSystemMetricsAppendChunkKey(t *testing.T) {
 	systemMetrics1 := getSystemMetrics()
 	systemMetrics2 := getSystemMetrics()
 	systemMetrics2.Artifact.MetricChunks = map[string]MetricChunks{
-		"Test": MetricChunks{
+		"Test": {
 			Chunks: []string{key1, key2},
 			Format: FileText,
 		},
@@ -348,6 +353,7 @@ func TestSystemMetricsRemove(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()
@@ -393,6 +399,7 @@ func TestSystemMetricsSaveNew(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()
@@ -475,6 +482,8 @@ func TestSystemMetricsDownload(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
+	require.NoError(t, db.Collection(configurationCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
@@ -635,6 +644,7 @@ func TestSystemMetricsClose(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := env.Context()
 	defer cancel()
+	require.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(systemMetricsCollection).Drop(ctx))
 	}()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13051

The tests appear to be flaking because `(*model.SystemMetrics).Append()` relies on using unix timestamps in milliseconds for unique keys in the bucket. However, tests sometimes run fast enough that two calls to `Append()` occur within the same millisecond, which causes the earlier one to be overwritten.

The buildlogger tests that use `(*model.Log).Append()` also suffer from flakiness because they use sleeping and unix timestamps in milliseconds.

* Drop test collections during test setup.
* Use unix nanosecond timestamps instead of millisecond timestamps (while it's not perfect, it's highly unlikely that two `Append()` calls would occur in the same nanosecond).
* Remove reliance on sleeping in system metrics test.
