### PR TITLE
EVG-15254: Add first 10 failing tests to test results DB doc

### DIFF
--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -274,8 +274,8 @@ func TestTestResultsAppend(t *testing.T) {
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
 		assert.Empty(t, tr.FailedTestsSample)
 
-		failedResults := make([]TestResult, 20)
-		for i := 0; i < 10; i++ {
+		failedResults := make([]TestResult, 2*failedTestsSampleSize)
+		for i := 0; i < 2*failedTestsSampleSize; i++ {
 			failedResults[i] = getTestResult()
 			failedResults[i].Status = "fail"
 		}
@@ -291,9 +291,9 @@ func TestTestResultsAppend(t *testing.T) {
 		require.NoError(t, bson.Unmarshal(data, &savedResults))
 		assert.Equal(t, append(results, failedResults...), savedResults.Results)
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
-		require.Len(t, tr.FailedTestsSample, 10)
+		require.Len(t, tr.FailedTestsSample, failedTestsSampleSize)
 		for i, testName := range tr.FailedTestsSample {
-			assert.Equal(t, failedResults[i].getDisplayName(), testName)
+			assert.Equal(t, failedResults[i].GetDisplayName(), testName)
 		}
 	})
 }

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -225,6 +225,8 @@ func TestTestResultsAppend(t *testing.T) {
 	require.NoError(t, err)
 
 	tr := getTestResults()
+	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr)
+	require.NoError(t, err)
 	tr.populated = true
 	results := []TestResult{}
 	for i := 0; i < 10; i++ {
@@ -263,14 +265,36 @@ func TestTestResultsAppend(t *testing.T) {
 		var savedResults testResultsDoc
 		r, err := testBucket.Get(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection))
 		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, r.Close())
-		}()
 		data, err := ioutil.ReadAll(r)
+		assert.NoError(t, r.Close())
 		require.NoError(t, err)
 		require.NoError(t, bson.Unmarshal(data, &savedResults))
-
 		assert.Equal(t, results, savedResults.Results)
+		var saved TestResults
+		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
+		assert.Empty(t, tr.FailedTestsSample)
+
+		failedResults := make([]TestResult, 20)
+		for i := 0; i < 10; i++ {
+			failedResults[i] = getTestResult()
+			failedResults[i].Status = "fail"
+		}
+		tr.Setup(env)
+		require.NoError(t, tr.Append(ctx, failedResults[0:3]))
+		require.NoError(t, tr.Append(ctx, failedResults[3:]))
+
+		r, err = testBucket.Get(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection))
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(r)
+		assert.NoError(t, r.Close())
+		require.NoError(t, err)
+		require.NoError(t, bson.Unmarshal(data, &savedResults))
+		assert.Equal(t, append(results, failedResults...), savedResults.Results)
+		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
+		require.Len(t, tr.FailedTestsSample, 10)
+		for i, testName := range tr.FailedTestsSample {
+			assert.Equal(t, failedResults[i].getDisplayName(), testName)
+		}
 	})
 }
 

--- a/rpc/internal/test_results_service.go
+++ b/rpc/internal/test_results_service.go
@@ -170,15 +170,11 @@ func (s *testResultsService) updateHistoricalData(record *model.TestResults, res
 		taskName = record.Info.TaskName
 	}
 	for _, res := range results {
-		testName := res.DisplayTestName
-		if testName == "" {
-			testName = res.TestName
-		}
 		info := model.HistoricalTestDataInfo{
 			Project:     record.Info.Project,
 			Variant:     record.Info.Variant,
 			TaskName:    taskName,
-			TestName:    testName,
+			TestName:    res.GetDisplayName(),
 			RequestType: record.Info.RequestType,
 			Date:        res.TestEndTime,
 		}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15254

This is to optimize fetching of a sample of the failing tests for a given task, used by the UI for hover pop-ups.