### PR TITLE
EVG-14223: Fix flaky buildlogger append test

### DIFF
--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -364,6 +364,9 @@ func TestBuildloggerAppend(t *testing.T) {
 	t.Run("AppendToBucketAndDB", func(t *testing.T) {
 		log.Setup(env)
 		require.NoError(t, log.Append(ctx, chunk1))
+		// We need to sleep for a ms here to avoid a key name collision
+		// in the pail-backed blog storage since key names are the
+		// current time as a unix timestamp with millisecond precision.
 		time.Sleep(time.Millisecond)
 		require.NoError(t, log.Append(ctx, chunk2))
 		expectedData := []byte{}

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -326,7 +326,7 @@ func TestBuildloggerAppend(t *testing.T) {
 		{
 			Priority:  level.Info,
 			Timestamp: time.Now().Add(-56 * time.Minute).Round(time.Millisecond).UTC(),
-			Data:      "Buildogger logging logs.",
+			Data:      "Buildlogger logging logs.",
 		},
 
 		{

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -365,7 +365,7 @@ func TestBuildloggerAppend(t *testing.T) {
 		log.Setup(env)
 		require.NoError(t, log.Append(ctx, chunk1))
 		// We need to sleep for a ms here to avoid a key name collision
-		// in the pail-backed blog storage since key names are the
+		// in the pail-backed blob storage since key names are the
 		// current time as a unix timestamp with millisecond precision.
 		time.Sleep(time.Millisecond)
 		require.NoError(t, log.Append(ctx, chunk2))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14223

This took me hours to figure out and ended up being really stupid: occasionally the pail file is overwritten by the second call to append. The pail key is a string of the unix timestamp in milliseconds of `time.Now` and since the appends are called sequentially, this would sometimes result in the same millisecond precision unix timestamp and the first log file would get overwritten.