### PR TITLE
EVG-14672: store test results more efficiently

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -180,6 +180,8 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 		return errors.Wrap(err, "getting uploaded test results")
 	}
 	if r != nil {
+		defer r.Close()
+
 		data, err := ioutil.ReadAll(r)
 		if err != nil {
 			return errors.Wrap(err, "reading uploaded test results")
@@ -192,6 +194,9 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 	allResults.Results = append(allResults.Results, results...)
 
 	data, err := bson.Marshal(&allResults)
+	if err != nil {
+		return errors.Wrap(err, "marshalling test results")
+	}
 	if err = bucket.Put(ctx, testResultsCollection, bytes.NewReader(data)); err != nil {
 		return errors.Wrap(err, "uploading test results")
 	}
@@ -237,6 +242,7 @@ func (t *TestResults) Download(ctx context.Context) ([]TestResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getting test results")
 	}
+	defer r.Close()
 
 	data, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -227,8 +227,6 @@ func (t *TestResults) Download(ctx context.Context) ([]TestResult, error) {
 	var results testResultsDoc
 	r, err := bucket.Get(ctx, testResultsCollection)
 	if pail.IsKeyNotFoundError(err) {
-		// TODO (EVG-14672): Once the migration is complete, remove
-		// this code and return nil, nil.
 		iter := NewTestResultsIterator(bucket)
 		for iter.Next(ctx) {
 			results.Results = append(results.Results, iter.Item())

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -167,19 +167,18 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 	if err != nil && !pail.IsKeyNotFoundError(err) {
 		return errors.Wrap(err, "getting uploaded test results")
 	}
-	if !pail.IsKeyNotFoundError(err) {
+	if err == nil {
 		catcher := grip.NewBasicCatcher()
 
 		data, err := ioutil.ReadAll(r)
+		catcher.Add(r.Close())
 		if err != nil {
 			catcher.Wrap(err, "reading uploaded test results")
-			catcher.Add(r.Close())
 			return catcher.Resolve()
 		}
 
 		if err = bson.Unmarshal(data, &allResults); err != nil {
 			catcher.Wrap(err, "unmarshalling uploaded test results")
-			catcher.Add(r.Close())
 			return catcher.Resolve()
 		}
 	}

--- a/model/test_results_iterator.go
+++ b/model/test_results_iterator.go
@@ -13,6 +13,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// TODO (EVG-14672): Remove this code and the relevant tests once the migration
+// is complete.
+
 const testResultsIteratorBatchSize = 100
 
 // TestResultsIterator is an interface that enables iterating over test results.

--- a/model/test_results_iterator.go
+++ b/model/test_results_iterator.go
@@ -13,9 +13,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TODO (EVG-14672): Remove this code and the relevant tests once the migration
-// is complete.
-
 const testResultsIteratorBatchSize = 100
 
 // TestResultsIterator is an interface that enables iterating over test results.

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -262,6 +262,9 @@ func TestTestResultsAppend(t *testing.T) {
 		var savedResults testResultsDoc
 		r, err := testBucket.Get(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection))
 		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, r.Close())
+		}()
 		data, err := ioutil.ReadAll(r)
 		require.NoError(t, err)
 		require.NoError(t, bson.Unmarshal(data, &savedResults))

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -600,6 +600,7 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
 	testBucket2, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr2.ID})
+	require.NoError(t, err)
 
 	savedResults2 := testResultsDoc{}
 	for i := 0; i < 10; i++ {

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -218,6 +218,7 @@ func TestTestResultsAppend(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
+		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()
 
 	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir})
@@ -283,20 +284,12 @@ func TestTestResultsDownload(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
+		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()
 
 	tr := getTestResults()
 	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr.ID})
 	require.NoError(t, err)
-
-	savedResults := testResultsDoc{}
-	savedResults.Results = make([]TestResult, 10)
-	for i := 0; i < 10; i++ {
-		savedResults.Results[i] = getTestResult()
-	}
-	data, err := bson.Marshal(&savedResults)
-	require.NoError(t, err)
-	require.NoError(t, testBucket.Put(ctx, testResultsCollection, bytes.NewReader(data)))
 
 	t.Run("NoEnv", func(t *testing.T) {
 		tr.populated = true
@@ -327,11 +320,48 @@ func TestTestResultsDownload(t *testing.T) {
 	require.NoError(t, conf.Find())
 	conf.Bucket.TestResultsBucket = tmpDir
 	require.NoError(t, conf.Save())
-	t.Run("DownloadFromBucket", func(t *testing.T) {
+	t.Run("DownloadFromBucketVersion1", func(t *testing.T) {
+		savedResults := testResultsDoc{}
+		savedResults.Results = make([]TestResult, 10)
+		for i := 0; i < 10; i++ {
+			savedResults.Results[i] = getTestResult()
+		}
+		data, err := bson.Marshal(&savedResults)
+		require.NoError(t, err)
+		require.NoError(t, testBucket.Put(ctx, testResultsCollection, bytes.NewReader(data)))
+
 		tr.Setup(env)
 		results, err := tr.Download(ctx)
 		require.NoError(t, err)
 		assert.Equal(t, savedResults.Results, results)
+	})
+	t.Run("DownloadFromBucketVersion0", func(t *testing.T) {
+		tr0 := getTestResults()
+		tr0.populated = true
+		tr0.Artifact.Version = 0
+		testBucket0, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr0.ID})
+		require.NoError(t, err)
+		resultMap := map[string]TestResult{}
+		for i := 0; i < 10; i++ {
+			result := getTestResult()
+			resultMap[result.TestName] = result
+			var data []byte
+			data, err = bson.Marshal(result)
+			require.NoError(t, err)
+			require.NoError(t, testBucket0.Put(ctx, result.TestName, bytes.NewReader(data)))
+		}
+
+		tr0.Setup(env)
+		results, err := tr0.Download(ctx)
+		require.NoError(t, err)
+
+		require.Len(t, results, len(resultMap))
+		for _, result := range results {
+			expected, ok := resultMap[result.TestName]
+			require.True(t, ok)
+			assert.Equal(t, expected, result)
+			delete(resultMap, result.TestName)
+		}
 	})
 }
 
@@ -539,6 +569,7 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
+		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()
 	conf := &CedarConfig{
 		Bucket:    BucketConfig{TestResultsBucket: tmpDir},
@@ -555,15 +586,13 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	testBucket1, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr1.ID})
 	require.NoError(t, err)
 
-	resultMap := map[string]TestResult{}
+	savedResults1 := testResultsDoc{}
 	for i := 0; i < 10; i++ {
-		result := getTestResult()
-		resultMap[result.TestName] = result
-		var data []byte
-		data, err = bson.Marshal(result)
-		require.NoError(t, err)
-		require.NoError(t, testBucket1.Put(ctx, result.TestName, bytes.NewReader(data)))
+		savedResults1.Results = append(savedResults1.Results, getTestResult())
 	}
+	data, err := bson.Marshal(&savedResults1)
+	require.NoError(t, err)
+	require.NoError(t, testBucket1.Put(ctx, testResultsCollection, bytes.NewReader(data)))
 
 	tr2 := getTestResults()
 	tr2.Info.DisplayTaskID = "display"
@@ -571,27 +600,22 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
 	testBucket2, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr2.ID})
