### PR TITLE
EVG-13831: Remove proc_name in migration

### DIFF
--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -649,7 +649,7 @@ func updateOutdatedTaskLogs(ctx context.Context, env cedar.Environment, ids []st
 
 	match := bson.M{"_id": bson.M{"$in": ids}}
 	update := bson.M{
-		"$push": bson.M{
+		"$addToSet": bson.M{
 			bsonutil.GetDottedKeyName(logInfoKey, logInfoTagsKey): logType,
 		},
 		"$unset": bson.M{

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -999,6 +999,7 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "one",
 			Info: LogInfo{
+				Project:     AgentLog,
 				ProcessName: AgentLog,
 				Tags:        []string{"tag1", "tag2", "tag3"},
 			},
@@ -1006,12 +1007,14 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "two",
 			Info: LogInfo{
+				Project:     AgentLog,
 				ProcessName: AgentLog,
 			},
 		},
 		&Log{
 			ID: "three",
 			Info: LogInfo{
+				Project:     AgentLog,
 				ProcessName: AgentLog,
 				Tags:        []string{"tag1"},
 			},
@@ -1019,6 +1022,7 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "four",
 			Info: LogInfo{
+				Project:     TaskLog,
 				ProcessName: TaskLog,
 				Tags:        []string{"tag1", "tag2", "tag3"},
 			},
@@ -1026,12 +1030,14 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "five",
 			Info: LogInfo{
+				Project:     TaskLog,
 				ProcessName: TaskLog,
 			},
 		},
 		&Log{
 			ID: "six",
 			Info: LogInfo{
+				Project:     TaskLog,
 				ProcessName: TaskLog,
 				Tags:        []string{"tag1"},
 			},
@@ -1039,6 +1045,7 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "seven",
 			Info: LogInfo{
+				Project:     SystemLog,
 				ProcessName: SystemLog,
 				Tags:        []string{"tag1", "tag2", "tag3"},
 			},
@@ -1046,12 +1053,14 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		&Log{
 			ID: "eight",
 			Info: LogInfo{
+				Project:     SystemLog,
 				ProcessName: SystemLog,
 			},
 		},
 		&Log{
 			ID: "nine",
 			Info: LogInfo{
+				Project:     SystemLog,
 				ProcessName: SystemLog,
 				Tags:        []string{"tag1"},
 			},
@@ -1077,7 +1086,8 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		require.Len(t, updatedLogs, 9)
 
 		for _, log := range updatedLogs {
-			assert.True(t, utility.StringSliceContains(log.Info.Tags, log.Info.ProcessName))
+			assert.True(t, utility.StringSliceContains(log.Info.Tags, log.Info.Project))
+			assert.Empty(t, log.Info.ProcessName)
 		}
 	})
 	t.Run("SmallLimit", func(t *testing.T) {
@@ -1095,13 +1105,18 @@ func TestFindAndUpdateOutdatedTaskLogs(t *testing.T) {
 		require.NoError(t, it.All(ctx, &updatedLogs))
 		require.Len(t, updatedLogs, 9)
 
-		count := 0
+		updatedCount := 0
+		outdatedCount := 0
 		for _, log := range updatedLogs {
-			if utility.StringSliceContains(log.Info.Tags, log.Info.ProcessName) {
-				count += 1
+			if utility.StringSliceContains(log.Info.Tags, log.Info.Project) && log.Info.ProcessName == "" {
+				updatedCount += 1
+			}
+			if !utility.StringSliceContains(log.Info.Tags, log.Info.ProcessName) && log.Info.ProcessName != "" {
+				outdatedCount += 1
 			}
 		}
-		assert.Equal(t, 3, count)
+		assert.Equal(t, 3, updatedCount)
+		assert.Equal(t, 6, outdatedCount)
 	})
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13831

Turns out the index was not being used as we expected, unfortunately `$ne` and `$nin` are not selective and thus indexes cannot be used with them. So as the number of docs with `agent_log`, `task_log`, and `system_log` in the `info.tags` array increased, the time the query took to filter out those docs increased drastically. 

This code changes the update to remove the `info.proc` field as way to mark that doc as processed.