### PR TITLE
EVG-13419: Create a mutli test results iterator

### DIFF
--- a/model/test_results_iterator_test.go
+++ b/model/test_results_iterator_test.go
@@ -64,8 +64,8 @@ func TestTestResultsIterator(t *testing.T) {
 			for i := 0; i < numResults; i++ {
 				result := getTestResult()
 				results1[result.TestName] = result
-				data, err := bson.Marshal(result)
-				require.NoError(t, err)
+				data, marshalErr := bson.Marshal(result)
+				require.NoError(t, marshalErr)
 				require.NoError(t, testBucket1.Put(ctx, result.TestName, bytes.NewReader(data)))
 			}
 
@@ -79,8 +79,8 @@ func TestTestResultsIterator(t *testing.T) {
 			for i := 0; i < numResults; i++ {
 				result := getTestResult()
 				results2[result.TestName] = result
-				data, err := bson.Marshal(result)
-				require.NoError(t, err)
+				data, marshalErr := bson.Marshal(result)
+				require.NoError(t, marshalErr)
 				require.NoError(t, testBucket2.Put(ctx, result.TestName, bytes.NewReader(data)))
 			}
 			for testName, result := range results1 {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13419

In effort to create a new rest route to fetch test results by display name we will need to iterator over multiple `TestResultsIterator`s, so I created a new `multiTestResultsIterator` for convenience.