### PR TITLE
EVG-14066: Update indexes and clean up some perf code

### DIFF
--- a/model/indexes.go
+++ b/model/indexes.go
@@ -27,54 +27,6 @@ type SystemIndexes struct {
 func GetRequiredIndexes() []SystemIndexes {
 	return []SystemIndexes{
 		{
-			Keys:       bson.D{{Key: perfCreatedAtKey, Value: 1}, {Key: perfCompletedAtKey, Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskIDKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoExecutionKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTrialKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoParentKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTagsKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoSchemaKey), Value: 1}},
-			Collection: perfResultCollection,
-		},
-		{
 			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(dbUserLoginCacheKey, loginCacheTokenKey), Value: 1}},
 			Options:    bson.D{{Key: "unique", Value: true}},
 			Collection: userCollection,
@@ -84,6 +36,22 @@ func GetRequiredIndexes() []SystemIndexes {
 			Collection: userCollection,
 		},
 		{
+			Keys:       bson.D{{Key: perfCreatedAtKey, Value: 1}, {Key: perfCompletedAtKey, Value: 1}},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTagsKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys:       bson.D{{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoParentKey), Value: 1}},
+			Collection: perfResultCollection,
+		},
+		{
 			Keys: bson.D{
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1},
@@ -91,6 +59,43 @@ func GetRequiredIndexes() []SystemIndexes {
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfArtifactsKey, artifactInfoFormatKey), Value: 1},
+				{Key: perfFailedRollupAttempts, Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueVersionKey), Value: 1},
+				{Key: perfCreatedAtKey, Value: 1},
 			},
 			Collection: perfResultCollection,
 		},