-	require.NoError(t, err)
 
+	savedResults2 := testResultsDoc{}
 	for i := 0; i < 10; i++ {
-		result := getTestResult()
-		resultMap[result.TestName] = result
-		var data []byte
-		data, err = bson.Marshal(result)
-		require.NoError(t, err)
-		require.NoError(t, testBucket2.Put(ctx, result.TestName, bytes.NewReader(data)))
+		savedResults2.Results = append(savedResults2.Results, getTestResult())
 	}
+	data, err = bson.Marshal(&savedResults2)
+	require.NoError(t, err)
+	require.NoError(t, testBucket2.Put(ctx, testResultsCollection, bytes.NewReader(data)))
 
 	opts := TestResultsFindOptions{DisplayTaskID: "display"}
 	results, err := FindAndDownloadTestResults(ctx, env, opts)
 	require.NoError(t, err)
 
-	require.Len(t, results, 20)
-	for _, result := range results {
-		expected, ok := resultMap[result.TestName]
-		require.True(t, ok)
-		assert.Equal(t, expected, result)
-		delete(resultMap, result.TestName)
+	require.Len(t, results, len(savedResults1.Results)+len(savedResults2.Results))
+	for _, result := range append(savedResults1.Results, savedResults2.Results...) {
+		assert.Contains(t, results, result)
 	}
 }
 
