### PR TITLE
EVG-14175: clean up perf routes

### DIFF
--- a/model/perf.go
+++ b/model/perf.go
@@ -411,7 +411,7 @@ func (r *PerformanceResults) Find(ctx context.Context, opts PerfFindOptions) err
 	if opts.Info.Parent != "" { // this is the root node
 		search["_id"] = opts.Info.Parent
 	} else {
-		if opts.Interval.IsZero() || !opts.Interval.IsValid() {
+		if opts.Info.Version == "" && opts.Info.TaskID == "" && (opts.Interval.IsZero() || !opts.Interval.IsValid()) {
 			return errors.New("invalid time range given")
 		}
 		search = r.createFindQuery(opts)

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -558,6 +558,8 @@ func (s *perfResultsSuite) TearDownTest() {
 	s.NoError(s.r.env.GetDB().Collection(perfResultCollection).Drop(s.ctx))
 }
 
+// kim: TODO: continue from here. Figure out if/when we still need interval for
+// perf routes, or if it's just for buildlogger routes.
 func (s *perfResultsSuite) TestFindWithNilEnv() {
 	env := s.r.env
 	s.r.env = nil

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -558,8 +558,6 @@ func (s *perfResultsSuite) TearDownTest() {
 	s.NoError(s.r.env.GetDB().Collection(perfResultCollection).Drop(s.ctx))
 }
 
-// kim: TODO: continue from here. Figure out if/when we still need interval for
-// perf routes, or if it's just for buildlogger routes.
 func (s *perfResultsSuite) TestFindWithNilEnv() {
 	env := s.r.env
 	s.r.env = nil

--- a/rest/buildlogger_routes.go
+++ b/rest/buildlogger_routes.go
@@ -59,7 +59,7 @@ func (h *logGetByIDHandler) Parse(_ context.Context, r *http.Request) error {
 	vals := r.URL.Query()
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
 	catcher.Add(err)
 	if len(vals[limit]) > 0 {
 		h.opts.Limit, err = strconv.Atoi(vals[limit][0])
@@ -167,7 +167,7 @@ func (h *logGetByTaskIDHandler) Parse(_ context.Context, r *http.Request) error 
 	h.opts.Tags = vals[tags]
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
 	catcher.Add(err)
 	if len(vals[execution]) > 0 {
 		h.opts.Execution, err = strconv.Atoi(vals[execution][0])
@@ -296,7 +296,7 @@ func (h *logGetByTestNameHandler) Parse(_ context.Context, r *http.Request) erro
 	h.opts.Tags = vals[tags]
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
 	catcher.Add(err)
 	if len(vals[execution]) > 0 {
 		h.opts.Execution, err = strconv.Atoi(vals[execution][0])
@@ -445,7 +445,7 @@ func (h *logGroupHandler) Parse(_ context.Context, r *http.Request) error {
 		h.opts.EmptyExecution = true
 	}
 	if vals.Get(logStartAt) != "" || vals.Get(logEndAt) != "" {
-		h.opts.TimeRange, err = parseTimeRange(vals, logStartAt, logEndAt)
+		h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
 		catcher.Add(err)
 	}
 	if len(vals[limit]) > 0 {

--- a/rest/buildlogger_routes.go
+++ b/rest/buildlogger_routes.go
@@ -59,7 +59,7 @@ func (h *logGetByIDHandler) Parse(_ context.Context, r *http.Request) error {
 	vals := r.URL.Query()
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals.Get(logStartAt), vals.Get(logEndAt))
 	catcher.Add(err)
 	if len(vals[limit]) > 0 {
 		h.opts.Limit, err = strconv.Atoi(vals[limit][0])
@@ -167,7 +167,7 @@ func (h *logGetByTaskIDHandler) Parse(_ context.Context, r *http.Request) error 
 	h.opts.Tags = vals[tags]
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals.Get(logStartAt), vals.Get(logEndAt))
 	catcher.Add(err)
 	if len(vals[execution]) > 0 {
 		h.opts.Execution, err = strconv.Atoi(vals[execution][0])
@@ -296,7 +296,7 @@ func (h *logGetByTestNameHandler) Parse(_ context.Context, r *http.Request) erro
 	h.opts.Tags = vals[tags]
 	h.opts.PrintTime = vals.Get(printTime) == trueString
 	h.opts.PrintPriority = vals.Get(printPriority) == trueString
-	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
+	h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals.Get(logStartAt), vals.Get(logEndAt))
 	catcher.Add(err)
 	if len(vals[execution]) > 0 {
 		h.opts.Execution, err = strconv.Atoi(vals[execution][0])
@@ -445,7 +445,7 @@ func (h *logGroupHandler) Parse(_ context.Context, r *http.Request) error {
 		h.opts.EmptyExecution = true
 	}
 	if vals.Get(logStartAt) != "" || vals.Get(logEndAt) != "" {
-		h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals, logStartAt, logEndAt)
+		h.opts.TimeRange, err = parseTimeRange(time.RFC3339Nano, vals.Get(logStartAt), vals.Get(logEndAt))
 		catcher.Add(err)
 	}
 	if len(vals[limit]) > 0 {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -24,19 +24,6 @@ type Connector interface {
 	// FindPerformanceResults returns all performance results that match the
 	// given options.
 	FindPerformanceResults(context.Context, PerformanceOptions) ([]model.APIPerformanceResult, error)
-	// // FindPerformanceResultsByTaskId returns the performance results with
-	// // the given task id and that fall within given time range, filtered by
-	// // the optional tags.
-	// FindPerformanceResultsByTaskId(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
-	// // FindPerformanceResultsByTaskName returns the performance results
-	// // with the given task name and that fall within given time range,
-	// // filtered by the optional tags.
-	// FindPerformanceResultsByTaskName(context.Context, PerformanceOptions) ([]model.APIPerformanceResult, error)
-	// // FindPerformanceResultsByTaskName(context.Context, string, string, string, dbModel.TimeRange, int, ...string) ([]model.APIPerformanceResult, error)
-	// // FindPerformanceResultsByVersion returns the performance results with
-	// // the given version and that fall within given time range, filtered by
-	// // the optional tags.
-	// FindPerformanceResultsByVersion(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
 	// FindPerformanceResultWithChildren returns the the performance result
 	// with the given id and its children up to the given depth and
 	// filtered by the optional tags.

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -21,18 +21,22 @@ type Connector interface {
 	// RemovePerformanceResultById removes the performance result with the
 	// given id and its children.
 	RemovePerformanceResultById(context.Context, string) (int, error)
-	// FindPerformanceResultsByTaskId returns the performance results with
-	// the given task id and that fall within given time range, filtered by
-	// the optional tags.
-	FindPerformanceResultsByTaskId(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
-	// FindPerformanceResultsByTaskName returns the performance results
-	// with the given task name and that fall within given time range,
-	// filtered by the optional tags.
-	FindPerformanceResultsByTaskName(context.Context, string, string, string, dbModel.TimeRange, int, ...string) ([]model.APIPerformanceResult, error)
-	// FindPerformanceResultsByVersion returns the performance results with
-	// the given version and that fall within given time range, filtered by
-	// the optional tags.
-	FindPerformanceResultsByVersion(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
+	// FindPerformanceResults returns all performance results that match the
+	// given options.
+	FindPerformanceResults(context.Context, PerformanceOptions) ([]model.APIPerformanceResult, error)
+	// // FindPerformanceResultsByTaskId returns the performance results with
+	// // the given task id and that fall within given time range, filtered by
+	// // the optional tags.
+	// FindPerformanceResultsByTaskId(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
+	// // FindPerformanceResultsByTaskName returns the performance results
+	// // with the given task name and that fall within given time range,
+	// // filtered by the optional tags.
+	// FindPerformanceResultsByTaskName(context.Context, PerformanceOptions) ([]model.APIPerformanceResult, error)
+	// // FindPerformanceResultsByTaskName(context.Context, string, string, string, dbModel.TimeRange, int, ...string) ([]model.APIPerformanceResult, error)
+	// // FindPerformanceResultsByVersion returns the performance results with
+	// // the given version and that fall within given time range, filtered by
+	// // the optional tags.
+	// FindPerformanceResultsByVersion(context.Context, string, dbModel.TimeRange, ...string) ([]model.APIPerformanceResult, error)
 	// FindPerformanceResultWithChildren returns the the performance result
 	// with the given id and its children up to the given depth and
 	// filtered by the optional tags.
@@ -144,4 +148,17 @@ type TestResultsOptions struct {
 	TestName       string
 	Execution      int
 	EmptyExecution bool
+}
+
+// PerformanceOptions holds all values required to find a specific
+// PerformanceResult or PerformanceResults using connector functions.
+type PerformanceOptions struct {
+	Project  string
+	Version  string
+	Variant  string
+	TaskID   string
+	TaskName string
+	Tags     []string
+	Interval dbModel.TimeRange
+	Limit    int
 }

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -71,7 +71,8 @@ func (dbc *DBConnector) RemovePerformanceResultById(ctx context.Context, id stri
 }
 
 // FindPerformanceResults queries the database to find all performance results
-// that match the given options.
+// that match the given options. If querying by task name, results are sorted
+// (descending) by the Evergreen order.
 func (dbc *DBConnector) FindPerformanceResults(ctx context.Context, opts PerformanceOptions) ([]dataModel.APIPerformanceResult, error) {
 	var results model.PerformanceResults
 	results.Setup(dbc.env)
@@ -117,144 +118,6 @@ func (dbc *DBConnector) FindPerformanceResults(ctx context.Context, opts Perform
 	}
 	return apiResults, nil
 }
-
-// kim: TODO: delete
-// // FindPerformanceResultsByTaskId queries the database to find all performance
-// // results with the given taskId and that fall within interval, filtered by
-// // tags.
-// func (dbc *DBConnector) FindPerformanceResultsByTaskId(ctx context.Context, taskId string, interval model.TimeRange, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := model.PerformanceResults{}
-//     results.Setup(dbc.env)
-//
-//     options := model.PerfFindOptions{
-//         // kim: TODO: delete
-//         // Interval: interval,
-//         Info: model.PerformanceResultInfo{
-//             TaskID: taskId,
-//             Tags:   tags,
-//         },
-//         MaxDepth: 0,
-//     }
-//
-//     if err := results.Find(ctx, options); err != nil {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusInternalServerError,
-//             Message:    errors.Wrap(err, "database error").Error(),
-//         }
-//     }
-//     if results.IsNil() {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//
-//     apiResults := make([]dataModel.APIPerformanceResult, len(results.Results))
-//     for i, result := range results.Results {
-//         err := apiResults[i].Import(result)
-//         if err != nil {
-//             return nil, gimlet.ErrorResponse{
-//                 StatusCode: http.StatusInternalServerError,
-//                 Message:    errors.Wrap(err, "corrupt data").Error(),
-//             }
-//         }
-//     }
-//     return apiResults, nil
-// }
-
-// kim: TODO: delete
-// // FindPerformanceResultsByTaskName queries the database to find all
-// // performance results with the given taskName and that fall within interval,
-// // filtered by tags. Results are returned sorted (descending) by the Evergreen
-// // order. If limit is greater than 0, the number of results returned will be no
-// // greater than limit.
-// func (dbc *DBConnector) FindPerformanceResultsByTaskName(ctx context.Context, project, taskName, variant string, interval model.TimeRange, limit int, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := model.PerformanceResults{}
-//     results.Setup(dbc.env)
-//
-//     options := model.PerfFindOptions{
-//         // kim: TODO: delete
-//         // Interval: interval,
-//         Info: model.PerformanceResultInfo{
-//             Project:  project,
-//             Variant:  variant,
-//             TaskName: taskName,
-//             Tags:     tags,
-//         },
-//         MaxDepth: 0,
-//         Limit:    limit,
-//         Sort:     []string{"info.order"},
-//     }
-//
-//     if err := results.Find(ctx, options); err != nil {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusInternalServerError,
-//             Message:    errors.Wrap(err, "database error").Error(),
-//         }
-//     }
-//     if results.IsNil() {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//
-//     apiResults := make([]dataModel.APIPerformanceResult, len(results.Results))
-//     for i, result := range results.Results {
-//         err := apiResults[i].Import(result)
-//         if err != nil {
-//             return nil, gimlet.ErrorResponse{
-//                 StatusCode: http.StatusInternalServerError,
-//                 Message:    errors.Wrap(err, "corrupt data").Error(),
-//             }
-//         }
-//     }
-//     return apiResults, nil
-// }
-
-// kim: TODO: delete
-// // FindPerformanceResultsByVersion queries the database to find all performance
-// // results with the given version and that fall within interval, filtered by
-// // tags.
-// func (dbc *DBConnector) FindPerformanceResultsByVersion(ctx context.Context, version string, interval model.TimeRange, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := model.PerformanceResults{}
-//     results.Setup(dbc.env)
-//
-//     options := model.PerfFindOptions{
-//         // kim: TODO: delete
-//         // Interval: interval,
-//         Info: model.PerformanceResultInfo{
-//             Version: version,
-//             Tags:    tags,
-//         },
-//         MaxDepth: 0,
-//     }
-//
-//     if err := results.Find(ctx, options); err != nil {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusInternalServerError,
-//             Message:    errors.Wrap(err, "database error").Error(),
-//         }
-//     }
-//     if results.IsNil() {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//
-//     apiResults := make([]dataModel.APIPerformanceResult, len(results.Results))
-//     for i, result := range results.Results {
-//         err := apiResults[i].Import(result)
-//         if err != nil {
-//             return nil, gimlet.ErrorResponse{
-//                 StatusCode: http.StatusInternalServerError,
-//                 Message:    errors.Wrap(err, "corrupt data").Error(),
-//             }
-//         }
-//     }
-//     return apiResults, nil
-// }
 
 // FindPerformanceResultWithChildren queries the database to find a performance
 // result with the given id and its children up to maxDepth and filtered by
@@ -369,9 +232,14 @@ func (mc *MockConnector) RemovePerformanceResultById(_ context.Context, id strin
 	return len(children) + 1, err
 }
 
+// FindPerformanceResults finds the performance results matching the given
+// options.
 func (mc *MockConnector) FindPerformanceResults(_ context.Context, opts PerformanceOptions) ([]dataModel.APIPerformanceResult, error) {
 	var results []dataModel.APIPerformanceResult
 	for _, result := range mc.CachedPerformanceResults {
+		if opts.Project != "" && opts.Project != result.Info.Project {
+			continue
+		}
 		if opts.Version != "" && opts.Version != result.Info.Version {
 			continue
 		}
@@ -381,10 +249,8 @@ func (mc *MockConnector) FindPerformanceResults(_ context.Context, opts Performa
 		if opts.TaskID != "" && opts.TaskID != result.Info.TaskID {
 			continue
 		}
-		if opts.TaskName != "" {
-			if opts.TaskName != result.Info.TaskName {
-				continue
-			}
+		if opts.TaskName != "" && opts.TaskName != result.Info.TaskName {
+			continue
 		}
 		if opts.TaskID == "" && opts.Version == "" {
 			if !result.Info.Mainline {
@@ -426,135 +292,6 @@ func (mc *MockConnector) FindPerformanceResults(_ context.Context, opts Performa
 	return results, nil
 }
 
-// // FindPerformanceResultsByVersion queries the mock cache to find all
-// // performance results with the given version and that fall within interval,
-// // filtered by tags.
-// func (mc *MockConnector) FindPerformanceResultsByVersion(_ context.Context, version string, interval model.TimeRange, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := []dataModel.APIPerformanceResult{}
-//     for _, result := range mc.CachedPerformanceResults {
-//         if result.Info.Version == version && containsTags(tags, result.Info.Tags) {
-//             apiResult := dataModel.APIPerformanceResult{}
-//             err := apiResult.Import(result)
-//             if err != nil {
-//                 return nil, gimlet.ErrorResponse{
-//                     StatusCode: http.StatusInternalServerError,
-//                     Message:    errors.Wrap(err, "corrupt data").Error(),
-//                 }
-//             }
-//
-//             results = append(results, apiResult)
-//         }
-// =======
-//     if opts.Limit > 0 && opts.Limit < len(results) {
-//         results = results[:opts.Limit]
-//     }
-//
-//     return results, nil
-// }
-
-// kim: TODO: delete
-// // FindPerformanceResultsByTaskId queries the mock cache to find all
-// // performance results with the given taskId and that fall within interval,
-// // filtered by tags.
-// func (mc *MockConnector) FindPerformanceResultsByTaskId(_ context.Context, taskId string, interval model.TimeRange, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := []dataModel.APIPerformanceResult{}
-//     for _, result := range mc.CachedPerformanceResults {
-//         // kim: TODO: delete
-//         // if result.Info.TaskID == taskId && mc.checkInterval(result.ID, interval) && containsTags(tags, result.Info.Tags) {
-//         if result.Info.TaskID == taskId && containsTags(tags, result.Info.Tags) {
-//             apiResult := dataModel.APIPerformanceResult{}
-//             err := apiResult.Import(result)
-//             if err != nil {
-//                 return nil, gimlet.ErrorResponse{
-//                     StatusCode: http.StatusInternalServerError,
-//                     Message:    errors.Wrap(err, "corrupt data").Error(),
-//                 }
-//             }
-//
-//             results = append(results, apiResult)
-//         }
-//     }
-//
-//     if len(results) == 0 {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//     return results, nil
-// }
-
-// // FindPerformanceResultsByTaskName queries the mock cache to find all
-// // performance results with the given taskName and that fall within interval,
-// // filtered by tags. Results are returned sorted (descending) by the Evergreen
-// // order. If limit is greater than 0, the number of results returned will be no
-// // greater than limit.
-// func (mc *MockConnector) FindPerformanceResultsByTaskName(_ context.Context, project, taskName, variant string, interval model.TimeRange, limit int, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := []dataModel.APIPerformanceResult{}
-//     for _, result := range mc.CachedPerformanceResults {
-//         // kim: TODO: delete
-//         // if result.Info.TaskName == taskName && mc.checkInterval(result.ID, interval) && containsTags(tags, result.Info.Tags) &&
-//         if result.Info.TaskName == taskName && containsTags(tags, result.Info.Tags) &&
-//             result.Info.Mainline && (variant == "" || result.Info.Variant == variant) {
-//             apiResult := dataModel.APIPerformanceResult{}
-//             err := apiResult.Import(result)
-//             if err != nil {
-//                 return nil, gimlet.ErrorResponse{
-//                     StatusCode: http.StatusInternalServerError,
-//                     Message:    errors.Wrap(err, "corrupt data").Error(),
-//                 }
-//             }
-//             results = append(results, apiResult)
-//         }
-//     }
-//
-//     if len(results) == 0 {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//
-//     sort.Slice(results, func(i, j int) bool { return results[i].Info.Order > results[j].Info.Order })
-//     if limit > 0 && limit < len(results) {
-//         results = results[:limit]
-//     }
-//
-//     return results, nil
-// }
-
-// kim: TODO: delete
-// // FindPerformanceResultsByVersion queries the mock cache to find all
-// // performance results with the given version and that fall within interval,
-// // filtered by tags.
-// func (mc *MockConnector) FindPerformanceResultsByVersion(_ context.Context, version string, interval model.TimeRange, tags ...string) ([]dataModel.APIPerformanceResult, error) {
-//     results := []dataModel.APIPerformanceResult{}
-//     for _, result := range mc.CachedPerformanceResults {
-//         // kim: TODO: delete
-//         // if result.Info.Version == version && mc.checkInterval(result.ID, interval) && containsTags(tags, result.Info.Tags) && result.Info.Mainline {
-//         if result.Info.Version == version && containsTags(tags, result.Info.Tags) && result.Info.Mainline {
-//             apiResult := dataModel.APIPerformanceResult{}
-//             err := apiResult.Import(result)
-//             if err != nil {
-//                 return nil, gimlet.ErrorResponse{
-//                     StatusCode: http.StatusInternalServerError,
-//                     Message:    errors.Wrap(err, "corrupt data").Error(),
-//                 }
-//             }
-//
-//             results = append(results, apiResult)
-//         }
-//     }
-//
-//     if len(results) == 0 {
-//         return nil, gimlet.ErrorResponse{
-//             StatusCode: http.StatusNotFound,
-//             Message:    "not found",
-//         }
-//     }
-//     return results, nil
-// }
-
 // FindPerformanceResultWithChildren queries the mock cache to find a
 // performance result with the given id and its children up to maxDepth and
 // filtered by tags. If maxDepth is less than 0, the child search is
@@ -572,7 +309,6 @@ func (mc *MockConnector) FindPerformanceResultWithChildren(ctx context.Context, 
 	return append(results, children...), err
 }
 
-// kim: TODO: delete
 func (mc *MockConnector) checkInterval(id string, interval model.TimeRange) bool {
 	result := mc.CachedPerformanceResults[id]
 	createdAt := result.CreatedAt

--- a/rest/data/perf_test.go
+++ b/rest/data/perf_test.go
@@ -375,11 +375,14 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskId() {
 			expectedCount++
 		}
 	}
-	dur, err := time.ParseDuration("100h")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
+	// kim: TODO: delete
+	// dur, err := time.ParseDuration("100h")
+	// s.Require().NoError(err)
+	// tr := model.GetTimeRange(time.Time{}, dur)
 
-	actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr)
+	// kim: TODO: delete
+	// actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{TaskID: expectedTaskID})
 	s.Equal(expectedCount, len(actualResult))
 	for _, result := range actualResult {
 		s.Equal(expectedTaskID, *result.Info.TaskID)
@@ -387,32 +390,58 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskId() {
 	s.NoError(err)
 
 	// Now with tags
-	actualResult, err = s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr, "tag1", "tag2")
-	s.True(len(actualResult) < expectedCount)
-	for _, result := range actualResult {
-		s.Equal(expectedTaskID, *result.Info.TaskID)
-		foundTag := false
-		for _, tag := range result.Info.Tags {
-			if tag == "tag1" || tag == "tag2" {
-				foundTag = true
-				break
+	s.T().Run("WithTags", func(t *testing.T) {
+		// kim :TODO: delete
+		// actualResult, err = s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr, "tag1", "tag2")
+		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+			TaskID: expectedTaskID,
+			Tags:   []string{"tag1", "tag2"},
+		})
+		s.True(len(actualResult) < expectedCount)
+		for _, result := range actualResult {
+			s.Equal(expectedTaskID, *result.Info.TaskID)
+			foundTag := false
+			for _, tag := range result.Info.Tags {
+				if tag == "tag1" || tag == "tag2" {
+					foundTag = true
+					break
+				}
 			}
+			s.True(foundTag)
 		}
-		s.True(foundTag)
-	}
-	s.NoError(err)
+		s.NoError(err)
+	})
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskIdDoesNotExist() {
-	dur, err := time.ParseDuration("100h")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
+	// kim: TODO: Delete
+	// dur, err := time.ParseDuration("100h")
+	// s.Require().NoError(err)
+	// tr := model.GetTimeRange(time.Time{}, dur)
 
 	var expectedResult []dataModel.APIPerformanceResult
-	actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, "doesNotExist", tr)
+	// kim: TODO: Delete
+	// actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, "doesNotExist", tr)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+		TaskID: "doesNotExist",
+	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
+
+// kim: TODO: delete
+// func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskIdNarrowInterval() {
+//     s.T().Skip("test disabled as time range and task_id queries might not make sense")
+//
+//     dur, err := time.ParseDuration("1ns")
+//     s.Require().NoError(err)
+//     tr := model.GetTimeRange(time.Time{}, dur)
+//
+//     var expectedResult []dataModel.APIPerformanceResult
+//     actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, s.results[0].info.TaskID, tr)
+//     s.Equal(expectedResult, actualResult)
+//     s.Error(err)
+// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	expectedTaskName := s.results[0].info.TaskName
@@ -422,11 +451,17 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 			expectedCount++
 		}
 	}
+	// kim: TODO: delete
 	dur, err := time.ParseDuration("100h")
 	s.Require().NoError(err)
 	tr := model.GetTimeRange(time.Time{}, dur)
 
-	actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0)
+	// kim: TODO: delete
+	// actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+		TaskName: expectedTaskName,
+		Interval: tr,
+	})
 	s.Require().Equal(expectedCount, len(actualResult))
 	previousOrder := actualResult[0].Info.Order
 	for _, result := range actualResult {
@@ -436,58 +471,88 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	}
 	s.NoError(err)
 
-	limit := 2
-	actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, limit)
-	s.Equal(limit, len(actualResult))
-	for _, result := range actualResult {
-		s.Equal(expectedTaskName, *result.Info.TaskName)
-	}
-	s.NoError(err)
-
-	// Now with tags
-	actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0, "tag1", "tag2")
-	s.True(len(actualResult) < expectedCount)
-	for _, result := range actualResult {
-		s.Equal(expectedTaskName, *result.Info.TaskName)
-		foundTag := false
-		for _, tag := range result.Info.Tags {
-			if tag == "tag1" || tag == "tag2" {
-				foundTag = true
-				break
-			}
+	s.T().Run("WithLimit", func(t *testing.T) {
+		limit := 2
+		// kim: TODO: delete
+		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, limit)
+		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+			TaskName: expectedTaskName,
+			Interval: tr,
+			Limit:    limit,
+		})
+		s.Equal(limit, len(actualResult))
+		for _, result := range actualResult {
+			s.Equal(expectedTaskName, *result.Info.TaskName)
 		}
-		s.True(foundTag)
-	}
-	s.NoError(err)
+		s.NoError(err)
+	})
 
-	// search by variant
-	actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "v", tr, 0)
-	s.NoError(err)
-	s.Require().Len(actualResult, 1)
-	s.Equal(actualResult[0].Info.Variant, utility.ToStringPtr("v"))
+	s.T().Run("WithTags", func(t *testing.T) {
+		// Now with tags
+		// kim: TODO: delete
+		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0, "tag1", "tag2")
+		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+			TaskName: expectedTaskName,
+			Interval: tr,
+			Tags:     []string{"tag1", "tag2"},
+		})
+		s.True(len(actualResult) < expectedCount)
+		for _, result := range actualResult {
+			s.Equal(expectedTaskName, *result.Info.TaskName)
+			foundTag := false
+			for _, tag := range result.Info.Tags {
+				if tag == "tag1" || tag == "tag2" {
+					foundTag = true
+					break
+				}
+			}
+			s.True(foundTag)
+		}
+		s.NoError(err)
+	})
+
+	s.T().Run("WithVariant", func(t *testing.T) {
+		// search by variant
+		// kim: TODO: delete
+		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "v", tr, 0)
+		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+			TaskName: expectedTaskName,
+			Interval: tr,
+			Variant:  "v",
+		})
+		s.NoError(err)
+		s.Require().Len(actualResult, 1)
+		s.Equal(actualResult[0].Info.Variant, utility.ToStringPtr("v"))
+	})
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskNameDoesNotExist() {
-	dur, err := time.ParseDuration("100h")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
+	// kim: TODO: delete
+	// dur, err := time.ParseDuration("100h")
+	// s.Require().NoError(err)
+	// tr := model.GetTimeRange(time.Time{}, dur)
 
 	var expectedResult []dataModel.APIPerformanceResult
-	actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", "doesNotExist", "", tr, 0)
+	// kim: TODO: delete
+	// actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", "doesNotExist", "", tr, 0)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+		TaskName: "doesNotExist",
+	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
 
-func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskNameNarrowInterval() {
-	dur, err := time.ParseDuration("1ns")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
-
-	var expectedResult []dataModel.APIPerformanceResult
-	actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", s.results[0].info.TaskName, "", tr, 0)
-	s.Equal(expectedResult, actualResult)
-	s.Error(err)
-}
+// kim: TODO: delete
+// func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskNameNarrowInterval() {
+//     dur, err := time.ParseDuration("1ns")
+//     s.Require().NoError(err)
+//     tr := model.GetTimeRange(time.Time{}, dur)
+//
+//     var expectedResult []dataModel.APIPerformanceResult
+//     actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", s.results[0].info.TaskName, "", tr, 0)
+//     s.Equal(expectedResult, actualResult)
+//     s.Error(err)
+// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 	expectedVersion := s.results[0].info.Version
@@ -497,11 +562,16 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 			expectedCount++
 		}
 	}
-	dur, err := time.ParseDuration("100h")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
+	// kim: TODO: delete
+	// dur, err := time.ParseDuration("100h")
+	// s.Require().NoError(err)
+	// tr := model.GetTimeRange(time.Time{}, dur)
 
-	actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr)
+	// kim: TODO: delete
+	// actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+		Version: expectedVersion,
+	})
 	s.Equal(expectedCount, len(actualResult))
 	for _, result := range actualResult {
 		s.Equal(expectedVersion, *result.Info.Version)
@@ -509,32 +579,55 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 	s.NoError(err)
 
 	// Now with tags
-	actualResult, err = s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr, "tag1")
-	s.True(len(actualResult) < expectedCount)
-	for _, result := range actualResult {
-		s.Equal(expectedVersion, *result.Info.Version)
-		foundTag := false
-		for _, tag := range result.Info.Tags {
-			if tag == "tag1" {
-				foundTag = true
-				break
+	// actualResult, err = s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr, "tag1")
+	s.T().Run("WithTags", func(t *testing.T) {
+		actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+			Version: expectedVersion,
+			Tags:    []string{"tag1"},
+		})
+		s.True(len(actualResult) < expectedCount)
+		for _, result := range actualResult {
+			s.Equal(expectedVersion, *result.Info.Version)
+			foundTag := false
+			for _, tag := range result.Info.Tags {
+				if tag == "tag1" {
+					foundTag = true
+					break
+				}
 			}
+			s.True(foundTag)
 		}
-		s.True(foundTag)
-	}
-	s.NoError(err)
+		s.NoError(err)
+	})
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersionDoesNotExist() {
-	dur, err := time.ParseDuration("100h")
-	s.Require().NoError(err)
-	tr := model.GetTimeRange(time.Time{}, dur)
+	// kim: TODO: delete
+	// dur, err := time.ParseDuration("100h")
+	// s.Require().NoError(err)
+	// tr := model.GetTimeRange(time.Time{}, dur)
 
 	var expectedResult []dataModel.APIPerformanceResult
-	actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, "doesNotExist", tr)
+	// kim: TODO: delete
+	// actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, "doesNotExist", tr)
+	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
+		Version: "doesNotExist",
+	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
+
+// kim: TODO: delete
+// func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersionNarrowInterval() {
+//     dur, err := time.ParseDuration("1ns")
+//     s.Require().NoError(err)
+//     tr := model.GetTimeRange(time.Time{}, dur)
+//
+//     var expectedResult []dataModel.APIPerformanceResult
+//     actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, s.results[0].info.Version, tr)
+//     s.Equal(expectedResult, actualResult)
+//     s.Error(err)
+// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultWithChildren() {
 	expectedLineage := s.getLineage(s.results[0].info.ID())

