### PR TITLE
EVG-13431: Only report latest execution when forwarding performance results from cedar into signal processing service

### DIFF
--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -192,12 +192,14 @@ func GetPerformanceData(ctx context.Context, env cedar.Environment, performanceR
 			"$sort": bson.M{bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoExecutionKey): 1},
 		},
 		{
-			"_id": bson.M{
-				"task_id": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
+			"$group": bson.M{
+				"_id": bson.M{
+					"task_id": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskIDKey),
+				},
+				"id":      bson.M{"$last": "$_id"},
+				"info":    bson.M{"$last": "$" + perfInfoKey},
+				"rollups": bson.M{"$last": "$" + perfRollupsKey},
 			},
-			"id":      bson.M{"$last": "_id"},
-			"info":    bson.M{"$last": perfInfoKey},
-			"rollups": bson.M{"$last": perfRollupsKey},
 		},
 		{
 			"$unwind": "$" + bsonutil.GetDottedKeyName("rollups", perfRollupsStatsKey),

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -189,29 +189,40 @@ func GetPerformanceData(ctx context.Context, env cedar.Environment, performanceR
 			},
 		},
 		{
-			"$unwind": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey),
+			"$sort": bson.M{bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoExecutionKey): 1},
+		},
+		{
+			"_id": bson.M{
+				"task_id": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
+			},
+			"id":      bson.M{"$last": "_id"},
+			"info":    bson.M{"$last": perfInfoKey},
+			"rollups": bson.M{"$last": perfRollupsKey},
+		},
+		{
+			"$unwind": "$" + bsonutil.GetDottedKeyName("rollups", perfRollupsStatsKey),
 		},
 		{
 			"$group": bson.M{
 				"_id": bson.M{
-					"project":     "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
-					"variant":     "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
-					"task":        "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
-					"test":        "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
-					"measurement": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
-					"args":        "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
+					"project":     "$" + bsonutil.GetDottedKeyName("info", perfResultInfoProjectKey),
+					"variant":     "$" + bsonutil.GetDottedKeyName("info", perfResultInfoVariantKey),
+					"task":        "$" + bsonutil.GetDottedKeyName("info", perfResultInfoTaskNameKey),
+					"test":        "$" + bsonutil.GetDottedKeyName("info", perfResultInfoTestNameKey),
+					"measurement": "$" + bsonutil.GetDottedKeyName("rollups", perfRollupsStatsKey, perfRollupValueNameKey),
+					"args":        "$" + bsonutil.GetDottedKeyName("info", perfResultInfoArgumentsKey),
 				},
 				"time_series": bson.M{
 					"$push": bson.M{
 						"value": bson.M{
 							"$ifNull": bson.A{
-								"$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueValueKey),
+								"$" + bsonutil.GetDottedKeyName("rollups", perfRollupsStatsKey, perfRollupValueValueKey),
 								0,
 							},
 						},
-						"order":          "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey),
-						"perf_result_id": "$_id",
-						"version":        "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey),
+						"order":          "$" + bsonutil.GetDottedKeyName("info", perfResultInfoOrderKey),
+						"perf_result_id": "$id",
+						"version":        "$" + bsonutil.GetDottedKeyName("info", perfResultInfoVersionKey),
 					},
 				},
 			},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13431

This adds a `$sort` and `$group` stage to the aggregation pipeline when fetching performance data for signal processing. The `$sort` sorts by execution and the `$group` groups by `task_id` using the `$last` accumulator to get only the latest execution in each group.