### PR TITLE
EVG-13301: Merge rollups when saving new perf data

### DIFF
--- a/model/perf_data.go
+++ b/model/perf_data.go
@@ -126,7 +126,6 @@ func (r *PerfRollups) Add(ctx context.Context, rollup PerfRollupValue) error {
 				},
 			})
 	}
-
 	if err != nil {
 		return errors.Wrap(err, "problem adding rollup")
 	}

--- a/model/perf_data_test.go
+++ b/model/perf_data_test.go
@@ -291,6 +291,19 @@ func (s *perfRollupSuite) TestUpdateExistingEntry() {
 	s.Equal(out.Rollups.Stats[0].Value, 12.24)
 	s.Equal(out.Rollups.Stats[0].UserSubmitted, true)
 
+	s.Require().NoError(s.r.Add(s.ctx, PerfRollupValue{
+		Name:          "mean",
+		Version:       4,
+		Value:         24.12,
+		MetricType:    MetricTypeMax,
+		UserSubmitted: true,
+	}))
+	s.Require().NoError(c.FindOne(s.ctx, search).Decode(&out))
+	s.Require().Len(out.Rollups.Stats, 1)
+	s.Equal(out.Rollups.Stats[0].Version, 4)
+	s.Equal(out.Rollups.Stats[0].Value, 24.12)
+	s.Equal(out.Rollups.Stats[0].UserSubmitted, true)
+
 	s.NoError(s.r.Add(s.ctx, PerfRollupValue{
 		Name:          "mean",
 		Version:       5,

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -131,7 +131,8 @@ func TestPerfSaveNew(t *testing.T) {
 		assert.Equal(t, result1.ID, savedResult.ID)
 		assert.Equal(t, result1.Info, savedResult.Info)
 		assert.Equal(t, result1.Artifacts, savedResult.Artifacts)
-		assert.Equal(t, result1.Rollups, savedResult.Rollups)
+		assert.Equal(t, result1.Rollups.Stats, savedResult.Rollups.Stats)
+		assert.True(t, time.Since(savedResult.Rollups.ProcessedAt) < time.Minute)
 	})
 	t.Run("WithoutID", func(t *testing.T) {
 		savedResult := &PerformanceResult{}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13301

There are two ways to add rollups: (1) via `PerformanceResult.SaveNew` and (2) via `PerformanceResult.MergeRollups`. The latter ensures no duplicate rollup names are added and checks against the version of a rollup (if it exists already). This PR refactors `PerformanceResult.SaveNew` to use `MergeRollups` instead of inserting the rollups as they are.