### PR TITLE
EVG-13447: Implement historical test routes in cedar

### DIFF
--- a/cedar.go
+++ b/cedar.go
@@ -17,10 +17,29 @@ const (
 var BuildRevision = ""
 
 const (
+	// Auth constants.
 	AuthTokenCookie        = "cedar-token"
 	APIUserHeader          = "Api-User"
 	APIKeyHeader           = "Api-Key"
 	EvergreenAPIUserHeader = "Evergreen-Api-User"
 	EvergreenAPIKeyHeader  = "Evergreen-Api-Key"
 	TokenExpireAfter       = time.Hour
+
+	// Version requester types.
+	PatchVersionRequester       = "patch_request"
+	GithubPRRequester           = "github_pull_request"
+	GitTagRequester             = "git_tag_request"
+	RepotrackerVersionRequester = "gitter_request"
+	TriggerRequester            = "trigger_request"
+	MergeTestRequester          = "merge_test"
+	AdHocRequester              = "ad_hoc"
+)
+
+var (
+	// Convenience slice for patch requester types.
+	PatchRequesters = []string{
+		PatchVersionRequester,
+		GithubPRRequester,
+		MergeTestRequester,
+	}
 )

--- a/model/historical_test_data.go
+++ b/model/historical_test_data.go
@@ -298,7 +298,7 @@ var (
 
 // GetHistoricalTestData queries the historical test data using a filter.
 func GetHistoricalTestData(ctx context.Context, env cedar.Environment, filter HistoricalTestDataFilter) ([]AggregatedHistoricalTestData, error) {
-	err := filter.validate()
+	err := filter.Validate()
 	if err != nil {
 		return nil, errors.Wrap(err, "the provided HistoricalTestDataFilter is invalid")
 	}
@@ -401,7 +401,8 @@ type HistoricalTestDataFilter struct {
 	Sort         HTDSort
 }
 
-func (f *HistoricalTestDataFilter) validate() error {
+// Validate ensures that the HistoricalTestDataFilter is valid.
+func (f *HistoricalTestDataFilter) Validate() error {
 	if f == nil {
 		return errors.New("historical test data filter should not be nil")
 	}

--- a/model/historical_test_data.go
+++ b/model/historical_test_data.go
@@ -284,7 +284,6 @@ type AggregatedHistoricalTestData struct {
 	NumPass         int           `bson:"num_pass"`
 	NumFail         int           `bson:"num_fail"`
 	AverageDuration time.Duration `bson:"avg_duration"`
-	LastUpdate      time.Time     `bson:"last_update"`
 }
 
 var (
@@ -295,7 +294,6 @@ var (
 	aggregatedHistoricalTestDataNumPassKey     = bsonutil.MustHaveTag(AggregatedHistoricalTestData{}, "NumPass")
 	aggregatedHistoricalTestDataNumFailKey     = bsonutil.MustHaveTag(AggregatedHistoricalTestData{}, "NumFail")
 	aggregatedHistoricalTestDataAvgDurationKey = bsonutil.MustHaveTag(AggregatedHistoricalTestData{}, "AverageDuration")
-	aggregatedHistoricalTestDataLastUpdateKey  = bsonutil.MustHaveTag(AggregatedHistoricalTestData{}, "LastUpdate")
 )
 
 // GetHistoricalTestData queries the historical test data using a filter.

--- a/model/historical_test_data_test.go
+++ b/model/historical_test_data_test.go
@@ -1634,7 +1634,7 @@ func getHistoricalTestData(t *testing.T) *HistoricalTestData {
 
 	data, err := CreateHistoricalTestData(info)
 	require.NoError(t, err)
-	data.NumPass = rand.Intn(1000)
+	data.NumPass = rand.Intn(1000) + 1
 	var total time.Duration
 	data.NumFail = rand.Intn(1000)
 	for i := 0; i < data.NumPass; i++ {

--- a/rest/data/historical_test_data.go
+++ b/rest/data/historical_test_data.go
@@ -1,0 +1,66 @@
+package data
+
+import (
+	"context"
+	"net/http"
+
+	dbModel "github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/cedar/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+/////////////////////////////
+// DBConnector Implementation
+/////////////////////////////
+
+// GetHistoricalTestData queries the service backend to retrieve the aggregated
+// historical test data that match the given filter.
+func (dbc *DBConnector) GetHistoricalTestData(ctx context.Context, f dbModel.HistoricalTestDataFilter) ([]model.APIAggregatedHistoricalTestData, error) {
+	data, err := dbModel.GetHistoricalTestData(ctx, dbc.env, f)
+	if err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "problem fetching historical test data").Error(),
+		}
+	}
+
+	apiData := make([]model.APIAggregatedHistoricalTestData, len(data))
+	for i, d := range data {
+		if err = apiData[i].Import(d); err != nil {
+			return nil, gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrap(err, "corrupt data for historical test data").Error(),
+			}
+		}
+	}
+
+	return apiData, nil
+}
+
+///////////////////////////////
+// MockConnector Implementation
+///////////////////////////////
+
+// GetHistoricalTestData returns the cached historical test data, only
+// enforcing the Limit field of the filter.
+func (mc *MockConnector) GetHistoricalTestData(ctx context.Context, f dbModel.HistoricalTestDataFilter) ([]model.APIAggregatedHistoricalTestData, error) {
+	var data []dbModel.AggregatedHistoricalTestData
+	if f.Limit > len(mc.CachedHistoricalTestData) || f.Limit < 1 {
+		data = mc.CachedHistoricalTestData
+	} else {
+		data = mc.CachedHistoricalTestData[:f.Limit]
+	}
+
+	apiData := make([]model.APIAggregatedHistoricalTestData, len(data))
+	for i, d := range data {
+		if err := apiData[i].Import(d); err != nil {
+			return nil, gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrap(err, "corrupt data for historical test data").Error(),
+			}
+		}
+	}
+
+	return apiData, nil
+}

--- a/rest/data/historical_test_data_test.go
+++ b/rest/data/historical_test_data_test.go
@@ -1,0 +1,155 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	dbModel "github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/cedar/rest/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistoricalTestDataConnectorDB(t *testing.T) {
+	dbc, cleanup := newDBConnector(t)
+	defer cleanup()
+
+	t.Run("GetHistoricalTestData", func(t *testing.T) {
+		expected := []model.APIAggregatedHistoricalTestData{
+			{
+				TestName:        model.ToAPIString("test1"),
+				TaskName:        model.ToAPIString("task1"),
+				Variant:         model.ToAPIString("v1"),
+				Date:            model.NewTime(utility.GetUTCDay(time.Now())),
+				NumPass:         1,
+				AverageDuration: time.Second.Seconds(),
+			},
+			{
+				TestName:        model.ToAPIString("test2"),
+				TaskName:        model.ToAPIString("task2"),
+				Variant:         model.ToAPIString("v1"),
+				Date:            model.NewTime(utility.GetUTCDay(time.Now())),
+				NumPass:         1,
+				AverageDuration: time.Second.Seconds(),
+			},
+		}
+		data, err := dbc.GetHistoricalTestData(context.TODO(), dbModel.HistoricalTestDataFilter{
+			AfterDate:    utility.GetUTCDay(time.Now().Add(-24 * time.Hour)),
+			BeforeDate:   utility.GetUTCDay(time.Now().Add(24 * time.Hour)),
+			GroupNumDays: 1,
+			Project:      "p1",
+			Requesters:   []string{"r1", "r2"},
+			Tests:        []string{"test1", "test2"},
+			Tasks:        []string{"task1", "task2"},
+			Variants:     []string{"v1", "v2"},
+			GroupBy:      dbModel.HTDGroupByVariant,
+			Sort:         dbModel.HTDSortEarliestFirst,
+			Limit:        1000,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, expected, data)
+	})
+	t.Run("InvalidFilter", func(t *testing.T) {
+		data, err := dbc.GetHistoricalTestData(context.TODO(), dbModel.HistoricalTestDataFilter{
+			AfterDate:  utility.GetUTCDay(time.Now().Add(-24 * time.Hour)),
+			BeforeDate: utility.GetUTCDay(time.Now().Add(24 * time.Hour)),
+			Project:    "p1",
+			Requesters: []string{"r1", "r2"},
+			Tests:      []string{"test1", "test2"},
+			Tasks:      []string{"task1", "task2"},
+			Variants:   []string{"v1", "v2"},
+			GroupBy:    dbModel.HTDGroupByVariant,
+			Sort:       dbModel.HTDSortEarliestFirst,
+			Limit:      1000,
+		})
+		assert.Error(t, err)
+		assert.Nil(t, data)
+	})
+}
+
+func TestHistoricalTestDataConnectorMock(t *testing.T) {
+	mc := newMockConnector()
+	expected := make([]model.APIAggregatedHistoricalTestData, len(mc.CachedHistoricalTestData))
+	for i, data := range mc.CachedHistoricalTestData {
+		require.NoError(t, expected[i].Import(data))
+	}
+
+	t.Run("GetHistoricalTestDataNoLimit", func(t *testing.T) {
+		data, err := mc.GetHistoricalTestData(context.TODO(), dbModel.HistoricalTestDataFilter{})
+		require.NoError(t, err)
+		assert.Equal(t, expected, data)
+	})
+	t.Run("GetHistoricalTestDataLimit", func(t *testing.T) {
+		data, err := mc.GetHistoricalTestData(context.TODO(), dbModel.HistoricalTestDataFilter{Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, expected[:1], data)
+	})
+}
+
+func newDBConnector(t *testing.T) (Connector, func()) {
+	env := cedar.GetEnvironment()
+	db := env.GetDB()
+	require.NotNil(t, db)
+	require.NoError(t, db.Drop(context.TODO()))
+
+	data := []dbModel.HistoricalTestDataInfo{
+		{
+			Project:     "p1",
+			Variant:     "v1",
+			TaskName:    "task1",
+			TestName:    "test1",
+			RequestType: "r1",
+			Date:        time.Now(),
+		},
+		{
+			Project:     "p1",
+			Variant:     "v1",
+			TaskName:    "task2",
+			TestName:    "test2",
+			RequestType: "r1",
+			Date:        time.Now(),
+		},
+	}
+	for _, info := range data {
+		htd, err := dbModel.CreateHistoricalTestData(info)
+		require.NoError(t, err)
+		now := time.Now()
+		htd.Setup(env)
+		require.NoError(t, htd.Update(context.TODO(), dbModel.TestResult{
+			Status:        "pass",
+			TestStartTime: now.Add(-time.Second),
+			TestEndTime:   now,
+		}))
+	}
+
+	return CreateNewDBConnector(env), func() { assert.NoError(t, db.Drop(context.TODO())) }
+}
+
+func newMockConnector() *MockConnector {
+	return &MockConnector{
+		CachedHistoricalTestData: []dbModel.AggregatedHistoricalTestData{
+			{
+				TestName:        "test1",
+				TaskName:        "task1",
+				Variant:         "v1",
+				Date:            time.Now(),
+				NumPass:         1,
+				NumFail:         1,
+				AverageDuration: time.Second,
+			},
+			{
+				TestName:        "test2",
+				TaskName:        "task1",
+				Variant:         "v1",
+				Date:            time.Now(),
+				NumPass:         1,
+				NumFail:         1,
+				AverageDuration: time.Second,
+			},
+		},
+		env: cedar.GetEnvironment(),
+	}
+}

--- a/rest/data/impl.go
+++ b/rest/data/impl.go
@@ -26,6 +26,7 @@ type MockConnector struct {
 	ChildMap                 map[string][]string
 	CachedLogs               map[string]model.Log
 	CachedTestResults        map[string]model.TestResults
+	CachedHistoricalTestData []model.AggregatedHistoricalTestData
 	CachedSystemMetrics      map[string]model.SystemMetrics
 	Users                    map[string]bool
 	Bucket                   string

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -94,11 +94,18 @@ type Connector interface {
 	// FindTestResultsByTaskId queries the database to find all test
 	// results with the given options.
 	FindTestResultsByTaskId(context.Context, dbModel.TestResultsFindOptions) ([]model.APITestResult, error)
-	// FindTestResultByTestName finds the test result of a single test, specified
-	// by the given options.
-	// If execution is not specified, this will return the test result from the most
-	// recent.
+	// FindTestResultByTestName finds the test result of a single test,
+	// specified by the given options.
+	// If execution is not specified, this will return the test result from
+	// the most recent.
 	FindTestResultByTestName(context.Context, TestResultsTestNameOptions) (*model.APITestResult, error)
+
+	///////////////////////
+	// Historical Test Data
+	///////////////////////
+	// GetHistoricalTestData queries the historical test data using a
+	// filter.
+	GetHistoricalTestData(context.Context, dbModel.HistoricalTestDataFilter) ([]model.APIAggregatedHistoricalTestData, error)
 
 	/////////////////
 	// System Metrics

--- a/rest/historical_test_data_routes.go
+++ b/rest/historical_test_data_routes.go
@@ -107,7 +107,9 @@ func (h *historicalTestDataHandler) Run(ctx context.Context) gimlet.Responder {
 				"problem paginating response"))
 		}
 	}
-	resp.AddData(data[:lastIndex])
+	if err = resp.AddData(data[:lastIndex]); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem creating response"))
+	}
 
 	return resp
 }
@@ -145,6 +147,9 @@ func (h *htdFilterHandler) parse(vals url.Values) error {
 	}
 
 	h.filter.StartAt, err = h.readStartAt(vals.Get("start_at"))
+	if err != nil {
+		return err
+	}
 
 	h.filter.GroupBy, err = h.readGroupBy(vals.Get("group_by"))
 	if err != nil {
@@ -236,7 +241,7 @@ func (h *htdFilterHandler) readRequesters(requesters []string) ([]string, error)
 		case htdAPIRequesterAdhoc:
 			requesterValues = append(requesterValues, cedar.AdHocRequester)
 		default:
-			return nil, errors.Errorf("Invalid requester value %v", requester)
+			return nil, errors.Errorf("invalid requester value %v", requester)
 		}
 	}
 	return requesterValues, nil
@@ -266,7 +271,7 @@ func (h *htdFilterHandler) readInt(intString string, min, max, defaultValue int)
 	}
 
 	if value < min || value > max {
-		return 0, errors.New("Invalid int parameter value")
+		return 0, errors.New("invalid int parameter value")
 	}
 	return value, nil
 }

