### PR TITLE
EVG-13536: Add perf rollups based on counter.n

### DIFF
--- a/perf/ftdc_rollups.go
+++ b/perf/ftdc_rollups.go
@@ -11,6 +11,7 @@ import (
 type PerformanceStatistics struct {
 	counters struct {
 		operationsTotal int64
+		documentsTotal  int64
 		sizeTotal       int64
 		errorsTotal     int64
 	}
@@ -59,6 +60,8 @@ func CreatePerformanceStats(dx *ftdc.ChunkIterator) (*PerformanceStatistics, err
 			switch name := metric.Key(); name {
 			case "counters.ops":
 				perfStats.counters.operationsTotal = metric.Values[len(metric.Values)-1]
+			case "counters.n":
+				perfStats.counters.documentsTotal = metric.Values[len(metric.Values)-1]
 			case "counters.size":
 				perfStats.counters.sizeTotal = metric.Values[len(metric.Values)-1]
 			case "counters.errors":
@@ -85,7 +88,7 @@ func CreatePerformanceStats(dx *ftdc.ChunkIterator) (*PerformanceStatistics, err
 				}
 				t := metric.Values[len(metric.Values)-1]
 				end = time.Unix(t/1000, t%1000*1000000)
-			case "counters.n", "id":
+			case "id":
 				continue
 			default:
 				return nil, errors.Errorf("unknown field name %s", name)

--- a/perf/rollup_factory.go
+++ b/perf/rollup_factory.go
@@ -18,6 +18,7 @@ var rollupsMap = map[string]RollupFactory{
 	latencyAverageName:      &latencyAverage{},
 	sizeAverageName:         &sizeAverage{},
 	operationThroughputName: &operationThroughput{},
+	documentThroughputName:  &documentThroughput{},
 	sizeThroughputName:      &sizeThroughput{},
 	errorThroughputName:     &errorThroughput{},
 	latencyPercentileName:   &latencyPercentile{},
@@ -26,6 +27,7 @@ var rollupsMap = map[string]RollupFactory{
 	durationSumName:         &durationSum{},
 	errorsSumName:           &errorsSum{},
 	operationsSumName:       &operationsSum{},
+	documentsSumName:        &documentsSum{},
 	sizeSumName:             &sizeSum{},
 	overheadSumName:         &overheadSum{},
 }

--- a/perf/rollup_factory.go
+++ b/perf/rollup_factory.go
@@ -14,7 +14,6 @@ type RollupFactory interface {
 	Calc(*PerformanceStatistics, bool) []model.PerfRollupValue
 }
 
-// TODO: Should this be a registry?
 var rollupsMap = map[string]RollupFactory{
 	latencyAverageName:      &latencyAverage{},
 	sizeAverageName:         &sizeAverage{},
@@ -31,7 +30,6 @@ var rollupsMap = map[string]RollupFactory{
 	overheadSumName:         &overheadSum{},
 }
 
-// TODO: Which function of the two following is better?
 func RollupsMap() map[string]RollupFactory {
 	return rollupsMap
 }
@@ -44,6 +42,7 @@ var defaultRollups = []RollupFactory{
 	&latencyAverage{},
 	&sizeAverage{},
 	&operationThroughput{},
+	&documentThroughput{},
 	&sizeThroughput{},
 	&errorThroughput{},
 	&latencyPercentile{},
@@ -52,6 +51,7 @@ var defaultRollups = []RollupFactory{
 	&durationSum{},
 	&errorsSum{},
 	&operationsSum{},
+	&documentsSum{},
 	&sizeSum{},
 	&overheadSum{},
 }
@@ -134,6 +134,31 @@ func (f *operationThroughput) Calc(s *PerformanceStatistics, user bool) []model.
 
 	if s.timers.totalWallTime > 0 {
 		rollup.Value = float64(s.counters.operationsTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []model.PerfRollupValue{rollup}
+}
+
+type documentThroughput struct{}
+
+const (
+	documentThroughputName    = "DocumentThroughput"
+	documentThroughputVersion = 0
+)
+
+func (f *documentThroughput) Type() string    { return documentThroughputName }
+func (f *documentThroughput) Names() []string { return []string{documentThroughputName} }
+func (f *documentThroughput) Version() int    { return documentThroughputVersion }
+func (f *documentThroughput) Calc(s *PerformanceStatistics, user bool) []model.PerfRollupValue {
+	rollup := model.PerfRollupValue{
+		Name:          documentThroughputName,
+		Version:       documentThroughputVersion,
+		MetricType:    model.MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.documentsTotal) / s.timers.totalWallTime.Seconds()
 	}
 
 	return []model.PerfRollupValue{rollup}
@@ -395,6 +420,28 @@ func (f *operationsSum) Calc(s *PerformanceStatistics, user bool) []model.PerfRo
 			Name:          operationsSumName,
 			Value:         s.counters.operationsTotal,
 			Version:       operationsSumVersion,
+			MetricType:    model.MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type documentsSum struct{}
+
+const (
+	documentsSumName    = "DocumentsTotal"
+	documentsSumVersion = 0
+)
+
+func (f *documentsSum) Type() string    { return documentsSumName }
+func (f *documentsSum) Names() []string { return []string{documentsSumName} }
+func (f *documentsSum) Version() int    { return documentsSumVersion }
+func (f *documentsSum) Calc(s *PerformanceStatistics, user bool) []model.PerfRollupValue {
+	return []model.PerfRollupValue{
+		model.PerfRollupValue{
+			Name:          documentsSumName,
+			Value:         s.counters.documentsTotal,
+			Version:       documentsSumVersion,
 			MetricType:    model.MetricTypeSum,
 			UserSubmitted: user,
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13536

This adds two rollups based on `n` (number of documents) from the raw ftdc data, `DocumentThroughput` and `DocumentsTotal`. 