@@ -612,8 +636,9 @@ func getTestResults() *TestResults {
 		CreatedAt:   time.Now().Add(-time.Hour).UTC().Round(time.Millisecond),
 		CompletedAt: time.Now().UTC().Round(time.Millisecond),
 		Artifact: TestResultsArtifactInfo{
-			Type:   PailLocal,
-			Prefix: info.ID(),
+			Type:    PailLocal,
+			Prefix:  info.ID(),
+			Version: 1,
 		},
 	}
 }

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -3,17 +3,13 @@ package data
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	dbModel "github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/rest/model"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/anser/db"
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 /////////////////////////////
@@ -21,7 +17,7 @@ import (
 /////////////////////////////
 
 func (dbc *DBConnector) FindTestResults(ctx context.Context, opts TestResultsOptions) ([]model.APITestResult, error) {
-	it, err := dbModel.FindAndDownloadTestResults(ctx, dbc.env, convertToDBTestResultsOptions(opts))
+	results, err := dbModel.FindAndDownloadTestResults(ctx, dbc.env, convertToDBTestResultsOptions(opts))
 	if db.ResultsNotFound(err) {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -34,11 +30,11 @@ func (dbc *DBConnector) FindTestResults(ctx context.Context, opts TestResultsOpt
 		}
 	}
 
-	return importTestResults(ctx, it)
+	return importTestResults(ctx, results)
 }
 
 func (dbc *DBConnector) FindTestResultByTestName(ctx context.Context, opts TestResultsOptions) (*model.APITestResult, error) {
-	results, err := dbModel.FindTestResults(ctx, dbc.env, convertToDBTestResultsOptions(opts))
+	results, err := dbModel.FindAndDownloadTestResults(ctx, dbc.env, convertToDBTestResultsOptions(opts))
 	if db.ResultsNotFound(err) {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -51,15 +47,7 @@ func (dbc *DBConnector) FindTestResultByTestName(ctx context.Context, opts TestR
 		}
 	}
 
-	bucket, err := results[0].GetBucket(ctx)
-	if err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "getting bucket").Error(),
-		}
-	}
-
-	return getAPITestResultFromBucket(ctx, bucket, opts.TestName)
+	return getAPITestResultByTestName(ctx, results, opts.TestName)
 }
 
 ///////////////////////////////
@@ -98,18 +86,18 @@ func (mc *MockConnector) findTestResultsByTaskID(ctx context.Context, opts TestR
 		}
 	}
 
-	bucket, err := mc.getBucket(ctx, testResults.Artifact.Prefix)
+	results, err := testResults.Download(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return importTestResults(ctx, dbModel.NewTestResultsIterator(bucket))
+	return importTestResults(ctx, results)
 }
 
 func (mc *MockConnector) findTestResultsByDisplayTaskID(ctx context.Context, opts TestResultsOptions) ([]model.APITestResult, error) {
 	var (
 		testResults     []*dbModel.TestResults
-		its             []dbModel.TestResultsIterator
+		combinedResults []dbModel.TestResult
 		latestExecution int
 	)
 
@@ -125,24 +113,24 @@ func (mc *MockConnector) findTestResultsByDisplayTaskID(ctx context.Context, opt
 		}
 	}
 
-	for _, result := range testResults {
-		if !opts.EmptyExecution || result.Info.Execution == latestExecution {
-			bucket, err := mc.getBucket(ctx, result.Artifact.Prefix)
-			if err != nil {
-				return nil, err
-			}
-			its = append(its, dbModel.NewTestResultsIterator(bucket))
-		}
-	}
-
-	if testResults == nil || its == nil {
+	if testResults == nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    "test results not found",
 		}
 	}
 
