### PR TITLE
EVG-13831: Change task level logs to use tags instead of process_name

### DIFF
--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -630,7 +630,7 @@ func findOutdatedTaskLogs(ctx context.Context, env cedar.Environment) ([]Log, er
 			"$nin": []string{AgentLog, TaskLog, SystemLog},
 		},
 	}
-	opts := options.Find().SetLimit(conf.LogMigrationLimit)
+	opts := options.Find().SetLimit(limit)
 	it, err := env.GetDB().Collection(buildloggerCollection).Find(ctx, query, opts)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -650,6 +650,10 @@ func findOutdatedTaskLogs(ctx context.Context, env cedar.Environment) ([]Log, er
 }
 
 func updateOutdatedTaskLogs(ctx context.Context, env cedar.Environment, ids []string, logType string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
 	match := bson.M{"_id": bson.M{"$in": ids}}
 	update := bson.M{"$push": bson.M{
 		bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): logType,

--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -616,6 +616,11 @@ func findOutdatedTaskLogs(ctx context.Context, env cedar.Environment) ([]Log, er
 	if err := conf.Find(); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	limit := conf.LogMigrationLimit
+	if limit <= 0 {
+		// Default limit to 1000.
+		limit = 1000
+	}
 
 	query := bson.M{
 		bsonutil.GetDottedKeyName(logInfoKey, logInfoProcessNameKey): bson.M{

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -985,6 +985,7 @@ func TestBuildloggerMerge(t *testing.T) {
 	})
 }
 
+// TODO: Remove this test once the task log migration is complete (EVG-13831).
 func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 	env := cedar.GetEnvironment()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/model/config.go
+++ b/model/config.go
@@ -30,6 +30,8 @@ type CedarConfig struct {
 	Flags          OperationalFlags          `bson:"flags" json:"flags" yaml:"flags"`
 	Service        ServiceConfig             `bson:"service" json:"service" yaml:"service"`
 	ChangeDetector ChangeDetectorConfig      `bson:"change_detector" json:"change_detector" yaml:"change_detector"`
+	// TODO: Remove once task log migration is complete (EVG-13831).
+	LogMigrationLimit int64 `bson:"log_migration_limit" json:"log_migration_limit" yaml:"log_migration_limit"`
 
 	populated bool
 	env       cedar.Environment

--- a/units/crons.go
+++ b/units/crons.go
@@ -89,6 +89,7 @@ func StartCrons(ctx context.Context, env cedar.Environment, rpcTLS bool) error {
 		job := NewPeriodicTimeSeriesUpdateJob(utility.RoundPartOfMinute(0).Format(tsFormat))
 		return queue.Put(ctx, job)
 	})
+	// TODO: Remove once task log migration is complete (EVG-13831).
 	amboy.IntervalQueueOperation(ctx, remote, time.Minute, time.Now(), opts, func(ctx context.Context, queue amboy.Queue) error {
 		job := NewMigrateTaskLogsJob()
 		return queue.Put(ctx, job)

--- a/units/crons.go
+++ b/units/crons.go
@@ -89,6 +89,10 @@ func StartCrons(ctx context.Context, env cedar.Environment, rpcTLS bool) error {
 		job := NewPeriodicTimeSeriesUpdateJob(utility.RoundPartOfMinute(0).Format(tsFormat))
 		return queue.Put(ctx, job)
 	})
+	amboy.IntervalQueueOperation(ctx, remote, time.Minute, time.Now(), opts, func(ctx context.Context, queue amboy.Queue) error {
+		job := NewMigrateTaskLogsJob()
+		return queue.Put(ctx, job)
+	})
 
 	return nil
 }

--- a/units/migrate_task_logs.go
+++ b/units/migrate_task_logs.go
@@ -3,11 +3,10 @@ package units
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/evergreen-ci/cedar"
 	"github.com/evergreen-ci/cedar/model"
-	"github.com/evergreen-ci/cedar/perf"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/dependency"
 	"github.com/mongodb/amboy/job"
@@ -51,11 +50,11 @@ func makeMigrateTaskLogsJob() *migrateTaskLogsJob {
 	return j
 }
 
-func NewMigrateTaskLogsJob(factories []perf.RollupFactory) amboy.Job {
+func NewMigrateTaskLogsJob() amboy.Job {
 	j := makeMigrateTaskLogsJob()
 
-	// TODO: round this down to hour?
-	j.SetID(fmt.Sprintf("%s.%s", migrateTaskLogsJobName, time.Now()))
+	ts := utility.RoundPartOfMinute(0).Format(tsFormat)
+	j.SetID(fmt.Sprintf("%s.%s", migrateTaskLogsJobName, ts))
 
 	return j
 }

--- a/units/migrate_task_logs.go
+++ b/units/migrate_task_logs.go
@@ -1,0 +1,75 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/cedar/perf"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/dependency"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
+)
+
+// TODO: Remove this job once task log migration is complete (EVG-13831).
+// This is a temporary migration job. We need to take all task logs (logs with
+// "info.proc_name" == "agent_log", "task_log", or "system_log") in the
+// database and push the process name into the "info.tags" array. There are
+// an estimated ~180,000,000 documents that need to be migrated so we will do
+// this in smallish bathches over a few weeks to avoid overwhelming the prod
+// database.
+
+const (
+	migrateTaskLogsJobName = "migrate-task-logs"
+)
+
+type migrateTaskLogsJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+	env      cedar.Environment
+	queue    amboy.Queue
+}
+
+func init() {
+	registry.AddJobType(migrateTaskLogsJobName, func() amboy.Job { return makeMigrateTaskLogsJob() })
+}
+
+func makeMigrateTaskLogsJob() *migrateTaskLogsJob {
+	j := &migrateTaskLogsJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    migrateTaskLogsJobName,
+				Version: 1,
+			},
+		},
+	}
+
+	j.SetDependency(dependency.NewAlways())
+	return j
+}
+
+func NewMigrateTaskLogsJob(factories []perf.RollupFactory) amboy.Job {
+	j := makeMigrateTaskLogsJob()
+
+	// TODO: round this down to hour?
+	j.SetID(fmt.Sprintf("%s.%s", migrateTaskLogsJobName, time.Now()))
+
+	return j
+}
+
+func (j *migrateTaskLogsJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = cedar.GetEnvironment()
+	}
+	if j.queue == nil {
+		j.queue = j.env.GetRemoteQueue()
+	}
+
+	j.AddError(errors.Wrap(model.FindAndUpdateOutdatedTaskLogs(ctx, j.env),
+		"problem finding and updating outdated task logs"))
+}


### PR DESCRIPTION
JIRA: Change task level logs to use tags instead of process_name

This is temporary code for the task log migration.