### PR TITLE
EVG-14848: Store perf arguments in sorted order in the db

### DIFF
--- a/model/perf.go
+++ b/model/perf.go
@@ -331,6 +331,14 @@ var (
 	perfResultInfoSchemaKey    = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Schema")
 )
 
+// PerformanceArguments wraps map[string]int32 and implements the
+// bson.Marshaler interface in order to have a unified ordering of keys. BSON
+// objects are only equal if the key/value pairs match AND are in the same
+// order. Since maps are not ordered but still marshalled into BSON objects,
+// marshalling two equal Go maps into BSON can can result in two BSON objects
+// that are not equal. By implementing the bson.Marshal interface, we are able
+// to first sort the keys of the map and convert the key/value pairs into a
+// bson.D object, where ordered is preserved.
 type PerformanceArguments map[string]int32
 
 func (args PerformanceArguments) MarshalBSON() ([]byte, error) {

--- a/model/perf.go
+++ b/model/perf.go
@@ -291,27 +291,27 @@ func (result *PerformanceResult) Close(ctx context.Context, completedAt time.Tim
 
 }
 
-////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 //
 // Component Types
 
 // PerformanceResultInfo describes information unique to a single performance
 // result.
 type PerformanceResultInfo struct {
-	Project   string           `bson:"project,omitempty"`
-	Version   string           `bson:"version,omitempty"`
-	Variant   string           `bson:"variant,omitempty"`
-	Order     int              `bson:"order,omitempty"`
-	TaskName  string           `bson:"task_name,omitempty"`
-	TaskID    string           `bson:"task_id,omitempty"`
-	Execution int              `bson:"execution"`
-	TestName  string           `bson:"test_name,omitempty"`
-	Trial     int              `bson:"trial"`
-	Parent    string           `bson:"parent,omitempty"`
-	Tags      []string         `bson:"tags,omitempty"`
-	Arguments map[string]int32 `bson:"args,omitempty"`
-	Mainline  bool             `bson:"mainline"`
-	Schema    int              `bson:"schema,omitempty"`
+	Project   string               `bson:"project,omitempty"`
+	Version   string               `bson:"version,omitempty"`
+	Variant   string               `bson:"variant,omitempty"`
+	Order     int                  `bson:"order,omitempty"`
+	TaskName  string               `bson:"task_name,omitempty"`
+	TaskID    string               `bson:"task_id,omitempty"`
+	Execution int                  `bson:"execution"`
+	TestName  string               `bson:"test_name,omitempty"`
+	Trial     int                  `bson:"trial"`
+	Parent    string               `bson:"parent,omitempty"`
+	Tags      []string             `bson:"tags,omitempty"`
+	Arguments PerformanceArguments `bson:"args,omitempty"`
+	Mainline  bool                 `bson:"mainline"`
+	Schema    int                  `bson:"schema,omitempty"`
 }
 
 var (
@@ -330,6 +330,20 @@ var (
 	perfResultInfoMainlineKey  = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Mainline")
 	perfResultInfoSchemaKey    = bsonutil.MustHaveTag(PerformanceResultInfo{}, "Schema")
 )
+
+type PerformanceArguments map[string]int32
+
+func (args PerformanceArguments) MarshalBSON() ([]byte, error) {
+	sortedArgs := bson.D{}
+	for key, value := range args {
+		sortedArgs = append(sortedArgs, bson.E{Key: key, Value: value})
+	}
+	sort.Slice(sortedArgs, func(i, j int) bool {
+		return sortedArgs[i].Key < sortedArgs[j].Key
+	})
+
+	return bson.Marshal(&sortedArgs)
+}
 
 // ID creates a unique hash for a performance result.
 func (id *PerformanceResultInfo) ID() string {

--- a/model/perf.go
+++ b/model/perf.go
@@ -339,6 +339,9 @@ var (
 // that are not equal. By implementing the bson.Marshal interface, we are able
 // to first sort the keys of the map and convert the key/value pairs into a
 // bson.D object, where ordered is preserved.
+//
+// See: `https://docs.mongodb.com/manual/reference/bson-type-comparison-order/#objects`
+// for more information.
 type PerformanceArguments map[string]int32
 
 func (args PerformanceArguments) MarshalBSON() ([]byte, error) {

--- a/model/perf.go
+++ b/model/perf.go
@@ -335,10 +335,10 @@ var (
 // bson.Marshaler interface in order to have a unified ordering of keys. BSON
 // objects are only equal if the key/value pairs match AND are in the same
 // order. Since maps are not ordered but still marshalled into BSON objects,
-// marshalling two equal Go maps into BSON can can result in two BSON objects
-// that are not equal. By implementing the bson.Marshal interface, we are able
-// to first sort the keys of the map and convert the key/value pairs into a
-// bson.D object, where ordered is preserved.
+// marshalling two equal Go maps into BSON can result in two BSON objects that
+// are not equal. By implementing the bson.Marshal interface, we are able to
+// first sort the keys of the map and convert the key/value pairs into a bson.D
+// object, where ordered is preserved.
 //
 // See: `https://docs.mongodb.com/manual/reference/bson-type-comparison-order/#objects`
 // for more information.

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -415,6 +416,22 @@ func TestPerfClose(t *testing.T) {
 		assert.Equal(t, result2.Artifacts, updatedResult.Artifacts)
 		assert.Equal(t, result2.Rollups, updatedResult.Rollups)
 	})
+}
+
+func TestPerformanceArgumentsBSONMarshal(t *testing.T) {
+	args := PerformanceArguments{"spruce": 2, "evergreen": 0, "cedar": 1}
+	data, err := bson.Marshal(&args)
+	require.NoError(t, err)
+
+	var out bson.D
+	require.NoError(t, bson.Unmarshal(data, &out))
+	require.Len(t, out, len(args))
+	for _, elem := range out {
+		assert.Equal(t, args[elem.Key], elem.Value)
+	}
+	assert.True(t, sort.SliceIsSorted(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	}))
 }
 
 func getTestPerformanceResults() (*PerformanceResult, *PerformanceResult) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14848