### PR TITLE
EVG-14420: set job ID for historical test data job

### DIFF
--- a/units/historical_test_data.go
+++ b/units/historical_test_data.go
@@ -44,6 +44,7 @@ func NewHistoricalTestDataJob(env cedar.Environment, info model.TestResultsInfo,
 		RequestType: info.RequestType,
 		Date:        tr.TestEndTime.UTC(),
 	}
+	j.SetID(strings.Join([]string{historicalTestDataJobName, j.Info.Project, j.Info.Variant, j.Info.TaskName, j.Info.TestName, j.Info.RequestType, j.Info.Date.String()}, "."))
 
 	return j
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14420

Set the unique job ID. I could have just used `j.Info.ID()`, but I thought it would be more human-friendly to have a searchable job ID rather than a hash.