--- a/model/perf.go
+++ b/model/perf.go
@@ -301,8 +301,8 @@ type PerformanceResultInfo struct {
 	Project   string           `bson:"project,omitempty"`
 	Version   string           `bson:"version,omitempty"`
 	Variant   string           `bson:"variant,omitempty"`
-	TaskName  string           `bson:"task_name,omitempty"`
 	Order     int              `bson:"order,omitempty"`
+	TaskName  string           `bson:"task_name,omitempty"`
 	TaskID    string           `bson:"task_id,omitempty"`
 	Execution int              `bson:"execution"`
 	TestName  string           `bson:"test_name,omitempty"`
@@ -318,8 +318,8 @@ var (
 	perfResultInfoProjectKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Project")
 	perfResultInfoVersionKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Version")
 	perfResultInfoVariantKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Variant")
-	perfResultInfoTaskNameKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TaskName")
 	perfResultInfoOrderKey     = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Order")
+	perfResultInfoTaskNameKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TaskName")
 	perfResultInfoTaskIDKey    = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TaskID")
 	perfResultInfoExecutionKey = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Execution")
 	perfResultInfoTestNameKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TestName")

--- a/model/perf.go
+++ b/model/perf.go
@@ -300,9 +300,9 @@ func (result *PerformanceResult) Close(ctx context.Context, completedAt time.Tim
 type PerformanceResultInfo struct {
 	Project   string           `bson:"project,omitempty"`
 	Version   string           `bson:"version,omitempty"`
-	Order     int              `bson:"order,omitempty"`
 	Variant   string           `bson:"variant,omitempty"`
 	TaskName  string           `bson:"task_name,omitempty"`
+	Order     int              `bson:"order,omitempty"`
 	TaskID    string           `bson:"task_id,omitempty"`
 	Execution int              `bson:"execution"`
 	TestName  string           `bson:"test_name,omitempty"`
@@ -317,9 +317,9 @@ type PerformanceResultInfo struct {
 var (
 	perfResultInfoProjectKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Project")
 	perfResultInfoVersionKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Version")
-	perfResultInfoOrderKey     = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Order")
 	perfResultInfoVariantKey   = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Variant")
 	perfResultInfoTaskNameKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TaskName")
+	perfResultInfoOrderKey     = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Order")
 	perfResultInfoTaskIDKey    = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TaskID")
 	perfResultInfoExecutionKey = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Execution")
 	perfResultInfoTestNameKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "TestName")
@@ -390,7 +390,6 @@ type PerfFindOptions struct {
 	MaxDepth    int
 	GraphLookup bool
 	Limit       int
-	Variant     string
 	Sort        []string
 }
 
@@ -473,6 +472,9 @@ func (r *PerformanceResults) createFindQuery(opts PerfFindOptions) map[string]in
 	if opts.Info.Version != "" {
 		search[bsonutil.GetDottedKeyName("info", "version")] = opts.Info.Version
 	}
+	if opts.Info.Variant != "" {
+		search[bsonutil.GetDottedKeyName("info", "variant")] = opts.Info.Variant
+	}
 	if opts.Info.TaskName != "" {
 		search[bsonutil.GetDottedKeyName("info", "task_name")] = opts.Info.TaskName
 	}
@@ -494,9 +496,6 @@ func (r *PerformanceResults) createFindQuery(opts PerfFindOptions) map[string]in
 	}
 	if len(opts.Info.Tags) > 0 {
 		search[bsonutil.GetDottedKeyName("info", "tags")] = bson.M{"$in": opts.Info.Tags}
-	}
-	if opts.Variant != "" {
-		search[bsonutil.GetDottedKeyName("info", "variant")] = opts.Variant
 	}
 
 	if len(opts.Info.Arguments) > 0 {
@@ -576,7 +575,7 @@ func (r *PerformanceResults) findAllChildrenGraphLookup(ctx context.Context, par
 						"input": "$" + "children",
 						"as":    "child",
 						"cond": bson.M{
-							"$eq": []interface{}{
+							"$setIsSubset": []interface{}{
 								tags,
 								"$$" + bsonutil.GetDottedKeyName("child", "info", "tags"),
 							},

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -685,7 +685,7 @@ func (s *perfResultsSuite) TestSearchResultsWithParent() {
 
 	info = PerformanceResultInfo{
 		Parent: nodeB.ID,
-		Tags:   []string{"tag1"},
+		Tags:   []string{"tag1", "tag2", "tag3"},
 	}
 	nodeD := CreatePerformanceResult(info, []ArtifactInfo{}, nil)
 	nodeD.Setup(cedar.GetEnvironment())
@@ -817,7 +817,7 @@ func (s *perfResultsSuite) TestSearchResultsWithParent() {
 		GraphLookup: true,
 	}
 	options.Info.Parent = nodeA.ID
-	options.Info.Tags = []string{"tag1"}
+	options.Info.Tags = []string{"tag1", "tag3"}
 	s.NoError(s.r.Find(s.ctx, options))
 	s.Require().Len(s.r.Results, 2)
 	s.Equal(s.r.Results[0].ID, nodeA.ID)

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -135,12 +135,12 @@ func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) (
 	cur, err := env.GetDB().Collection(perfResultCollection).Aggregate(ctx, []bson.M{
 		{
 			"$match": bson.M{
-				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey):    bson.M{"$exists": true},
-				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey): true,
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey):  bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey):  bson.M{"$exists": true},
+				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey):    bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): bson.M{"$exists": true},
+				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey): true,
 			},
 		},
 		{
@@ -180,12 +180,12 @@ func GetPerformanceData(ctx context.Context, env cedar.Environment, performanceR
 	pipe := []bson.M{
 		{
 			"$match": bson.M{
-				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey):    bson.M{"$exists": true},
-				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey): true,
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey):  performanceResultId.Project,
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey):  performanceResultId.Variant,
+				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey):    bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): performanceResultId.Task,
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): performanceResultId.Test,
+				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey): true,
 			},
 		},
 		{

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -124,13 +124,13 @@ func (dbc *DBConnector) FindPerformanceResultsByTaskName(ctx context.Context, pr
 	options := model.PerfFindOptions{
 		Interval: interval,
 		Info: model.PerformanceResultInfo{
+			Project:  project,
+			Variant:  variant,
 			TaskName: taskName,
 			Tags:     tags,
-			Project:  project,
 		},
 		MaxDepth: 0,
 		Limit:    limit,
-		Variant:  variant,
 		Sort:     []string{"info.order"},
 	}
 

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -191,9 +191,9 @@ func (h *perfGetByTaskNameHandler) Factory() gimlet.RouteHandler {
 func (h *perfGetByTaskNameHandler) Parse(_ context.Context, r *http.Request) error {
 	h.taskName = gimlet.GetVars(r)["task_name"]
 	vals := r.URL.Query()
-	h.tags = vals["tags"]
-	h.variant = vals.Get("variant")
 	h.project = vals.Get("project")
+	h.variant = vals.Get("variant")
+	h.tags = vals["tags"]
 	var err error
 	catcher := grip.NewBasicCatcher()
 	h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14066

The bug in EVG-14066 is caused by missing indexes. I did an audit of the `perf_results` collection's indexes and cleaned them up. I also cleaned up the code about and changed the perf with children route to use `$isSetSubset` instead of `$eq` when comparing tags.