--- a/rest/historical_test_data_routes.go
+++ b/rest/historical_test_data_routes.go
@@ -50,7 +50,7 @@ const (
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// GET /historical_test_data/<project_id>
+// GET /historical_test_data/{project_id}
 
 type historicalTestDataHandler struct {
 	sc data.Connector

--- a/rest/historical_test_data_routes.go
+++ b/rest/historical_test_data_routes.go
@@ -1,0 +1,343 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/cedar/rest/data"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+const (
+	// Requester API values.
+	htdAPIRequesterMainline = "mainline"
+	htdAPIRequesterPatch    = "patch"
+	htdAPIRequesterTrigger  = "trigger"
+	htdAPIRequesterGitTag   = "git_tag"
+	htdAPIRequesterAdhoc    = "adhoc"
+
+	// Sort API values.
+	htdAPISortEarliest = "earliest"
+	htdAPISortLatest   = "latest"
+
+	// GroupBy API values for tests.
+	htdAPITestGroupByDistro  = "test_task_variant_distro"
+	htdAPITestGroupByVariant = "test_task_variant"
+	htdAPITestGroupByTask    = "test_task"
+	htdAPITestGroupByTest    = "test"
+
+	// GroupBy API values for tasks.
+	htdAPITaskGroupByDistro  = "task_variant_distro"
+	htdAPITaskGroupByVariant = "task_variant"
+	htdAPITaskGroupByTask    = "task"
+
+	// API Limits.
+	htdAPIMaxGroupNumDays = 26 * 7 // 26 weeks which is the maximum amount of data available
+	htdAPIMaxNumTests     = 50
+	htdAPIMaxNumTasks     = 50
+	htdAPIMaxLimit        = 1000
+
+	// Format used to encode dates in the API.
+	htdAPIDateFormat = "2006-01-02"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// GET /historical_test_data/<project_id>
+
+type historicalTestDataHandler struct {
+	sc data.Connector
+	htdFilterHandler
+}
+
+func (h *historicalTestDataHandler) Factory() gimlet.RouteHandler {
+	return &historicalTestDataHandler{sc: h.sc}
+}
+
+func (h *historicalTestDataHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.filter = model.HistoricalTestDataFilter{Project: gimlet.GetVars(r)["project_id"]}
+
+	err := h.parse(r.URL.Query())
+	if err != nil {
+		return errors.Wrap(err, "invalid query parameters")
+	}
+
+	err = h.filter.Validate()
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    err.Error(),
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	return nil
+}
+
+func (h *historicalTestDataHandler) Run(ctx context.Context) gimlet.Responder {
+	data, err := h.sc.GetHistoricalTestData(ctx, h.filter)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "problem to fetching historical test data"))
+	}
+
+	resp := gimlet.NewJSONResponse(nil)
+	requestLimit := h.filter.Limit - 1
+	lastIndex := len(data)
+	if len(data) > requestLimit {
+		lastIndex = requestLimit
+
+		err = resp.SetPages(&gimlet.ResponsePages{
+			Next: &gimlet.Page{
+				Relation:        "next",
+				LimitQueryParam: "limit",
+				KeyQueryParam:   "start_at",
+				BaseURL:         baseURL,
+				Key:             data[requestLimit].StartAtKey(),
+				Limit:           requestLimit,
+			},
+		})
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err,
+				"problem paginating response"))
+		}
+	}
+	resp.AddData(data[:lastIndex])
+
+	return resp
+}
+
+func makeGetHistoricalTestData(sc data.Connector) gimlet.RouteHandler {
+	return &historicalTestDataHandler{sc: sc}
+}
+
+// htdFilterHandler handles parsing the url query and populating the
+// HistoricalTestDataFilter for the request.
+type htdFilterHandler struct {
+	filter model.HistoricalTestDataFilter
+}
+
+// parse parses the query parameter values and fills the struct filter field.
+func (h *htdFilterHandler) parse(vals url.Values) error {
+	var err error
+
+	h.filter.Requesters, err = h.readRequesters(h.readStringList(vals["requesters"]))
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "invalid requesters value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	h.filter.Variants = h.readStringList(vals["variants"])
+
+	h.filter.GroupNumDays, err = h.readInt(vals.Get("group_num_days"), 1, htdAPIMaxGroupNumDays, 1)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "invalid group_num_days value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	h.filter.StartAt, err = h.readStartAt(vals.Get("start_at"))
+
+	h.filter.GroupBy, err = h.readGroupBy(vals.Get("group_by"))
+	if err != nil {
+		return err
+	}
+
+	h.filter.Limit, err = h.readInt(vals.Get("limit"), 1, htdAPIMaxLimit, htdAPIMaxLimit)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "invalid limit value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	// Add 1 for pagination.
+	h.filter.Limit++
+
+	h.filter.Tasks = h.readStringList(vals["tasks"])
+	if len(h.filter.Tasks) > htdAPIMaxNumTasks {
+		return gimlet.ErrorResponse{
+			Message:    "too many tasks values",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	beforeDate := vals.Get("before_date")
+	if beforeDate == "" {
+		return gimlet.ErrorResponse{
+			Message:    "missing before_date parameter",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	h.filter.BeforeDate, err = time.ParseInLocation(htdAPIDateFormat, beforeDate, time.UTC)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "invalid before_date value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	afterDate := vals.Get("after_date")
+	if afterDate == "" {
+		return gimlet.ErrorResponse{
+			Message:    "missing after_date parameter",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+	h.filter.AfterDate, err = time.ParseInLocation(htdAPIDateFormat, afterDate, time.UTC)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    "invalid after_date value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	h.filter.Tests = h.readStringList(vals["tests"])
+	if len(h.filter.Tests) > htdAPIMaxNumTests {
+		return gimlet.ErrorResponse{
+			Message:    "too many tests values",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	h.filter.Sort, err = h.readSort(vals.Get("sort"))
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// readRequesters parses requesters parameter values and translates them into a
+// list of internal Evergreen requester names.
+func (h *htdFilterHandler) readRequesters(requesters []string) ([]string, error) {
+	if len(requesters) == 0 {
+		requesters = []string{htdAPIRequesterMainline}
+	}
+
+	requesterValues := []string{}
+	for _, requester := range requesters {
+		switch requester {
+		case htdAPIRequesterMainline:
+			requesterValues = append(requesterValues, cedar.RepotrackerVersionRequester)
+		case htdAPIRequesterPatch:
+			requesterValues = append(requesterValues, cedar.PatchRequesters...)
+		case htdAPIRequesterTrigger:
+			requesterValues = append(requesterValues, cedar.TriggerRequester)
+		case htdAPIRequesterGitTag:
+			requesterValues = append(requesterValues, cedar.GitTagRequester)
+		case htdAPIRequesterAdhoc:
+			requesterValues = append(requesterValues, cedar.AdHocRequester)
+		default:
+			return nil, errors.Errorf("Invalid requester value %v", requester)
+		}
+	}
+	return requesterValues, nil
+}
+
+// readStringList parses a string list parameter value, the values can be comma
+// separated or specified multiple times.
+func (h *htdFilterHandler) readStringList(values []string) []string {
+	var parsedValues []string
+	for _, val := range values {
+		elements := strings.Split(val, ",")
+		parsedValues = append(parsedValues, elements...)
+	}
+	return parsedValues
+}
+
+// readInt parses an integer parameter value, given minimum, maximum, and
+// default values.
+func (h *htdFilterHandler) readInt(intString string, min, max, defaultValue int) (int, error) {
+	if intString == "" {
+		return defaultValue, nil
+	}
+
+	value, err := strconv.Atoi(intString)
+	if err != nil {
+		return 0, err
+	}
+
+	if value < min || value > max {
+		return 0, errors.New("Invalid int parameter value")
+	}
+	return value, nil
+}
+
+// readTestGroupBy parses a sort parameter value and returns the corresponding
+// HTDSort struct.
+func (h *htdFilterHandler) readSort(sortValue string) (model.HTDSort, error) {
+	switch sortValue {
+	case htdAPISortEarliest:
+		return model.HTDSortEarliestFirst, nil
+	case htdAPISortLatest:
+		return model.HTDSortLatestFirst, nil
+	case "":
+		return model.HTDSortEarliestFirst, nil
+	default:
+		return model.HTDSort(""), gimlet.ErrorResponse{
+			Message:    "invalid sort value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+}
+
+// readGroupBy parses a group_by parameter value and returns the corresponding
+// HTDGroupBy struct.
+func (h *htdFilterHandler) readGroupBy(groupByValue string) (model.HTDGroupBy, error) {
+	switch groupByValue {
+	case htdAPITestGroupByVariant:
+		return model.HTDGroupByVariant, nil
+	case htdAPITestGroupByTask:
+		return model.HTDGroupByTask, nil
+	case htdAPITestGroupByTest:
+		return model.HTDGroupByTest, nil
+	// We no longer store distro, but do not want to error if it is
+	// present.
+	case "", htdAPITestGroupByDistro:
+		return model.HTDGroupByVariant, nil
+	default:
+		return model.HTDGroupBy(""), gimlet.ErrorResponse{
+			Message:    "invalid group_by value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+}
+
+// readStartAt parses a start_at key value and returns the corresponding
+// HTDStartAt struct.
+func (h *htdFilterHandler) readStartAt(startAtValue string) (*model.HTDStartAt, error) {
+	if startAtValue == "" {
+		return nil, nil
+	}
+
+	elements := strings.Split(startAtValue, "|")
+	if len(elements) != 4 && len(elements) != 5 {
+		return nil, gimlet.ErrorResponse{
+			Message:    "invalid start_at value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	date, err := time.ParseInLocation(htdAPIDateFormat, elements[0], time.UTC)
+	if err != nil {
+		return nil, gimlet.ErrorResponse{
+			Message:    "invalid start_at value",
+			StatusCode: http.StatusBadRequest,
+		}
+	}
+
+	return &model.HTDStartAt{
+		Date:    date,
+		Variant: elements[1],
+		Task:    elements[2],
+		Test:    elements[3],
+	}, nil
+}

--- a/rest/historical_test_data_routes_test.go
+++ b/rest/historical_test_data_routes_test.go
@@ -1,0 +1,117 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	dbModel "github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/cedar/rest/data"
+	"github.com/evergreen-ci/cedar/rest/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTDFilterHandlerParse(t *testing.T) {
+	values := url.Values{
+		"requesters":  []string{htdAPIRequesterMainline, htdAPIRequesterPatch},
+		"after_date":  []string{"1998-07-12"},
+		"before_date": []string{"2018-07-15"},
+		"tests":       []string{"test1", "test2"},
+		"tasks":       []string{"task1", "task2"},
+		"variants":    []string{"v1,v2", "v3"},
+	}
+	handler := htdFilterHandler{}
+
+	err := handler.parse(values)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		cedar.RepotrackerVersionRequester,
+		cedar.PatchVersionRequester,
+		cedar.GithubPRRequester,
+		cedar.MergeTestRequester,
+	}, handler.filter.Requesters)
+	assert.Equal(t, time.Date(1998, 7, 12, 0, 0, 0, 0, time.UTC), handler.filter.AfterDate)
+	assert.Equal(t, time.Date(2018, 7, 15, 0, 0, 0, 0, time.UTC), handler.filter.BeforeDate)
+	assert.Equal(t, values["tests"], handler.filter.Tests)
+	assert.Equal(t, values["tasks"], handler.filter.Tasks)
+	assert.Equal(t, []string{"v1", "v2", "v3"}, handler.filter.Variants)
+	assert.Nil(t, handler.filter.StartAt)
+	assert.Equal(t, dbModel.HTDGroupByVariant, handler.filter.GroupBy) // default value
+	assert.Equal(t, dbModel.HTDSortEarliestFirst, handler.filter.Sort) // default value
+	assert.Equal(t, htdAPIMaxLimit+1, handler.filter.Limit)            // default value
+}
+
+func TestHTDDataHandlerRun(t *testing.T) {
+	var err error
+	sc := &data.MockConnector{
+		CachedHistoricalTestData: []dbModel.AggregatedHistoricalTestData{
+			{
+				TestName: "test1",
+				TaskName: "task1",
+				Variant:  "v1",
+				Date:     utility.GetUTCDay(time.Now()),
+			},
+			{
+				TestName: "test2",
+				TaskName: "task2",
+				Variant:  "v1",
+				Date:     utility.GetUTCDay(time.Now()),
+			},
+			{
+				TestName: "test3",
+				TaskName: "task3",
+				Variant:  "v1",
+				Date:     utility.GetUTCDay(time.Now()),
+			},
+		},
+	}
+	handler := makeGetHistoricalTestData(sc).(*historicalTestDataHandler)
+	require.NoError(t, err)
+
+	handler.filter = dbModel.HistoricalTestDataFilter{Limit: 4}
+	resp := handler.Run(context.Background())
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	assert.Nil(t, resp.Pages())
+
+	// pagination
+	handler.filter = dbModel.HistoricalTestDataFilter{Limit: 2}
+	resp = handler.Run(context.Background())
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.Status())
+	assert.NotNil(t, resp.Pages())
+	lastDoc := model.APIAggregatedHistoricalTestData{}
+	require.NoError(t, lastDoc.Import(sc.CachedHistoricalTestData[2]))
+	assert.Equal(t, lastDoc.StartAtKey(), resp.Pages().Next.Key)
+}
+
+func TestHTDReadStartAt(t *testing.T) {
+
+	// 5 values
+	handler := htdFilterHandler{}
+	startAt, err := handler.readStartAt("1998-07-12|variant1|task1|test1|distro1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(1998, 7, 12, 0, 0, 0, 0, time.UTC), startAt.Date)
+	assert.Equal(t, "variant1", startAt.Variant)
+	assert.Equal(t, "task1", startAt.Task)
+	assert.Equal(t, "test1", startAt.Test)
+
+	// 4 values
+	handler = htdFilterHandler{}
+	startAt, err = handler.readStartAt("1998-07-12|variant1|task1|test1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(1998, 7, 12, 0, 0, 0, 0, time.UTC), startAt.Date)
+	assert.Equal(t, "variant1", startAt.Variant)
+	assert.Equal(t, "task1", startAt.Task)
+	assert.Equal(t, "test1", startAt.Test)
+
+	// Invalid format
+	_, err = handler.readStartAt("1998-07-12|variant1|task1")
+	require.Error(t, err)
+}

--- a/rest/historical_test_data_routes_test.go
+++ b/rest/historical_test_data_routes_test.go
@@ -81,7 +81,7 @@ func TestHTDDataHandlerRun(t *testing.T) {
 	assert.Nil(t, resp.Pages())
 
 	// pagination
-	handler.filter = dbModel.HistoricalTestDataFilter{Limit: 2}
+	handler.filter = dbModel.HistoricalTestDataFilter{Limit: 3}
 	resp = handler.Run(context.Background())
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.Status())

--- a/rest/model/historical_test_data.go
+++ b/rest/model/historical_test_data.go
@@ -5,22 +5,29 @@ import (
 	"github.com/pkg/errors"
 )
 
-// APIHistoricalTestData describes aggregated test result data for a given date
-// range.
-type APIHistoricalTestData struct {
-	Info            APIHistoricalTestDataInfo `json:"info"`
-	NumPass         int                       `json:"num_pass"`
-	NumFail         int                       `json:"num_fail"`
-	AverageDuration float64                   `json:"average_duration"`
-	LastUpdate      APITime                   `json:"last_update"`
+// APIAggregatedHistoricalTestData describes aggregated test result data for a
+// given date range.
+type APIAggregatedHistoricalTestData struct {
+	TestName APIString `json:"test_name"`
+	TaskName APIString `json:"task_name,omitempty"`
+	Variant  APIString `json:"variant,omitempty"`
+	Date     APITime   `json:"date"`
+
+	NumPass         int     `json:"num_pass"`
+	NumFail         int     `json:"num_fail"`
+	AverageDuration float64 `json:"average_duration"`
+	LastUpdate      APITime `json:"last_update"`
 }
 
-// Import transforms a HistoricalTestData object into an APIHistoricalTestData
-// object.
-func (a *APIHistoricalTestData) Import(i interface{}) error {
+// Import transforms an AggregatedHistoricalTestData object into an
+// APIAggregatedHistoricalTestData object.
+func (a *APIAggregatedHistoricalTestData) Import(i interface{}) error {
 	switch hd := i.(type) {
-	case dbmodel.HistoricalTestData:
-		a.Info = getHistoricalTestDataInfo(hd.Info)
+	case dbmodel.AggregatedHistoricalTestData:
+		a.TestName = ToAPIString(hd.TestName)
+		a.TaskName = ToAPIString(hd.TaskName)
+		a.Variant = ToAPIString(hd.Variant)
+		a.Date = NewTime(hd.Date)
 		a.NumPass = hd.NumPass
 		a.NumFail = hd.NumFail
 		a.AverageDuration = hd.AverageDuration.Seconds()
@@ -29,26 +36,4 @@ func (a *APIHistoricalTestData) Import(i interface{}) error {
 		return errors.New("incorrect type when converting to APIHistoricalTestData type")
 	}
 	return nil
-}
-
-// APIHistoricalTestDataInfo describes information unique to a single test
-// statistics document.
-type APIHistoricalTestDataInfo struct {
-	Project     APIString `json:"project"`
-	Variant     APIString `json:"variant"`
-	TaskName    APIString `json:"task_name"`
-	TestName    APIString `json:"test_name"`
-	RequestType APIString `json:"request_type"`
-	Date        APITime   `json:"date"`
-}
-
-func getHistoricalTestDataInfo(info dbmodel.HistoricalTestDataInfo) APIHistoricalTestDataInfo {
-	return APIHistoricalTestDataInfo{
-		Project:     ToAPIString(info.Project),
-		Variant:     ToAPIString(info.Variant),
-		TaskName:    ToAPIString(info.TaskName),
-		TestName:    ToAPIString(info.TestName),
-		RequestType: ToAPIString(info.RequestType),
-		Date:        NewTime(info.Date),
-	}
 }

--- a/rest/model/historical_test_data.go
+++ b/rest/model/historical_test_data.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"strings"
+
 	dbmodel "github.com/evergreen-ci/cedar/model"
 	"github.com/pkg/errors"
 )
@@ -34,4 +36,29 @@ func (a *APIAggregatedHistoricalTestData) Import(i interface{}) error {
 		return errors.New("incorrect type when converting to APIHistoricalTestData type")
 	}
 	return nil
+}
+
+// StartAtKey returns the start_at key parameter that can be used to paginate
+// and start at this element.
+func (a *APIAggregatedHistoricalTestData) StartAtKey() string {
+	return HTDStartAtKey{
+		date:     a.Date.String(),
+		variant:  FromAPIString(a.Variant),
+		taskName: FromAPIString(a.TaskName),
+		testName: FromAPIString(a.TestName),
+	}.String()
+}
+
+// HTDStartAtKey is a struct used to build the start_at key parameter for
+// pagination.
+type HTDStartAtKey struct {
+	date     string
+	variant  string
+	taskName string
+	testName string
+}
+
+func (s HTDStartAtKey) String() string {
+	elements := []string{s.date, s.variant, s.taskName, s.testName}
+	return strings.Join(elements, "|")
 }

--- a/rest/model/historical_test_data.go
+++ b/rest/model/historical_test_data.go
@@ -16,7 +16,6 @@ type APIAggregatedHistoricalTestData struct {
 	NumPass         int     `json:"num_pass"`
 	NumFail         int     `json:"num_fail"`
 	AverageDuration float64 `json:"average_duration"`
-	LastUpdate      APITime `json:"last_update"`
 }
 
 // Import transforms an AggregatedHistoricalTestData object into an
@@ -31,7 +30,6 @@ func (a *APIAggregatedHistoricalTestData) Import(i interface{}) error {
 		a.NumPass = hd.NumPass
 		a.NumFail = hd.NumFail
 		a.AverageDuration = hd.AverageDuration.Seconds()
-		a.LastUpdate = NewTime(hd.LastUpdate)
 	default:
 		return errors.New("incorrect type when converting to APIHistoricalTestData type")
 	}

--- a/rest/model/historical_test_data_test.go
+++ b/rest/model/historical_test_data_test.go
@@ -10,40 +10,32 @@ import (
 
 func TestHistoricalTestDataImport(t *testing.T) {
 	t.Run("InvalidType", func(t *testing.T) {
-		apiHistoricalTestData := &APIHistoricalTestData{}
-		assert.Error(t, apiHistoricalTestData.Import(dbmodel.TestResults{}))
+		api := &APIAggregatedHistoricalTestData{}
+		assert.Error(t, api.Import(dbmodel.TestResults{}))
 	})
 	t.Run("ValidHistoricalTestData", func(t *testing.T) {
-		tr := dbmodel.HistoricalTestData{
-			Info: dbmodel.HistoricalTestDataInfo{
-				Project:     "project",
-				Variant:     "variant",
-				TaskName:    "task_name",
-				TestName:    "test_name",
-				RequestType: "request_type",
-				Date:        time.Now(),
-			},
+		tr := dbmodel.AggregatedHistoricalTestData{
+			TestName:        "test_name",
+			TaskName:        "task_name",
+			Variant:         "variant",
+			Date:            time.Now(),
 			NumPass:         2,
 			NumFail:         2,
 			AverageDuration: 30 * time.Second,
 			LastUpdate:      time.Now(),
 		}
-		expected := &APIHistoricalTestData{
-			Info: APIHistoricalTestDataInfo{
-				Project:     ToAPIString(tr.Info.Project),
-				Variant:     ToAPIString(tr.Info.Variant),
-				TaskName:    ToAPIString(tr.Info.TaskName),
-				TestName:    ToAPIString(tr.Info.TestName),
-				RequestType: ToAPIString(tr.Info.RequestType),
-				Date:        NewTime(tr.Info.Date),
-			},
+		expected := &APIAggregatedHistoricalTestData{
+			TestName:        ToAPIString(tr.TestName),
+			TaskName:        ToAPIString(tr.TaskName),
+			Variant:         ToAPIString(tr.Variant),
+			Date:            NewTime(tr.Date),
 			NumPass:         tr.NumPass,
 			NumFail:         tr.NumFail,
 			AverageDuration: tr.AverageDuration.Seconds(),
 			LastUpdate:      NewTime(tr.LastUpdate),
 		}
-		apiHistoricalTestData := &APIHistoricalTestData{}
-		assert.NoError(t, apiHistoricalTestData.Import(tr))
-		assert.Equal(t, expected, apiHistoricalTestData)
+		api := &APIAggregatedHistoricalTestData{}
+		assert.NoError(t, api.Import(tr))
+		assert.Equal(t, expected, api)
 	})
 }

--- a/rest/model/historical_test_data_test.go
+++ b/rest/model/historical_test_data_test.go
@@ -22,7 +22,6 @@ func TestHistoricalTestDataImport(t *testing.T) {
 			NumPass:         2,
 			NumFail:         2,
 			AverageDuration: 30 * time.Second,
-			LastUpdate:      time.Now(),
 		}
 		expected := &APIAggregatedHistoricalTestData{
 			TestName:        ToAPIString(tr.TestName),
@@ -32,7 +31,6 @@ func TestHistoricalTestDataImport(t *testing.T) {
 			NumPass:         tr.NumPass,
 			NumFail:         tr.NumFail,
 			AverageDuration: tr.AverageDuration.Seconds(),
-			LastUpdate:      NewTime(tr.LastUpdate),
 		}
 		api := &APIAggregatedHistoricalTestData{}
 		assert.NoError(t, api.Import(tr))

--- a/rest/service.go
+++ b/rest/service.go
@@ -331,5 +331,7 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskId(s.sc))
 	s.app.AddRoute("/test_results/test_name/{task_id}/{test_name}").Version(1).Get().RouteHandler(makeGetTestResultByTestName(s.sc))
 
+	s.app.AddRoute("/historical_test_data/<project_id>").Version(1).Get().RouteHandler(makeGetHistoricalTestData(s.sc))
+
 	s.app.AddRoute("/system_metrics/type/{task_id}/{type}").Version(1).Get().RouteHandler(makeGetSystemMetricsByType(s.sc))
 }

--- a/rest/service.go
+++ b/rest/service.go
@@ -331,7 +331,7 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskId(s.sc))
 	s.app.AddRoute("/test_results/test_name/{task_id}/{test_name}").Version(1).Get().RouteHandler(makeGetTestResultByTestName(s.sc))
 
-	s.app.AddRoute("/historical_test_data/<project_id>").Version(1).Get().RouteHandler(makeGetHistoricalTestData(s.sc))
+	s.app.AddRoute("/historical_test_data/{project_id}").Version(1).Get().RouteHandler(makeGetHistoricalTestData(s.sc))
 
 	s.app.AddRoute("/system_metrics/type/{task_id}/{type}").Version(1).Get().RouteHandler(makeGetSystemMetricsByType(s.sc))
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13447

This is the final PR for this ticket. It actually adds the REST route to fetch historical test data using the aggregation merged with a previous PR.