### PR TITLE
EVG-13536: Limit outdated rollup job to 1000 results per job

### DIFF
--- a/perf/ftdc_rollups.go
+++ b/perf/ftdc_rollups.go
@@ -13,6 +13,7 @@ const maxDurationsSize = 250000000
 type PerformanceStatistics struct {
 	counters struct {
 		operationsTotal int64
+		documentsTotal  int64
 		sizeTotal       int64
 		errorsTotal     int64
 	}
@@ -61,6 +62,8 @@ func CreatePerformanceStats(dx *ftdc.ChunkIterator) (*PerformanceStatistics, err
 			switch name := metric.Key(); name {
 			case "counters.ops":
 				perfStats.counters.operationsTotal = metric.Values[len(metric.Values)-1]
+			case "counters.n":
+				perfStats.counters.documentsTotal = metric.Values[len(metric.Values)-1]
 			case "counters.size":
 				perfStats.counters.sizeTotal = metric.Values[len(metric.Values)-1]
 			case "counters.errors":
@@ -92,7 +95,7 @@ func CreatePerformanceStats(dx *ftdc.ChunkIterator) (*PerformanceStatistics, err
 				}
 				t := metric.Values[len(metric.Values)-1]
 				end = time.Unix(t/1000, t%1000*1000000)
-			case "counters.n", "id":
+			case "id":
 				continue
 			default:
 				return nil, errors.Errorf("unknown field name %s", name)

--- a/perf/rollup_factory.go
+++ b/perf/rollup_factory.go
@@ -14,11 +14,11 @@ type RollupFactory interface {
 	Calc(*PerformanceStatistics, bool) []model.PerfRollupValue
 }
 
-// TODO: Should this be a registry?
 var rollupsMap = map[string]RollupFactory{
 	latencyAverageName:      &latencyAverage{},
 	sizeAverageName:         &sizeAverage{},
 	operationThroughputName: &operationThroughput{},
+	documentThroughputName:  &documentThroughput{},
 	sizeThroughputName:      &sizeThroughput{},
 	errorThroughputName:     &errorThroughput{},
 	latencyPercentileName:   &latencyPercentile{},
@@ -27,11 +27,11 @@ var rollupsMap = map[string]RollupFactory{
 	durationSumName:         &durationSum{},
 	errorsSumName:           &errorsSum{},
 	operationsSumName:       &operationsSum{},
+	documentsSumName:        &documentsSum{},
 	sizeSumName:             &sizeSum{},
 	overheadSumName:         &overheadSum{},
 }
 
-// TODO: Which function of the two following is better?
 func RollupsMap() map[string]RollupFactory {
 	return rollupsMap
 }
@@ -44,6 +44,7 @@ var defaultRollups = []RollupFactory{
 	&latencyAverage{},
 	&sizeAverage{},
 	&operationThroughput{},
+	&documentThroughput{},
 	&sizeThroughput{},
 	&errorThroughput{},
 	&latencyPercentile{},
@@ -52,6 +53,7 @@ var defaultRollups = []RollupFactory{
 	&durationSum{},
 	&errorsSum{},
 	&operationsSum{},
+	&documentsSum{},
 	&sizeSum{},
 	&overheadSum{},
 }
@@ -134,6 +136,31 @@ func (f *operationThroughput) Calc(s *PerformanceStatistics, user bool) []model.
 
 	if s.timers.totalWallTime > 0 {
 		rollup.Value = float64(s.counters.operationsTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []model.PerfRollupValue{rollup}
+}
+
+type documentThroughput struct{}
+
+const (
+	documentThroughputName    = "DocumentThroughput"
+	documentThroughputVersion = 0
+)
+
+func (f *documentThroughput) Type() string    { return documentThroughputName }
+func (f *documentThroughput) Names() []string { return []string{documentThroughputName} }
+func (f *documentThroughput) Version() int    { return documentThroughputVersion }
+func (f *documentThroughput) Calc(s *PerformanceStatistics, user bool) []model.PerfRollupValue {
+	rollup := model.PerfRollupValue{
+		Name:          documentThroughputName,
+		Version:       documentThroughputVersion,
+		MetricType:    model.MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.documentsTotal) / s.timers.totalWallTime.Seconds()
 	}
 
 	return []model.PerfRollupValue{rollup}
@@ -395,6 +422,28 @@ func (f *operationsSum) Calc(s *PerformanceStatistics, user bool) []model.PerfRo
 			Name:          operationsSumName,
 			Value:         s.counters.operationsTotal,
 			Version:       operationsSumVersion,
+			MetricType:    model.MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type documentsSum struct{}
+
+const (
+	documentsSumName    = "DocumentsTotal"
+	documentsSumVersion = 0
+)
+
+func (f *documentsSum) Type() string    { return documentsSumName }
+func (f *documentsSum) Names() []string { return []string{documentsSumName} }
+func (f *documentsSum) Version() int    { return documentsSumVersion }
+func (f *documentsSum) Calc(s *PerformanceStatistics, user bool) []model.PerfRollupValue {
+	return []model.PerfRollupValue{
+		model.PerfRollupValue{
+			Name:          documentsSumName,
+			Value:         s.counters.documentsTotal,
+			Version:       documentsSumVersion,
 			MetricType:    model.MetricTypeSum,
 			UserSubmitted: user,
 		},

--- a/units/find_outdated_rollups.go
+++ b/units/find_outdated_rollups.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	findOutdatedRollupsJobName = "find-outdated-rollups"
+	maxOutdatedPerfResults     = 1000
 )
 
 type findOutdatedRollupsJob struct {
@@ -110,10 +111,11 @@ func (j *findOutdatedRollupsJob) Run(ctx context.Context) {
 					j.createFTDCRollupsJobs(ctx, factories[i:], result)
 
 					count += 1
-					if count >= 1000 {
-						// Stop job after updating 1000
-						// results to avoid
-						// overwhelming amboy queue.
+					if count >= maxOutdatedPerfResults {
+						// Stop job after processing a
+						// max number of results to
+						// avoid overwhelming the amboy
+						// queue.
 						return
 					}
 				}

--- a/units/find_outdated_rollups.go
+++ b/units/find_outdated_rollups.go
@@ -94,6 +94,7 @@ func (j *findOutdatedRollupsJob) Run(ctx context.Context) {
 		factories = append(factories, factory)
 	}
 
+	count := 0
 	results := model.PerformanceResults{}
 	results.Setup(j.env)
 	for i, factory := range factories {
@@ -107,6 +108,14 @@ func (j *findOutdatedRollupsJob) Run(ctx context.Context) {
 			for _, result := range results.Results {
 				if _, ok := j.seenIDs[result.ID]; !ok {
 					j.createFTDCRollupsJobs(ctx, factories[i:], result)
+
+					count += 1
+					if count >= 1000 {
+						// Stop job after updating 1000
+						// results to avoid
+						// overwhelming amboy queue.
+						return
+					}
 				}
 			}
 		}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13536

The backfill job for outdated perf rollup jobs is already limited to update results created within the past 90 days. For a change that affects every single perf result (like adding a new rollup) this can be overwhelming for the amboy queue, creating duplicate jobs and backing it up. This change reverts the revert of a commit I made recently to add a new perf rollup and adds limits a the backfill job to 1000 results per job (which runs every hour) to avoid overwhelming the queue again. The database has about ~240,000 perf results that were created in the past 90 days. Not all of these results have ftdc data and thus will not need to be updated. But even all ~240,000 results needed to be updated, this would only take about 10 days. I chose 1000 because it seems reasonable and that is the threshold for long cedar amboy queue alerts in splunk.