--- a/rest/data/perf_test.go
+++ b/rest/data/perf_test.go
@@ -375,13 +375,6 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskId() {
 			expectedCount++
 		}
 	}
-	// kim: TODO: delete
-	// dur, err := time.ParseDuration("100h")
-	// s.Require().NoError(err)
-	// tr := model.GetTimeRange(time.Time{}, dur)
-
-	// kim: TODO: delete
-	// actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{TaskID: expectedTaskID})
 	s.Equal(expectedCount, len(actualResult))
 	for _, result := range actualResult {
@@ -389,10 +382,7 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskId() {
 	}
 	s.NoError(err)
 
-	// Now with tags
 	s.T().Run("WithTags", func(t *testing.T) {
-		// kim :TODO: delete
-		// actualResult, err = s.sc.FindPerformanceResultsByTaskId(s.ctx, expectedTaskID, tr, "tag1", "tag2")
 		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 			TaskID: expectedTaskID,
 			Tags:   []string{"tag1", "tag2"},
@@ -414,34 +404,13 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskId() {
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskIdDoesNotExist() {
-	// kim: TODO: Delete
-	// dur, err := time.ParseDuration("100h")
-	// s.Require().NoError(err)
-	// tr := model.GetTimeRange(time.Time{}, dur)
-
 	var expectedResult []dataModel.APIPerformanceResult
-	// kim: TODO: Delete
-	// actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, "doesNotExist", tr)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 		TaskID: "doesNotExist",
 	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
-
-// kim: TODO: delete
-// func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskIdNarrowInterval() {
-//     s.T().Skip("test disabled as time range and task_id queries might not make sense")
-//
-//     dur, err := time.ParseDuration("1ns")
-//     s.Require().NoError(err)
-//     tr := model.GetTimeRange(time.Time{}, dur)
-//
-//     var expectedResult []dataModel.APIPerformanceResult
-//     actualResult, err := s.sc.FindPerformanceResultsByTaskId(s.ctx, s.results[0].info.TaskID, tr)
-//     s.Equal(expectedResult, actualResult)
-//     s.Error(err)
-// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	expectedTaskName := s.results[0].info.TaskName
@@ -451,13 +420,10 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 			expectedCount++
 		}
 	}
-	// kim: TODO: delete
 	dur, err := time.ParseDuration("100h")
 	s.Require().NoError(err)
 	tr := model.GetTimeRange(time.Time{}, dur)
 
-	// kim: TODO: delete
-	// actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 		TaskName: expectedTaskName,
 		Interval: tr,
@@ -472,9 +438,7 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	s.NoError(err)
 
 	s.T().Run("WithLimit", func(t *testing.T) {
-		limit := 2
-		// kim: TODO: delete
-		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, limit)
+		const limit = 2
 		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 			TaskName: expectedTaskName,
 			Interval: tr,
@@ -488,9 +452,6 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	})
 
 	s.T().Run("WithTags", func(t *testing.T) {
-		// Now with tags
-		// kim: TODO: delete
-		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "", tr, 0, "tag1", "tag2")
 		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 			TaskName: expectedTaskName,
 			Interval: tr,
@@ -512,9 +473,6 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 	})
 
 	s.T().Run("WithVariant", func(t *testing.T) {
-		// search by variant
-		// kim: TODO: delete
-		// actualResult, err = s.sc.FindPerformanceResultsByTaskName(s.ctx, "", expectedTaskName, "v", tr, 0)
 		actualResult, err = s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 			TaskName: expectedTaskName,
 			Interval: tr,
@@ -527,32 +485,13 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskName() {
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskNameDoesNotExist() {
-	// kim: TODO: delete
-	// dur, err := time.ParseDuration("100h")
-	// s.Require().NoError(err)
-	// tr := model.GetTimeRange(time.Time{}, dur)
-
 	var expectedResult []dataModel.APIPerformanceResult
-	// kim: TODO: delete
-	// actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", "doesNotExist", "", tr, 0)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 		TaskName: "doesNotExist",
 	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
-
-// kim: TODO: delete
-// func (s *PerfConnectorSuite) TestFindPerformanceResultsByTaskNameNarrowInterval() {
-//     dur, err := time.ParseDuration("1ns")
-//     s.Require().NoError(err)
-//     tr := model.GetTimeRange(time.Time{}, dur)
-//
-//     var expectedResult []dataModel.APIPerformanceResult
-//     actualResult, err := s.sc.FindPerformanceResultsByTaskName(s.ctx, "", s.results[0].info.TaskName, "", tr, 0)
-//     s.Equal(expectedResult, actualResult)
-//     s.Error(err)
-// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 	expectedVersion := s.results[0].info.Version
@@ -562,13 +501,6 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 			expectedCount++
 		}
 	}
-	// kim: TODO: delete
-	// dur, err := time.ParseDuration("100h")
-	// s.Require().NoError(err)
-	// tr := model.GetTimeRange(time.Time{}, dur)
-
-	// kim: TODO: delete
-	// actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 		Version: expectedVersion,
 	})
@@ -578,8 +510,6 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 	}
 	s.NoError(err)
 