-	return importTestResults(ctx, dbModel.NewMultiTestResultsIterator(its...))
+	for i := range testResults {
+		if !opts.EmptyExecution || testResults[i].Info.Execution == latestExecution {
+			results, err := testResults[i].Download(ctx)
+			if err != nil {
+				return nil, err
+			}
+			combinedResults = append(combinedResults, results...)
+		}
+	}
+
+	return importTestResults(ctx, combinedResults)
 }
 
 func (mc *MockConnector) FindTestResultByTestName(ctx context.Context, opts TestResultsOptions) (*model.APITestResult, error) {
@@ -169,24 +157,24 @@ func (mc *MockConnector) FindTestResultByTestName(ctx context.Context, opts Test
 		}
 	}
 
-	bucket, err := mc.getBucket(ctx, testResults.Artifact.Prefix)
+	results, err := testResults.Download(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return getAPITestResultFromBucket(ctx, bucket, opts.TestName)
+	return getAPITestResultByTestName(ctx, results, opts.TestName)
 }
 
 ///////////////////
 // Helper Functions
 ///////////////////
 
-func importTestResults(ctx context.Context, it dbModel.TestResultsIterator) ([]model.APITestResult, error) {
+func importTestResults(ctx context.Context, results []dbModel.TestResult) ([]model.APITestResult, error) {
 	apiResults := []model.APITestResult{}
 
-	for it.Next(ctx) {
+	for _, result := range results {
 		apiResult := model.APITestResult{}
-		err := apiResult.Import(it.Item())
+		err := apiResult.Import(result)
 		if err != nil {
 			return nil, gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
@@ -195,58 +183,35 @@ func importTestResults(ctx context.Context, it dbModel.TestResultsIterator) ([]m
 		}
 		apiResults = append(apiResults, apiResult)
 	}
-	if err := it.Err(); err != nil {
+
+	if err := ctx.Err(); err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "iterating through test results").Error(),
+			Message:    err.Error(),
 		}
 	}
 
 	return apiResults, nil
 }
 
-func getAPITestResultFromBucket(ctx context.Context, bucket pail.Bucket, testName string) (*model.APITestResult, error) {
-	tr, err := bucket.Get(ctx, testName)
-	if pail.IsKeyNotFoundError(err) {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("test result with test_name '%s' not found", testName),
-		}
-	} else if err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "retrieving test result with test_name '%s'", testName).Error(),
-		}
-	}
-	defer func() {
-		grip.Warning(errors.Wrap(tr.Close(), "closing file"))
-	}()
-
-	data, err := ioutil.ReadAll(tr)
-	if err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "reading data").Error(),
+func getAPITestResultByTestName(ctx context.Context, results []dbModel.TestResult, testName string) (*model.APITestResult, error) {
+	for _, result := range results {
+		if testName == result.TestName {
+			apiResult := &model.APITestResult{}
+			if err := apiResult.Import(result); err != nil {
+				return nil, gimlet.ErrorResponse{
+					StatusCode: http.StatusInternalServerError,
+					Message:    errors.Wrap(err, "converting test result to output format").Error(),
+				}
+			}
+			return apiResult, ctx.Err()
 		}
 	}
 
-	var result dbModel.TestResult
-	if err := bson.Unmarshal(data, &result); err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "unmarshalling test result").Error(),
-		}
+	return nil, gimlet.ErrorResponse{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("test result with test_name '%s' not found", testName),
 	}
