### PR TITLE
EVG-13419: New Find methods for test results

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -407,11 +407,13 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts TestResult
 	}
 
 	execution := results[0].Info.Execution
-	for i, result := range results {
-		if result.Info.Execution != execution {
+	for i := range results {
+		if results[i].Info.Execution != execution {
 			results = results[:i]
 			break
 		}
+		results[i].populated = true
+		results[i].env = env
 	}
 
 	return results, nil
@@ -429,8 +431,6 @@ func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts
 
 	its := make([]TestResultsIterator, len(results))
 	for i, result := range results {
-		result.populated = true
-		result.env = env
 		its[i], err = result.Download(ctx)
 		if err != nil {
 			return nil, err

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -384,7 +384,7 @@ func (opts *TestResultsFindOptions) createErrorMessage() string {
 
 // FindTestResults searches the database for the TestResults associated with
 // the provided options. The environment should not be nil. If execution is
-// empty, it will default to most recent execution.
+// empty, it will default to the most recent execution.
 func FindTestResults(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) ([]TestResults, error) {
 	if env == nil {
 		return nil, errors.New("cannot find with a nil environment")
@@ -420,7 +420,7 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts TestResult
 // FindAndDownloadTestResults searches the database for the TestResults
 // associated with the provided options and returns a TestResultsIterator with
 // the downloaded test results. The environment should not be nil. If execution
-// is empty it will default to most recent execution.
+// is empty it will default to the most recent execution.
 func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) (TestResultsIterator, error) {
 	results, err := FindTestResults(ctx, env, opts)
 	if err != nil {

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -513,6 +513,8 @@ func TestFindTestResults(t *testing.T) {
 		assert.Equal(t, tr1.ID, results[0].ID)
 		assert.Equal(t, tr1.Info, results[0].Info)
 		assert.Equal(t, tr1.Artifact, results[0].Artifact)
+		assert.True(t, results[0].populated)
+		assert.Equal(t, env, results[0].env)
 	})
 	t.Run("WithTaskIDWithoutExecution", func(t *testing.T) {
 		opts := TestResultsFindOptions{
@@ -525,6 +527,8 @@ func TestFindTestResults(t *testing.T) {
 		assert.Equal(t, tr2.ID, results[0].ID)
 		assert.Equal(t, tr2.Info, results[0].Info)
 		assert.Equal(t, tr2.Artifact, results[0].Artifact)
+		assert.True(t, results[0].populated)
+		assert.Equal(t, env, results[0].env)
 	})
 	t.Run("WithDisplayTaskNameAndExecution", func(t *testing.T) {
 		opts := TestResultsFindOptions{DisplayTaskName: "display"}
@@ -536,12 +540,16 @@ func TestFindTestResults(t *testing.T) {
 				assert.Equal(t, tr1.ID, result.ID)
 				assert.Equal(t, tr1.Info, result.Info)
 				assert.Equal(t, tr1.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
 				count++
 			}
 			if result.ID == tr3.ID {
 				assert.Equal(t, tr3.ID, result.ID)
 				assert.Equal(t, tr3.Info, result.Info)
 				assert.Equal(t, tr3.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
 				count++
 			}
 		}
@@ -558,6 +566,8 @@ func TestFindTestResults(t *testing.T) {
 		assert.Equal(t, tr2.ID, results[0].ID)
 		assert.Equal(t, tr2.Info, results[0].Info)
 		assert.Equal(t, tr2.Artifact, results[0].Artifact)
+		assert.True(t, results[0].populated)
+		assert.Equal(t, env, results[0].env)
 	})
 }
 

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -93,13 +93,14 @@ type Connector interface {
 	// Test Results
 	///////////////
 	// FindTestResultsByTaskId queries the database to find all test
-	// results with the given options.
-	FindTestResultsByTaskId(context.Context, dbModel.TestResultsFindOptions) ([]model.APITestResult, error)
+	// results with the given options. If the execution is not specified,
+	// this will return the test results from the most recent execution.
+	FindTestResultsByTaskId(context.Context, TestResultsOptions) ([]model.APITestResult, error)
 	// FindTestResultByTestName finds the test result of a single test,
 	// specified by the given options.
 	// If execution is not specified, this will return the test result from
-	// the most recent.
-	FindTestResultByTestName(context.Context, TestResultsTestNameOptions) (*model.APITestResult, error)
+	// the most recent execution.
+	FindTestResultByTestName(context.Context, TestResultsOptions) (*model.APITestResult, error)
 
 	///////////////////////
 	// Historical Test Data
@@ -139,17 +140,9 @@ type BuildloggerOptions struct {
 // TestResultsOptions holds all values required to find a specific TestResults
 // or TestResult object using connector functions.
 type TestResultsOptions struct {
-	TaskID         string
-	TestName       string
-	Execution      int
-	EmptyExecution bool
-}
-
-// TestResultsTestNameOptions holds all values required to find a specific TestResults
-// or TestResult object using connector functions.
-type TestResultsTestNameOptions struct {
-	TaskID         string
-	TestName       string
-	Execution      int
-	EmptyExecution bool
+	TaskID          string
+	DisplayTaskName string
+	TestName        string
+	Execution       int
+	EmptyExecution  bool
 }

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -144,7 +144,7 @@ func (s *testResultsConnectorSuite) TearDownSuite() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultsByTaskIdExists() {
-	optsList := []dbModel.TestResultsFindOptions{{
+	optsList := []TestResultsOptions{{
 		TaskID:    "task1",
 		Execution: 0,
 	}, {
@@ -183,7 +183,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsByTaskIdExists() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTaskIdDNE() {
-	opts := dbModel.TestResultsFindOptions{
+	opts := TestResultsOptions{
 		TaskID:    "DNE",
 		Execution: 1,
 	}
@@ -194,9 +194,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTaskIdDNE() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTaskIdEmpty() {
-	opts := dbModel.TestResultsFindOptions{
-		Execution: 1,
-	}
+	opts := TestResultsOptions{Execution: 1}
 
 	result, err := s.sc.FindTestResultsByTaskId(s.ctx, opts)
 	s.Error(err)
@@ -204,7 +202,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTaskIdEmpty() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTestNameExists() {
-	optsList := []TestResultsTestNameOptions{{
+	optsList := []TestResultsOptions{{
 		TaskID:    "task1",
 		Execution: 1,
 		TestName:  "test1",
@@ -214,15 +212,14 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTestNameExists() {
 		TestName:       "test1",
 	}}
 	for _, opts := range optsList {
-		testResults := dbModel.TestResults{}
-		testResults.Setup(s.env)
 		findOpts := dbModel.TestResultsFindOptions{
 			TaskID:         opts.TaskID,
 			Execution:      opts.Execution,
 			EmptyExecution: opts.EmptyExecution,
 		}
-		s.Require().NoError(testResults.FindByTaskID(s.ctx, findOpts))
-		bucket, err := testResults.GetBucket(s.ctx)
+		results, err := dbModel.FindTestResults(s.ctx, s.env, findOpts)
+		s.Require().NoError(err)
+		bucket, err := results[0].GetBucket(s.ctx)
 		s.Require().NoError(err)
 
 		tr, err := bucket.Get(s.ctx, opts.TestName)
@@ -246,8 +243,8 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTestNameExists() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTestNameDNE() {
-	// test when metadata object doesn't exist
-	opts := TestResultsTestNameOptions{
+	// Test when metadata object doesn't exist.
+	opts := TestResultsOptions{
 		TaskID:    "DNE",
 		Execution: 1,
 		TestName:  "test1",
@@ -257,8 +254,8 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTestNameDNE() {
 	s.Error(err)
 	s.Nil(result)
 
-	// test when test object doesn't exist
-	opts = TestResultsTestNameOptions{
+	// Test when test object doesn't exist.
+	opts = TestResultsOptions{
 		TaskID:    "task1",
 		Execution: 1,
 		TestName:  "DNE",
@@ -270,7 +267,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTestNameDNE() {
 }
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTestNameEmpty() {
-	opts := TestResultsTestNameOptions{
+	opts := TestResultsOptions{
 		TaskID:    "task1",
 		Execution: 1,
 	}

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -144,8 +144,8 @@ func TestTestResultsHandlerSuite(t *testing.T) {
 
 func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIdHandlerFound() {
 	rh := s.rh["task_id"]
-	rh.(*testResultsGetByTaskIdHandler).options.TaskID = "task1"
-	rh.(*testResultsGetByTaskIdHandler).options.Execution = 0
+	rh.(*testResultsGetByTaskIdHandler).opts.TaskID = "task1"
+	rh.(*testResultsGetByTaskIdHandler).opts.Execution = 0
 
 	expected := make([]model.APITestResult, 0)
 	expectedKeys := []string{"task1_0_test0", "task1_0_test1", "task1_0_test2"}
@@ -170,8 +170,8 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIdHandlerFound() {
 
 func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIdHandlerNotFound() {
 	rh := s.rh["task_id"]
-	rh.(*testResultsGetByTaskIdHandler).options.TaskID = "DNE"
-	rh.(*testResultsGetByTaskIdHandler).options.Execution = 0
+	rh.(*testResultsGetByTaskIdHandler).opts.TaskID = "DNE"
+	rh.(*testResultsGetByTaskIdHandler).opts.Execution = 0
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)
@@ -182,8 +182,8 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIdHandlerCtxErr() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	rh := s.rh["task_id"]
-	rh.(*testResultsGetByTaskIdHandler).options.TaskID = "task1"
-	rh.(*testResultsGetByTaskIdHandler).options.Execution = 0
+	rh.(*testResultsGetByTaskIdHandler).opts.TaskID = "task1"
+	rh.(*testResultsGetByTaskIdHandler).opts.Execution = 0
 
 	resp := rh.Run(ctx)
 	s.Require().NotNil(resp)
@@ -293,7 +293,7 @@ func (s *TestResultsHandlerSuite) testParseDefaults(handler, urlString string) {
 func getTestResultsExecution(rh gimlet.RouteHandler, handler string) bool {
 	switch handler {
 	case "task_id":
-		return !rh.(*testResultsGetByTaskIdHandler).options.EmptyExecution
+		return !rh.(*testResultsGetByTaskIdHandler).opts.EmptyExecution
 	case "test_name":
 		return !rh.(*testResultGetByTestNameHandler).opts.EmptyExecution
 	default:


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13419

This changes the `TestResults.FindByTaskID` method to `FindTestResults` and enables searching by `DisplayTaskName`.