### PR TITLE
EVG-14612: Add indexes in the perf_results collection

### DIFF
--- a/model/indexes.go
+++ b/model/indexes.go
@@ -41,9 +41,31 @@ func GetRequiredIndexes() []SystemIndexes {
 		},
 		{
 			Keys: bson.D{
-				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1},
-				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskIDKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTagsKey), Value: 1},
+				{Key: perfCreatedAtKey, Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskIDKey), Value: 1},
+				{Key: perfCreatedAtKey, Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTagsKey), Value: 1},
+				{Key: perfCreatedAtKey, Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1},
+				{Key: perfCreatedAtKey, Value: 1},
 			},
 			Collection: perfResultCollection,
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14612

When fetching perf results by `task_id` or `version` we allow filtering by tags and sort by the `created_at` date. So far it hasn't been an issue for fetching by `task_id` since there typically are not many results in a single task id / execution run and nobody was using the `version` route until now.