-	// Now with tags
-	// actualResult, err = s.sc.FindPerformanceResultsByVersion(s.ctx, expectedVersion, tr, "tag1")
 	s.T().Run("WithTags", func(t *testing.T) {
 		actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 			Version: expectedVersion,
@@ -602,32 +532,13 @@ func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersion() {
 }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersionDoesNotExist() {
-	// kim: TODO: delete
-	// dur, err := time.ParseDuration("100h")
-	// s.Require().NoError(err)
-	// tr := model.GetTimeRange(time.Time{}, dur)
-
 	var expectedResult []dataModel.APIPerformanceResult
-	// kim: TODO: delete
-	// actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, "doesNotExist", tr)
 	actualResult, err := s.sc.FindPerformanceResults(s.ctx, PerformanceOptions{
 		Version: "doesNotExist",
 	})
 	s.Equal(expectedResult, actualResult)
 	s.Error(err)
 }
-
-// kim: TODO: delete
-// func (s *PerfConnectorSuite) TestFindPerformanceResultsByVersionNarrowInterval() {
-//     dur, err := time.ParseDuration("1ns")
-//     s.Require().NoError(err)
-//     tr := model.GetTimeRange(time.Time{}, dur)
-//
-//     var expectedResult []dataModel.APIPerformanceResult
-//     actualResult, err := s.sc.FindPerformanceResultsByVersion(s.ctx, s.results[0].info.Version, tr)
-//     s.Equal(expectedResult, actualResult)
-//     s.Error(err)
-// }
 
 func (s *PerfConnectorSuite) TestFindPerformanceResultWithChildren() {
 	expectedLineage := s.getLineage(s.results[0].info.ID())

--- a/rest/parse.go
+++ b/rest/parse.go
@@ -8,13 +8,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func parseTimeRange(vals url.Values, start, end string) (model.TimeRange, error) {
+func parseTimeRange(format string, vals url.Values, start, end string) (model.TimeRange, error) {
 	tr := model.TimeRange{EndAt: time.Now()}
 	startAt := vals.Get(start)
 	endAt := vals.Get(end)
 
 	if startAt != "" {
-		s, err := time.ParseInLocation(time.RFC3339Nano, startAt, time.UTC)
+		s, err := time.ParseInLocation(format, startAt, time.UTC)
 		if err != nil {
 			return model.TimeRange{}, errors.Errorf("problem parsing start time '%s'", startAt)
 		}
@@ -22,7 +22,7 @@ func parseTimeRange(vals url.Values, start, end string) (model.TimeRange, error)
 	}
 
 	if endAt != "" {
-		e, err := time.ParseInLocation(time.RFC3339Nano, endAt, time.UTC)
+		e, err := time.ParseInLocation(format, endAt, time.UTC)
 		if err != nil {
 			return model.TimeRange{}, errors.Errorf("problem parsing end time '%s'", endAt)
 		}

--- a/rest/parse.go
+++ b/rest/parse.go
@@ -1,30 +1,27 @@
 package rest
 
 import (
-	"net/url"
 	"time"
 
 	"github.com/evergreen-ci/cedar/model"
 	"github.com/pkg/errors"
 )
 
-func parseTimeRange(format string, vals url.Values, start, end string) (model.TimeRange, error) {
+func parseTimeRange(format, start, end string) (model.TimeRange, error) {
 	tr := model.TimeRange{EndAt: time.Now()}
-	startAt := vals.Get(start)
-	endAt := vals.Get(end)
 
-	if startAt != "" {
-		s, err := time.ParseInLocation(format, startAt, time.UTC)
+	if start != "" {
+		s, err := time.ParseInLocation(format, start, time.UTC)
 		if err != nil {
-			return model.TimeRange{}, errors.Errorf("problem parsing start time '%s'", startAt)
+			return model.TimeRange{}, errors.Errorf("problem parsing start time '%s'", start)
 		}
 		tr.StartAt = s
 	}
 
-	if endAt != "" {
-		e, err := time.ParseInLocation(format, endAt, time.UTC)
+	if end != "" {
+		e, err := time.ParseInLocation(format, end, time.UTC)
 		if err != nil {
-			return model.TimeRange{}, errors.Errorf("problem parsing end time '%s'", endAt)
+			return model.TimeRange{}, errors.Errorf("problem parsing end time '%s'", end)
 		}
 		tr.EndAt = e
 	}

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -19,6 +19,10 @@ const (
 	perfEndAt   = "finished_before"
 )
 
+// timeRangeFormatDay represents the time range format rounded to the nearest
+// day (YYYY-MM-DD).
+const timeRangeFormatDay = "2006-01-02"
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // GET /perf/{id}
@@ -114,10 +118,11 @@ func (h *perfRemoveByIdHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /perf/task_id/{task_id}
 
 type perfGetByTaskIdHandler struct {
-	taskId   string
-	interval model.TimeRange
-	tags     []string
-	sc       data.Connector
+	taskId string
+	// kim: TODO: delete
+	// interval model.TimeRange
+	tags []string
+	sc   data.Connector
 }
 
 func makeGetPerfByTaskId(sc data.Connector) gimlet.RouteHandler {
@@ -138,15 +143,23 @@ func (h *perfGetByTaskIdHandler) Parse(_ context.Context, r *http.Request) error
 	h.taskId = gimlet.GetVars(r)["task_id"]
 	vals := r.URL.Query()
 	h.tags = vals["tags"]
-	var err error
-	h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)
-	return err
+	return nil
+	// kim: TODO: delete
+	// var err error
+	// h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)
+	// return err
 }
 
-// Run calls the data FindPerformanceResultsByTaskId and function returns the
+// Run calls the data FindPerformanceResults function and returns the
 // PerformanceResults from the provider.
 func (h *perfGetByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResultsByTaskId(ctx, h.taskId, h.interval, h.tags...)
+	// kim: TODO: Delete
+	// perfResults, err := h.sc.FindPerformanceResultsByTaskId(ctx, h.taskId, h.interval, h.tags...)
+	// perfResults, err := h.sc.FindPerformanceResultsByTaskId(ctx, h.taskId, h.tags...)
+	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
+		TaskID: h.taskId,
+		Tags:   h.tags,
+	})
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by task id '%s'", h.taskId)
 		grip.Error(message.WrapError(err, message.Fields{
@@ -194,24 +207,34 @@ func (h *perfGetByTaskNameHandler) Parse(_ context.Context, r *http.Request) err
 	h.project = vals.Get("project")
 	h.variant = vals.Get("variant")
 	h.tags = vals["tags"]
-	var err error
 	catcher := grip.NewBasicCatcher()
-	h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)
-	catcher.Add(err)
+	var err error
+	h.interval, err = parseTimeRange(timeRangeFormatDay, vals, perfStartAt, perfEndAt)
+	catcher.Add(errors.Wrap(err, "invalid time range"))
 	limit := vals.Get("limit")
 	if limit != "" {
 		h.limit, err = strconv.Atoi(limit)
-		catcher.Add(err)
+		catcher.Add(errors.Wrap(err, "invalid limit"))
 	} else {
 		h.limit = 0
 	}
 	return catcher.Resolve()
 }
 
-// Run calls the data FindPerformanceResultsByTaskName function and returns the
+// Run calls the data FindPerformanceResults function and returns the
 // PerformanceResults from the provider.
 func (h *perfGetByTaskNameHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResultsByTaskName(ctx, h.project, h.taskName, h.variant, h.interval, h.limit, h.tags...)
+	// kim: TODO: delete
+	// perfResults, err := h.sc.FindPerformanceResultsByTaskName(ctx, h.project, h.taskName, h.variant, h.interval, h.limit, h.tags...)
+	// perfResults, err := h.sc.FindPerformanceResultsByTaskName(ctx, h.project, h.taskName, h.variant, h.limit, h.tags...)
+	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
+		Project:  h.project,
+		Variant:  h.variant,
+		TaskName: h.taskName,
+		Tags:     h.tags,
+		Interval: h.interval,
+		Limit:    h.limit,
+	})
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by task_name '%s'", h.taskName)
 		grip.Error(message.WrapError(err, message.Fields{
@@ -230,10 +253,11 @@ func (h *perfGetByTaskNameHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /perf/version/{version}
 
 type perfGetByVersionHandler struct {
-	version  string
-	interval model.TimeRange
-	tags     []string
-	sc       data.Connector
+	version string
+	// kim: TODO: delete
+	// interval model.TimeRange
+	tags []string
+	sc   data.Connector
 }
 
 func makeGetPerfByVersion(sc data.Connector) gimlet.RouteHandler {
@@ -254,15 +278,23 @@ func (h *perfGetByVersionHandler) Parse(_ context.Context, r *http.Request) erro
 	h.version = gimlet.GetVars(r)["version"]
 	vals := r.URL.Query()
 	h.tags = vals["tags"]
-	var err error
-	h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)
-	return err
+	// kim: TODO: delete
+	// var err error
+	// h.interval, err = parseTimeRange(vals, perfStartAt, perfEndAt)
+	// return err
+	return nil
 }
 
-// Run calls the data FindPerformanceResultsByVersion function returns the
+// Run calls the data FindPerformanceResults function returns the
 // PerformanceResult from the provider.
 func (h *perfGetByVersionHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResultsByVersion(ctx, h.version, h.interval, h.tags...)
+	// kim: TODO: delete
+	// perfResults, err := h.sc.FindPerformanceResultsByVersion(ctx, h.version, h.interval, h.tags...)
+	// perfResults, err := h.sc.FindPerformanceResultsByVersion(ctx, h.version, h.tags...)
+	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
+		Version: h.version,
+		Tags:    h.tags,
+	})
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by version '%s'", h.version)
 		grip.Error(message.WrapError(err, message.Fields{
@@ -307,7 +339,7 @@ func (h *perfGetChildrenHandler) Parse(_ context.Context, r *http.Request) error
 	h.tags = vals["tags"]
 	var err error
 	h.maxDepth, err = strconv.Atoi(vals.Get("max_depth"))
-	return errors.Wrap(err, "failed to parse request")
+	return errors.Wrap(err, "invalid max depth")
 }
 
 // Run calls the data FindPerformanceResultWithChildren function and returns

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
@@ -118,9 +117,8 @@ func (h *perfRemoveByIdHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /perf/task_id/{task_id}
 
 type perfGetByTaskIdHandler struct {
-	taskId string
-	tags   []string
-	sc     data.Connector
+	opts data.PerformanceOptions
+	sc   data.Connector
 }
 
 func makeGetPerfByTaskId(sc data.Connector) gimlet.RouteHandler {
@@ -138,25 +136,22 @@ func (h *perfGetByTaskIdHandler) Factory() gimlet.RouteHandler {
 
 // Parse fetches the task_id from the http request.
 func (h *perfGetByTaskIdHandler) Parse(_ context.Context, r *http.Request) error {
-	h.taskId = gimlet.GetVars(r)["task_id"]
-	h.tags = r.URL.Query()["tags"]
+	h.opts.TaskID = gimlet.GetVars(r)["task_id"]
+	h.opts.Tags = r.URL.Query()["tags"]
 	return nil
 }
 
 // Run calls the data FindPerformanceResults function and returns the
 // PerformanceResults from the provider.
 func (h *perfGetByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
-		TaskID: h.taskId,
-		Tags:   h.tags,
-	})
+	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
-		err = errors.Wrapf(err, "problem getting performance results by task id '%s'", h.taskId)
+		err = errors.Wrapf(err, "problem getting performance results by task id '%s'", h.opts.TaskID)
 		grip.Error(message.WrapError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/task_id/{task_id}",
-			"task_id": h.taskId,
+			"task_id": h.opts.TaskID,
 		}))
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -168,13 +163,8 @@ func (h *perfGetByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /perf/task_name/{task_name}
 
 type perfGetByTaskNameHandler struct {
-	taskName string
-	project  string
-	interval model.TimeRange
-	tags     []string
-	limit    int
-	variant  string
-	sc       data.Connector
+	opts data.PerformanceOptions
+	sc   data.Connector
 }
 
 func makeGetPerfByTaskName(sc data.Connector) gimlet.RouteHandler {
@@ -192,24 +182,24 @@ func (h *perfGetByTaskNameHandler) Factory() gimlet.RouteHandler {
 
 // Parse fetches the task_name from the http request.
 func (h *perfGetByTaskNameHandler) Parse(_ context.Context, r *http.Request) error {
-	h.taskName = gimlet.GetVars(r)["task_name"]
+	h.opts.TaskName = gimlet.GetVars(r)["task_name"]
 	vals := r.URL.Query()
-	h.project = vals.Get("project")
-	h.variant = vals.Get("variant")
-	h.tags = vals["tags"]
+	h.opts.Project = vals.Get("project")
+	h.opts.Variant = vals.Get("variant")
+	h.opts.Tags = vals["tags"]
 	catcher := grip.NewBasicCatcher()
 	var err error
-	h.interval, err = parseTimeRange(timeRangeFormatYearMonthDay, vals.Get(perfStartAt), vals.Get(perfEndAt))
+	h.opts.Interval, err = parseTimeRange(timeRangeFormatYearMonthDay, vals.Get(perfStartAt), vals.Get(perfEndAt))
 	catcher.Add(errors.Wrap(err, "invalid time range"))
-	catcher.NewWhen(h.interval.IsZero(), "time interval must have start and end")
-	catcher.NewWhen(!h.interval.IsValid(), "time interval must have a start time before its end time")
+	catcher.NewWhen(h.opts.Interval.IsZero(), "time interval must have start and end")
+	catcher.NewWhen(!h.opts.Interval.IsValid(), "time interval must have a start time before its end time")
 	limit := vals.Get("limit")
 	if limit != "" {
-		h.limit, err = strconv.Atoi(limit)
+		h.opts.Limit, err = strconv.Atoi(limit)
 		catcher.Add(errors.Wrap(err, "invalid limit"))
-		catcher.NewWhen(h.limit < 0, "cannot have negative limit")
+		catcher.NewWhen(h.opts.Limit < 0, "cannot have negative limit")
 	} else {
-		h.limit = 0
+		h.opts.Limit = 0
 	}
 	return catcher.Resolve()
 }
@@ -217,21 +207,14 @@ func (h *perfGetByTaskNameHandler) Parse(_ context.Context, r *http.Request) err
 // Run calls the data FindPerformanceResults function and returns the
 // PerformanceResults from the provider.
 func (h *perfGetByTaskNameHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
-		Project:  h.project,
-		Variant:  h.variant,
-		TaskName: h.taskName,
-		Tags:     h.tags,
-		Interval: h.interval,
-		Limit:    h.limit,
-	})
+	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
-		err = errors.Wrapf(err, "problem getting performance results by task_name '%s'", h.taskName)
+		err = errors.Wrapf(err, "problem getting performance results by task_name '%s'", h.opts.TaskName)
 		grip.Error(message.WrapError(err, message.Fields{
 			"request":   gimlet.GetRequestID(ctx),
 			"method":    "GET",
 			"route":     "/perf/task_name/{task_name}",
-			"task_name": h.taskName,
+			"task_name": h.opts.TaskName,
 		}))
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -243,9 +226,8 @@ func (h *perfGetByTaskNameHandler) Run(ctx context.Context) gimlet.Responder {
 // GET /perf/version/{version}
 
 type perfGetByVersionHandler struct {
-	version string
-	tags    []string
-	sc      data.Connector
+	opts data.PerformanceOptions
+	sc   data.Connector
 }
 
 func makeGetPerfByVersion(sc data.Connector) gimlet.RouteHandler {
@@ -263,25 +245,22 @@ func (h *perfGetByVersionHandler) Factory() gimlet.RouteHandler {
 
 // Parse fetches the version from the http request.
 func (h *perfGetByVersionHandler) Parse(_ context.Context, r *http.Request) error {
-	h.version = gimlet.GetVars(r)["version"]
-	h.tags = r.URL.Query()["tags"]
+	h.opts.Version = gimlet.GetVars(r)["version"]
+	h.opts.Tags = r.URL.Query()["tags"]
 	return nil
 }
 
 // Run calls the data FindPerformanceResults function returns the
 // PerformanceResult from the provider.
 func (h *perfGetByVersionHandler) Run(ctx context.Context) gimlet.Responder {
-	perfResults, err := h.sc.FindPerformanceResults(ctx, data.PerformanceOptions{
-		Version: h.version,
-		Tags:    h.tags,
-	})
+	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
-		err = errors.Wrapf(err, "problem getting performance results by version '%s'", h.version)
+		err = errors.Wrapf(err, "problem getting performance results by version '%s'", h.opts.Version)
 		grip.Error(message.WrapError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/version/{version}",
-			"version": h.version,
+			"version": h.opts.Version,
 		}))
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/rest/perf_routes_test.go
+++ b/rest/perf_routes_test.go
@@ -170,8 +170,8 @@ func (s *PerfHandlerSuite) TestPerfRemoveByIdHandler() {
 
 func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerFound() {
 	rh := s.rh["task_id"]
-	rh.(*perfGetByTaskIdHandler).taskId = "123"
-	rh.(*perfGetByTaskIdHandler).tags = []string{"d"}
+	rh.(*perfGetByTaskIdHandler).opts.TaskID = "123"
+	rh.(*perfGetByTaskIdHandler).opts.Tags = []string{"d"}
 	expected := []datamodel.APIPerformanceResult{s.apiResults["jkl"]}
 
 	resp := rh.Run(context.TODO())
@@ -183,7 +183,7 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerFound() {
 
 func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerNotFound() {
 	rh := s.rh["task_id"]
-	rh.(*perfGetByTaskIdHandler).taskId = "555"
+	rh.(*perfGetByTaskIdHandler).opts.TaskID = "555"
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)
@@ -192,12 +192,12 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerNotFound() {
 
 func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerFound() {
 	rh := s.rh["task_name"]
-	rh.(*perfGetByTaskNameHandler).taskName = "taskname0"
-	rh.(*perfGetByTaskNameHandler).interval = model.TimeRange{
+	rh.(*perfGetByTaskNameHandler).opts.TaskName = "taskname0"
+	rh.(*perfGetByTaskNameHandler).opts.Interval = model.TimeRange{
 		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
 		EndAt:   time.Now(),
 	}
-	rh.(*perfGetByTaskNameHandler).tags = []string{"b"}
+	rh.(*perfGetByTaskNameHandler).opts.Tags = []string{"b"}
 	expected := []datamodel.APIPerformanceResult{
 		s.apiResults["jkl"],
 		s.apiResults["ghi"],
@@ -208,11 +208,11 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerFound() {
 	s.Require().NotNil(resp.Data())
 	s.Equal(expected, resp.Data())
 
-	rh.(*perfGetByTaskNameHandler).interval = model.TimeRange{
+	rh.(*perfGetByTaskNameHandler).opts.Interval = model.TimeRange{
 		StartAt: time.Time{},
 		EndAt:   time.Now(),
 	}
-	rh.(*perfGetByTaskNameHandler).tags = []string{}
+	rh.(*perfGetByTaskNameHandler).opts.Tags = []string{}
 	expected = []datamodel.APIPerformanceResult{
 		s.apiResults["jkl"],
 		s.apiResults["ghi"],
@@ -225,7 +225,7 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerFound() {
 	s.Require().NotNil(resp.Data())
 	s.Equal(expected, resp.Data())
 
-	rh.(*perfGetByTaskNameHandler).limit = 3
+	rh.(*perfGetByTaskNameHandler).opts.Limit = 3
 	expected = []datamodel.APIPerformanceResult{
 		s.apiResults["jkl"],
 		s.apiResults["ghi"],
@@ -241,8 +241,8 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerFound() {
 
 func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerNotFound() {
 	rh := s.rh["task_name"]
-	rh.(*perfGetByTaskNameHandler).taskName = "taskname2"
-	rh.(*perfGetByTaskNameHandler).interval = model.TimeRange{
+	rh.(*perfGetByTaskNameHandler).opts.TaskName = "taskname2"
+	rh.(*perfGetByTaskNameHandler).opts.Interval = model.TimeRange{
 		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
 		EndAt:   time.Now(),
 	}
@@ -254,8 +254,8 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerNotFound() {
 
 func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerFound() {
 	rh := s.rh["version"]
-	rh.(*perfGetByVersionHandler).version = "1"
-	rh.(*perfGetByVersionHandler).tags = []string{"d"}
+	rh.(*perfGetByVersionHandler).opts.Version = "1"
+	rh.(*perfGetByVersionHandler).opts.Tags = []string{"d"}
 	expected := []datamodel.APIPerformanceResult{s.apiResults["jkl"]}
 
 	resp := rh.Run(context.TODO())
@@ -267,7 +267,7 @@ func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerFound() {
 
 func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerNotFound() {
 	rh := s.rh["version"]
-	rh.(*perfGetByVersionHandler).version = "2"
+	rh.(*perfGetByVersionHandler).opts.Version = "2"
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)
@@ -385,11 +385,11 @@ func (s *PerfHandlerSuite) testParseDefaults(handler, urlString, query string, l
 func getPerfTags(rh gimlet.RouteHandler, handler string) []string {
 	switch handler {
 	case "task_id":
-		return rh.(*perfGetByTaskIdHandler).tags
+		return rh.(*perfGetByTaskIdHandler).opts.Tags
 	case "task_name":
-		return rh.(*perfGetByTaskNameHandler).tags
+		return rh.(*perfGetByTaskNameHandler).opts.Tags
 	case "version":
-		return rh.(*perfGetByVersionHandler).tags
+		return rh.(*perfGetByVersionHandler).opts.Tags
 	default:
 		return []string{}
 	}
@@ -398,7 +398,7 @@ func getPerfTags(rh gimlet.RouteHandler, handler string) []string {
 func getPerfLimit(rh gimlet.RouteHandler, handler string) int {
 	switch handler {
 	case "task_name":
-		return rh.(*perfGetByTaskNameHandler).limit
+		return rh.(*perfGetByTaskNameHandler).opts.Limit
 	default:
 		return 0
 	}

--- a/rest/perf_routes_test.go
+++ b/rest/perf_routes_test.go
@@ -170,10 +170,11 @@ func (s *PerfHandlerSuite) TestPerfRemoveByIdHandler() {
 func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerFound() {
 	rh := s.rh["task_id"]
 	rh.(*perfGetByTaskIdHandler).taskId = "123"
-	rh.(*perfGetByTaskIdHandler).interval = model.TimeRange{
-		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
-		EndAt:   time.Now(),
-	}
+	// kim: TODO: delete
+	// rh.(*perfGetByTaskIdHandler).interval = model.TimeRange{
+	//     StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
+	//     EndAt:   time.Now(),
+	// }
 	rh.(*perfGetByTaskIdHandler).tags = []string{"d"}
 	expected := []datamodel.APIPerformanceResult{s.apiResults["jkl"]}
 
@@ -187,10 +188,11 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerFound() {
 func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerNotFound() {
 	rh := s.rh["task_id"]
 	rh.(*perfGetByTaskIdHandler).taskId = "555"
-	rh.(*perfGetByTaskIdHandler).interval = model.TimeRange{
-		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
-		EndAt:   time.Now(),
-	}
+	// kim: TODO: delete
+	// rh.(*perfGetByTaskIdHandler).interval = model.TimeRange{
+	//     StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
+	//     EndAt:   time.Now(),
+	// }
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)
@@ -262,10 +264,11 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskNameHandlerNotFound() {
 func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerFound() {
 	rh := s.rh["version"]
 	rh.(*perfGetByVersionHandler).version = "1"
-	rh.(*perfGetByVersionHandler).interval = model.TimeRange{
-		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
-		EndAt:   time.Now(),
-	}
+	// kim: TODO: delete
+	// rh.(*perfGetByVersionHandler).interval = model.TimeRange{
+	//     StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
+	//     EndAt:   time.Now(),
+	// }
 	rh.(*perfGetByVersionHandler).tags = []string{"d"}
 	expected := []datamodel.APIPerformanceResult{s.apiResults["jkl"]}
 
@@ -279,10 +282,11 @@ func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerFound() {
 func (s *PerfHandlerSuite) TestPerfGetByVersionHandlerNotFound() {
 	rh := s.rh["version"]
 	rh.(*perfGetByVersionHandler).version = "2"
-	rh.(*perfGetByVersionHandler).interval = model.TimeRange{
-		StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
-		EndAt:   time.Now(),
-	}
+	// kim: TODO: delete
+	// rh.(*perfGetByVersionHandler).interval = model.TimeRange{
+	//     StartAt: time.Date(2018, time.November, 5, 0, 0, 0, 0, time.UTC),
+	//     EndAt:   time.Now(),
+	// }
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)
@@ -354,50 +358,42 @@ func (s *PerfHandlerSuite) TestParse() {
 			urlString: "http://example.com/perf/version/verison0",
 		},
 	} {
-		s.testParseValid(test.handler, test.urlString, test.limit)
-		s.testParseInvalid(test.handler, test.urlString)
-		s.testParseDefaults(test.handler, test.urlString, test.limit)
+		s.T().Run(test.handler, func(t *testing.T) {
+			s.testParseValid(test.handler, test.urlString, test.limit)
+			s.testParseDefaults(test.handler, test.urlString, test.limit)
+		})
 	}
 }
 
 func (s *PerfHandlerSuite) testParseValid(handler, urlString string, limit bool) {
 	ctx := context.Background()
-	urlString += "?started_after=2012-11-01T22:08:00%2B00:00"
-	urlString += "&finished_before=2013-11-01T22:08:00%2B00:00"
-	urlString += "&tags=hello&tags=world"
+	// kim: TODO: delete
+	// urlString += "?started_after=2012-11-01T22:08:00%2B00:00"
+	// urlString += "&finished_before=2013-11-01T22:08:00%2B00:00"
+	// urlString += "&tags=hello&tags=world"
+	urlString += "?tags=hello&tags=world"
 	urlString += "&limit=5"
 	req := &http.Request{Method: "GET"}
-	req.URL, _ = url.Parse(urlString)
-	expectedInterval := model.TimeRange{
-		StartAt: time.Date(2012, time.November, 1, 22, 8, 0, 0, time.UTC),
-		EndAt:   time.Date(2013, time.November, 1, 22, 8, 0, 0, time.UTC),
-	}
+	url, err := url.Parse(urlString)
+	s.Require().NoError(err)
+	req.URL = url
+	// kim: TODO: delete
+	// expectedInterval := model.TimeRange{
+	//     StartAt: time.Date(2012, time.November, 1, 22, 8, 0, 0, time.UTC),
+	//     EndAt:   time.Date(2013, time.November, 1, 22, 8, 0, 0, time.UTC),
+	// }
 	expectedTags := []string{"hello", "world"}
 	rh := s.rh[handler]
 
-	err := rh.Parse(ctx, req)
-	s.Equal(expectedInterval, getPerfInterval(rh, handler))
+	// err := rh.Parse(ctx, req)
+	s.NoError(rh.Parse(ctx, req))
+	// kim: TODO: delete
+	// s.Equal(expectedInterval, getPerfInterval(rh, handler))
 	s.Equal(expectedTags, getPerfTags(rh, handler))
 	if limit {
 		s.Equal(5, getPerfLimit(rh, handler))
 	}
-	s.NoError(err)
-}
-
-func (s *PerfHandlerSuite) testParseInvalid(handler, urlString string) {
-	ctx := context.Background()
-	invalidStart := "?started_after=hello"
-	invalidEnd := "?finished_before=world"
-	req := &http.Request{Method: "GET"}
-	rh := s.rh[handler]
-
-	req.URL, _ = url.Parse(urlString + invalidStart)
-	err := rh.Parse(ctx, req)
-	s.Error(err)
-
-	req.URL, _ = url.Parse(urlString + invalidEnd)
-	err = rh.Parse(ctx, req)
-	s.Error(err)
+	// s.NoError(err)
 }
 
 func (s *PerfHandlerSuite) testParseDefaults(handler, urlString string, limit bool) {
@@ -407,9 +403,10 @@ func (s *PerfHandlerSuite) testParseDefaults(handler, urlString string, limit bo
 	rh := s.rh[handler]
 
 	err := rh.Parse(ctx, req)
-	interval := getPerfInterval(rh, handler)
-	s.Equal(time.Time{}, interval.StartAt)
-	s.True(time.Since(interval.EndAt) <= time.Second)
+	// kim: TODO: delete
+	// interval := getPerfInterval(rh, handler)
+	// s.Equal(time.Time{}, interval.StartAt)
+	// s.True(time.Since(interval.EndAt) <= time.Second)
 	s.Nil(getPerfTags(rh, handler))
 	if limit {
 		s.Zero(getPerfLimit(rh, handler))
@@ -417,18 +414,19 @@ func (s *PerfHandlerSuite) testParseDefaults(handler, urlString string, limit bo
 	s.NoError(err)
 }
 
-func getPerfInterval(rh gimlet.RouteHandler, handler string) model.TimeRange {
-	switch handler {
-	case "task_id":
-		return rh.(*perfGetByTaskIdHandler).interval
-	case "task_name":
-		return rh.(*perfGetByTaskNameHandler).interval
-	case "version":
-		return rh.(*perfGetByVersionHandler).interval
-	default:
-		return model.TimeRange{}
-	}
-}
+// kim: TODO: delete
+// func getPerfInterval(rh gimlet.RouteHandler, handler string) model.TimeRange {
+//     switch handler {
+//     case "task_id":
+//         return rh.(*perfGetByTaskIdHandler).interval
+//     case "task_name":
+//         return rh.(*perfGetByTaskNameHandler).interval
+//     case "version":
+//         return rh.(*perfGetByVersionHandler).interval
+//     default:
+//         return model.TimeRange{}
+//     }
+// }
 
 func getPerfTags(rh gimlet.RouteHandler, handler string) []string {
 	switch handler {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14175

* Remove interval from perf version/task ID routes.
* Use YYYY-MM-DD timestamp format for perf task name route.
* Use options struct for perf data connector and consolidate find methods.
* I'll update the perf/buildlogger REST docs once this is merged.