-
-	apiResult := &model.APITestResult{}
-	if err := apiResult.Import(result); err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "converting test result to output format").Error(),
-		}
-	}
-
-	return apiResult, ctx.Err()
 }
 
 func convertToDBTestResultsOptions(opts TestResultsOptions) dbModel.TestResultsFindOptions {

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -1,20 +1,16 @@
 package data
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cedar"
 	dbModel "github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/rest/model"
-	"github.com/evergreen-ci/pail"
 	"github.com/stretchr/testify/suite"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 type testResultsConnectorSuite struct {
@@ -111,13 +107,6 @@ func (s *testResultsConnectorSuite) setup() {
 	for _, testResultsInfo := range testResultInfos {
 		testResults := dbModel.CreateTestResults(testResultsInfo, dbModel.PailLocal)
 
-		opts := pail.LocalOptions{
-			Path:   s.tempDir,
-			Prefix: testResults.Artifact.Prefix,
-		}
-		bucket, err := pail.NewLocalBucket(opts)
-		s.Require().NoError(err)
-
 		testResults.Setup(s.env)
 		err = testResults.SaveNew(s.ctx)
 
@@ -126,24 +115,19 @@ func (s *testResultsConnectorSuite) setup() {
 
 		for i := 0; i < 3; i++ {
 			result := dbModel.TestResult{
-				TaskID:         testResults.Info.TaskID,
-				Execution:      testResults.Info.Execution,
-				TestName:       fmt.Sprintf("test%d", i),
-				Trial:          0,
-				Status:         "teststatus",
-				LineNum:        0,
-				TaskCreateTime: time.Now().Add(-3 * time.Second),
-				TestStartTime:  time.Now().Add(-2 * time.Second),
-				TestEndTime:    time.Now().Add(-1 * time.Second),
+				TaskID:    testResults.Info.TaskID,
+				Execution: testResults.Info.Execution,
+				TestName:  fmt.Sprintf("test%d", i),
+				Trial:     0,
+				Status:    "teststatus",
+				LineNum:   0,
 			}
 
 			apiResult := model.APITestResult{}
 			s.Require().NoError(apiResult.Import(result))
 			s.apiResults[fmt.Sprintf("%s_%d_%s", result.TaskID, result.Execution, result.TestName)] = apiResult
 
-			data, err := bson.Marshal(result)
-			s.Require().NoError(err)
-			s.Require().NoError(bucket.Put(s.ctx, result.TestName, bytes.NewReader(data)))
+			s.Require().NoError(testResults.Append(s.ctx, []dbModel.TestResult{result}))
 		}
 	}
 }
@@ -263,16 +247,18 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTaskIDEmpty() {
 
 func (s *testResultsConnectorSuite) TestFindTestResultByTestNameExists() {
 	for _, test := range []struct {
-		name string
-		opts TestResultsOptions
+		name           string
+		opts           TestResultsOptions
+		expectedResult model.APITestResult
 	}{
 		{
 			name: "WithExecution",
 			opts: TestResultsOptions{
 				TaskID:    "task1",
-				Execution: 1,
+				Execution: 0,
 				TestName:  "test1",
 			},
+			expectedResult: s.apiResults["task1_0_test1"],
 		},
 		{
 			name: "WithoutExecution",
@@ -281,36 +267,13 @@ func (s *testResultsConnectorSuite) TestFindTestResultByTestNameExists() {
 				EmptyExecution: true,
 				TestName:       "test1",
 			},
+			expectedResult: s.apiResults["task1_1_test1"],
 		},
 	} {
 		s.T().Run(test.name, func(t *testing.T) {
-			findOpts := dbModel.TestResultsFindOptions{
-				TaskID:         test.opts.TaskID,
-				Execution:      test.opts.Execution,
-				EmptyExecution: test.opts.EmptyExecution,
-			}
-			results, err := dbModel.FindTestResults(s.ctx, s.env, findOpts)
+			result, err := s.sc.FindTestResultByTestName(s.ctx, test.opts)
 			s.Require().NoError(err)
-			bucket, err := results[0].GetBucket(s.ctx)
-			s.Require().NoError(err)
-
-			tr, err := bucket.Get(s.ctx, test.opts.TestName)
-			s.Require().NoError(err)
-			defer func() {
-				s.NoError(tr.Close())
-			}()
-
-			data, err := ioutil.ReadAll(tr)
-			s.Require().NoError(err)
-
-			var result dbModel.TestResult
-			s.Require().NoError(bson.Unmarshal(data, &result))
-			expected := &model.APITestResult{}
-			s.Require().NoError(expected.Import(result))
-
-			actual, err := s.sc.FindTestResultByTestName(s.ctx, test.opts)
-			s.Require().NoError(err)
-			s.Equal(expected, actual)
+			s.Equal(test.expectedResult, *result)
 		})
 	}
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14672

This stores test results as a single file in the respective s3 bucket location for the results. There really is no need to store results individually since they are tiny and the bottleneck ends up being network calls to s3.

There will be a follow up ticket to create a migration job for existing results stored the old way.