### PR TITLE
EVG-15303: Add new test results stats route

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -216,13 +216,13 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 }
 
 func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []TestResult) error {
-	var numFailed int
+	var failedCount int
 	for i := 0; i < len(results); i++ {
 		if strings.Contains(strings.ToLower(results[i].Status), "fail") {
 			if len(t.FailedTestsSample) < FailedTestsSampleSize {
 				t.FailedTestsSample = append(t.FailedTestsSample, results[i].GetDisplayName())
 			}
-			numFailed++
+			failedCount++
 		}
 	}
 
@@ -231,8 +231,8 @@ func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []
 		bson.M{testResultsIDKey: t.ID},
 		bson.M{
 			"$inc": bson.M{
-				bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsTotalCountKey): len(results),
-				bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsNumFailedKey):  numFailed,
+				bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsTotalCountKey):  len(results),
+				bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsFailedCountKey): failedCount,
 			},
 			"$set": bson.M{
 				testResultsFailedTestsSampleKey: t.FailedTestsSample,
@@ -243,7 +243,7 @@ func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []
 		"collection":          testResultsCollection,
 		"id":                  t.ID,
 		"inc_total_count":     len(results),
-		"inc_num_failed":      numFailed,
+		"inc_failed_count":    failedCount,
 		"failed_tests_sample": t.FailedTestsSample,
 		"update_result":       updateResult,
 		"op":                  "updating stats and failing tests sample",
@@ -253,7 +253,7 @@ func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []
 	}
 
 	t.Stats.TotalCount += len(results)
-	t.Stats.NumFailed += numFailed
+	t.Stats.FailedCount += failedCount
 
 	return errors.Wrapf(err, "appending to failing tests sample for test result record with id %s", t.ID)
 }
@@ -428,13 +428,13 @@ func (id *TestResultsInfo) ID() string {
 
 // TestResultsStats describes basic stats of the test results.
 type TestResultsStats struct {
-	TotalCount int `bson:"total_count"`
-	NumFailed  int `bson:"num_failed"`
+	TotalCount  int `bson:"total_count"`
+	FailedCount int `bson:"failed_count"`
 }
 
 var (
-	testResultsStatsTotalCountKey = bsonutil.MustHaveTag(TestResultsStats{}, "TotalCount")
-	testResultsStatsNumFailedKey  = bsonutil.MustHaveTag(TestResultsStats{}, "NumFailed")
+	testResultsStatsTotalCountKey  = bsonutil.MustHaveTag(TestResultsStats{}, "TotalCount")
+	testResultsStatsFailedCountKey = bsonutil.MustHaveTag(TestResultsStats{}, "FailedCount")
 )
 
 // TestResult describes a single test result to be stored as a BSON object in
@@ -563,7 +563,7 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts TestResult
 // FindAndDownloadTestResults searches the database for the TestResults
 // associated with the provided options and returns a TestResultsIterator with
 // the downloaded test results. The environment should not be nil. If execution
-// is nil it will default to the most recent execution.
+// is nil, it will default to the most recent execution.
 func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) ([]TestResult, error) {
 	testResults, err := FindTestResults(ctx, env, opts)
 	if err != nil {
@@ -626,6 +626,9 @@ func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts
 	return combinedResults, catcher.Resolve()
 }
 
+// GetTestResultsStats fetches basic stats for the test results associated with
+// the provided options. The environment should not be nil. If execution is
+// nil, it will defualt to the most recent execeution.
 func GetTestResultsStats(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) (TestResultsStats, error) {
 	var stats TestResultsStats
 
@@ -652,15 +655,15 @@ func GetTestResultsStats(ctx context.Context, env cedar.Environment, opts TestRe
 			testResultsStatsTotalCountKey: bson.M{
 				"$sum": "$" + bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsTotalCountKey),
 			},
-			testResultsStatsNumFailedKey: bson.M{
-				"$sum": "$" + bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsNumFailedKey),
+			testResultsStatsFailedCountKey: bson.M{
+				"$sum": "$" + bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsFailedCountKey),
 			},
 		}},
 	}
 	if opts.Execution == nil {
 		pipeline = append(pipeline, bson.M{
 			"$sort": bson.D{
-				{Key: bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey), Value: -1},
+				{Key: "_id", Value: -1},
 			},
 		})
 	}

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -628,7 +628,7 @@ func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts
 
 // GetTestResultsStats fetches basic stats for the test results associated with
 // the provided options. The environment should not be nil. If execution is
-// nil, it will defualt to the most recent execeution.
+// nil, it will default to the most recent execeution.
 func GetTestResultsStats(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) (TestResultsStats, error) {
 	var stats TestResultsStats
 

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -628,7 +628,7 @@ func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, opts
 
 // GetTestResultsStats fetches basic stats for the test results associated with
 // the provided options. The environment should not be nil. If execution is
-// nil, it will default to the most recent execeution.
+// nil, it will default to the most recent execution.
 func GetTestResultsStats(ctx context.Context, env cedar.Environment, opts TestResultsFindOptions) (TestResultsStats, error) {
 	var stats TestResultsStats
 

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -273,7 +273,7 @@ func TestTestResultsAppend(t *testing.T) {
 		var saved TestResults
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
 		assert.Equal(t, len(results), saved.Stats.TotalCount)
-		assert.Zero(t, saved.Stats.NumFailed)
+		assert.Zero(t, saved.Stats.FailedCount)
 		assert.Empty(t, saved.FailedTestsSample)
 
 		failedResults := make([]TestResult, 2*FailedTestsSampleSize)
@@ -294,7 +294,7 @@ func TestTestResultsAppend(t *testing.T) {
 		assert.Equal(t, append(results, failedResults...), savedResults.Results)
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
 		assert.Equal(t, len(results)+len(failedResults), saved.Stats.TotalCount)
-		assert.Equal(t, len(failedResults), saved.Stats.NumFailed)
+		assert.Equal(t, len(failedResults), saved.Stats.FailedCount)
 		require.Len(t, saved.FailedTestsSample, FailedTestsSampleSize)
 		for i, testName := range saved.FailedTestsSample {
 			assert.Equal(t, failedResults[i].GetDisplayName(), testName)
@@ -666,7 +666,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr1.Info.DisplayTaskID = "display"
 	tr1.Info.Execution = 0
 	tr1.Stats.TotalCount = 10
-	tr1.Stats.NumFailed = 5
+	tr1.Stats.FailedCount = 5
 	_, err := db.Collection(testResultsCollection).InsertOne(ctx, tr1)
 	require.NoError(t, err)
 
@@ -675,7 +675,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr2.Info.TaskID = tr1.Info.TaskID
 	tr2.Info.Execution = 1
 	tr2.Stats.TotalCount = 20
-	tr2.Stats.NumFailed = 10
+	tr2.Stats.FailedCount = 10
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
 
@@ -683,7 +683,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr3.Info.DisplayTaskID = "display"
 	tr3.Info.Execution = 1
 	tr3.Stats.TotalCount = 30
-	tr3.Stats.NumFailed = 15
+	tr3.Stats.FailedCount = 15
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr3)
 	require.NoError(t, err)
 
@@ -691,7 +691,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr4.Info.DisplayTaskID = "display"
 	tr4.Info.Execution = 0
 	tr4.Stats.TotalCount = 40
-	tr4.Stats.NumFailed = 20
+	tr4.Stats.FailedCount = 20
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr4)
 	require.NoError(t, err)
 
@@ -770,8 +770,8 @@ func TestGetTestResultsStats(t *testing.T) {
 				DisplayTask: true,
 			},
 			expectedStats: TestResultsStats{
-				TotalCount: tr2.Stats.TotalCount + tr3.Stats.TotalCount,
-				NumFailed:  tr2.Stats.NumFailed + tr3.Stats.NumFailed,
+				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount,
+				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount,
 			},
 		},
 		{
@@ -782,8 +782,8 @@ func TestGetTestResultsStats(t *testing.T) {
 				DisplayTask: true,
 			},
 			expectedStats: TestResultsStats{
-				TotalCount: tr1.Stats.TotalCount + tr4.Stats.TotalCount,
-				NumFailed:  tr1.Stats.NumFailed + tr4.Stats.NumFailed,
+				TotalCount:  tr1.Stats.TotalCount + tr4.Stats.TotalCount,
+				FailedCount: tr1.Stats.FailedCount + tr4.Stats.FailedCount,
 			},
 		},
 	} {

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -674,7 +674,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr2.Info.DisplayTaskID = "display"
 	tr2.Info.TaskID = tr1.Info.TaskID
 	tr2.Info.Execution = 1
-	tr2.Stats.TotalCount = 20
+	tr2.Stats.TotalCount = 30
 	tr2.Stats.FailedCount = 10
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
@@ -682,7 +682,7 @@ func TestGetTestResultsStats(t *testing.T) {
 	tr3 := getTestResults()
 	tr3.Info.DisplayTaskID = "display"
 	tr3.Info.Execution = 1
-	tr3.Stats.TotalCount = 30
+	tr3.Stats.TotalCount = 100
 	tr3.Stats.FailedCount = 15
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr3)
 	require.NoError(t, err)
@@ -766,12 +766,12 @@ func TestGetTestResultsStats(t *testing.T) {
 			env:  env,
 			opts: TestResultsFindOptions{
 				TaskID:      "display",
-				Execution:   utility.ToIntPtr(1),
+				Execution:   utility.ToIntPtr(0),
 				DisplayTask: true,
 			},
 			expectedStats: TestResultsStats{
-				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount,
-				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount,
+				TotalCount:  tr1.Stats.TotalCount + tr4.Stats.TotalCount,
+				FailedCount: tr1.Stats.FailedCount + tr4.Stats.FailedCount,
 			},
 		},
 		{
@@ -782,8 +782,8 @@ func TestGetTestResultsStats(t *testing.T) {
 				DisplayTask: true,
 			},
 			expectedStats: TestResultsStats{
-				TotalCount:  tr1.Stats.TotalCount + tr4.Stats.TotalCount,
-				FailedCount: tr1.Stats.FailedCount + tr4.Stats.FailedCount,
+				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount,
+				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount,
 			},
 		},
 	} {

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -87,11 +87,15 @@ type Connector interface {
 	// the given options. If the execution is nil, this will return the
 	// test results from the most recent execution.
 	FindTestResults(context.Context, TestResultsOptions) ([]model.APITestResult, error)
-	// FindFailedTestResultsSample queries the database to find all the
+	// GetFailedTestResultsSample queries the database to find all the
 	// sample of failed test results for the given options. If the
 	// execution is nil, this will return the sample from the most recent
 	// execution.
-	FindFailedTestResultsSample(context.Context, TestResultsOptions) ([]string, error)
+	GetFailedTestResultsSample(context.Context, TestResultsOptions) ([]string, error)
+	// GetTestResultsStats queries the database to aggregate basic stats
+	// of test results for the given options. If the execution is nil, this
+	// will return stats for the most recent execution.
+	GetTestResultsStats(context.Context, TestResultsOptions) (*model.APITestResultsStats, error)
 
 	///////////////////////
 	// Historical Test Data

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -64,7 +64,12 @@ func (dbc *DBConnector) GetTestResultsStats(ctx context.Context, opts TestResult
 	}
 
 	apiStats := &model.APITestResultsStats{}
-	apiStats.Import(stats)
+	if err = apiStats.Import(stats); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrapf(err, "importing stats into APITestResultsStats struct").Error(),
+		}
+	}
 
 	return apiStats, nil
 }
@@ -131,7 +136,12 @@ func (mc *MockConnector) GetTestResultsStats(ctx context.Context, opts TestResul
 			return nil, err
 		}
 
-		stats.Import(testResultsDoc.Stats)
+		if err = stats.Import(testResultsDoc.Stats); err != nil {
+			return nil, gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrapf(err, "importing stats into APITestResultsStats struct").Error(),
+			}
+		}
 	} else {
 		testResultsDocs, err := mc.findTestResultsByDisplayTaskID(ctx, opts)
 		if err != nil {

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -32,7 +32,7 @@ func (dbc *DBConnector) FindTestResults(ctx context.Context, opts TestResultsOpt
 	return importTestResults(ctx, results, opts.TestName)
 }
 
-func (dbc *DBConnector) FindFailedTestResultsSample(ctx context.Context, opts TestResultsOptions) ([]string, error) {
+func (dbc *DBConnector) GetFailedTestResultsSample(ctx context.Context, opts TestResultsOptions) ([]string, error) {
 	resultDocs, err := dbModel.FindTestResults(ctx, dbc.env, convertToDBTestResultsOptions(opts))
 	if db.ResultsNotFound(err) {
 		return nil, gimlet.ErrorResponse{
@@ -47,6 +47,26 @@ func (dbc *DBConnector) FindFailedTestResultsSample(ctx context.Context, opts Te
 	}
 
 	return extractFailedTestResultsSample(resultDocs...), nil
+}
+
+func (dbc *DBConnector) GetTestResultsStats(ctx context.Context, opts TestResultsOptions) (*model.APITestResultsStats, error) {
+	stats, err := dbModel.GetTestResultsStats(ctx, dbc.env, convertToDBTestResultsOptions(opts))
+	if db.ResultsNotFound(err) {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    "test results not found",
+		}
+	} else if err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "retrieving test results stats").Error(),
+		}
+	}
+
+	apiStats := &model.APITestResultsStats{}
+	apiStats.Import(stats)
+
+	return apiStats, nil
 }
 
 ///////////////////////////////
@@ -71,7 +91,7 @@ func (mc *MockConnector) FindTestResults(ctx context.Context, opts TestResultsOp
 	return importTestResults(ctx, results, opts.TestName)
 }
 
-func (mc *MockConnector) FindFailedTestResultsSample(ctx context.Context, opts TestResultsOptions) ([]string, error) {
+func (mc *MockConnector) GetFailedTestResultsSample(ctx context.Context, opts TestResultsOptions) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -84,6 +104,7 @@ func (mc *MockConnector) FindFailedTestResultsSample(ctx context.Context, opts T
 		if err != nil {
 			return nil, err
 		}
+
 		return extractFailedTestResultsSample(*testResultsDoc), nil
 	}
 
@@ -92,6 +113,38 @@ func (mc *MockConnector) FindFailedTestResultsSample(ctx context.Context, opts T
 		return nil, err
 	}
 	return extractFailedTestResultsSample(testResultsDocs...), nil
+}
+
+func (mc *MockConnector) GetTestResultsStats(ctx context.Context, opts TestResultsOptions) (*model.APITestResultsStats, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    err.Error(),
+		}
+	}
+
+	stats := &model.APITestResultsStats{}
+
+	if !opts.DisplayTask {
+		testResultsDoc, err := mc.findTestResultsByTaskID(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		stats.Import(testResultsDoc.Stats)
+	} else {
+		testResultsDocs, err := mc.findTestResultsByDisplayTaskID(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, doc := range testResultsDocs {
+			stats.TotalCount += doc.Stats.TotalCount
+			stats.FailedCount += doc.Stats.FailedCount
+		}
+	}
+
+	return stats, nil
 }
 
 func (mc *MockConnector) findAndDownloadTestResultsByTaskID(ctx context.Context, opts TestResultsOptions) ([]dbModel.TestResult, error) {

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -142,16 +142,18 @@ func (mc *MockConnector) GetTestResultsStats(ctx context.Context, opts TestResul
 				Message:    errors.Wrapf(err, "importing stats into APITestResultsStats struct").Error(),
 			}
 		}
-	} else {
-		testResultsDocs, err := mc.findTestResultsByDisplayTaskID(ctx, opts)
-		if err != nil {
-			return nil, err
-		}
 
-		for _, doc := range testResultsDocs {
-			stats.TotalCount += doc.Stats.TotalCount
-			stats.FailedCount += doc.Stats.FailedCount
-		}
+		return stats, nil
+	}
+
+	testResultsDocs, err := mc.findTestResultsByDisplayTaskID(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, doc := range testResultsDocs {
+		stats.TotalCount += doc.Stats.TotalCount
+		stats.FailedCount += doc.Stats.FailedCount
 	}
 
 	return stats, nil

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -193,7 +193,7 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			},
 		},
 		{
-			name: "SuccedsWithDisplayTaskIDAndExecution",
+			name: "SucceedsWithDisplayTaskIDAndExecution",
 			opts: TestResultsOptions{
 				TaskID:      "display_task1",
 				Execution:   utility.ToIntPtr(0),

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -139,14 +139,29 @@ func (s *testResultsConnectorSuite) TearDownSuite() {
 	s.NoError(s.env.GetDB().Drop(s.ctx))
 }
 
-func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
+func (s *testResultsConnectorSuite) TestFindTestResults() {
 	for _, test := range []struct {
 		name      string
 		opts      TestResultsOptions
 		resultMap map[string]model.APITestResult
+		hasErr    bool
 	}{
 		{
-			name: "TaskIDWithExecution",
+			name:   "FailsWithEmptyOptions",
+			hasErr: true,
+		},
+		{
+			name:   "FailsWhenTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE"},
+			hasErr: true,
+		},
+		{
+			name:   "FailsWhenDisplayTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE", DisplayTask: true},
+			hasErr: true,
+		},
+		{
+			name: "SucceedsWithTaskIDAndExecution",
 			opts: TestResultsOptions{
 				TaskID:    "task1",
 				Execution: utility.ToIntPtr(0),
@@ -158,7 +173,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 			},
 		},
 		{
-			name: "TaskIDWithoutExecution",
+			name: "SucceedsWithTaskIDAndNoExecution",
 			opts: TestResultsOptions{TaskID: "task1"},
 			resultMap: map[string]model.APITestResult{
 				"task1_1_test0": s.apiResults["task1_1_test0"],
@@ -167,7 +182,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 			},
 		},
 		{
-			name: "TaskIDWithTestName",
+			name: "SucceedsWithTaskIDAndTestName",
 			opts: TestResultsOptions{
 				TaskID:    "task1",
 				Execution: utility.ToIntPtr(0),
@@ -178,7 +193,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 			},
 		},
 		{
-			name: "DisplayTaskIDWithExecution",
+			name: "SuccedsWithDisplayTaskIDAndExecution",
 			opts: TestResultsOptions{
 				TaskID:      "display_task1",
 				Execution:   utility.ToIntPtr(0),
@@ -194,7 +209,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 			},
 		},
 		{
-			name: "DisplayTaskIDWithoutExecution",
+			name: "SucceedsWithDisplayTaskIDAndNoExecution",
 			opts: TestResultsOptions{
 				TaskID:      "display_task1",
 				DisplayTask: true,
@@ -206,7 +221,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 			},
 		},
 		{
-			name: "DisplayTaskIDWithTestName",
+			name: "SucceedsWithDisplayTaskIDAndTestName",
 			opts: TestResultsOptions{
 				TaskID:      "display_task1",
 				Execution:   utility.ToIntPtr(0),
@@ -221,58 +236,49 @@ func (s *testResultsConnectorSuite) TestFindTestResultsExists() {
 	} {
 		s.T().Run(test.name, func(t *testing.T) {
 			actualResults, err := s.sc.FindTestResults(s.ctx, test.opts)
-			s.Require().NoError(err)
 
-			s.Len(actualResults, len(test.resultMap))
-			for _, result := range actualResults {
-				key := fmt.Sprintf("%s_%d_%s", *result.TaskID, result.Execution, *result.TestName)
-				expected, ok := test.resultMap[key]
-				s.Require().True(ok)
-				s.Equal(expected.TestName, result.TestName)
-				s.Equal(expected.TaskID, result.TaskID)
-				s.Equal(expected.Execution, result.Execution)
-				delete(test.resultMap, key)
+			if test.hasErr {
+				s.Nil(actualResults)
+				s.Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				s.Len(actualResults, len(test.resultMap))
+				for _, result := range actualResults {
+					key := fmt.Sprintf("%s_%d_%s", *result.TaskID, result.Execution, *result.TestName)
+					expected, ok := test.resultMap[key]
+					s.Require().True(ok)
+					s.Equal(expected.TestName, result.TestName)
+					s.Equal(expected.TaskID, result.TaskID)
+					s.Equal(expected.Execution, result.Execution)
+					delete(test.resultMap, key)
+				}
 			}
 		})
 	}
 }
 
-func (s *testResultsConnectorSuite) TestFindTestResultDNE() {
-	for _, test := range []struct {
-		name string
-		opts TestResultsOptions
-	}{
-		{
-			name: "TaskID",
-			opts: TestResultsOptions{TaskID: "DNE"},
-		},
-		{
-			name: "DisplayTaskID",
-			opts: TestResultsOptions{TaskID: "DNE", DisplayTask: true},
-		},
-	} {
-		s.T().Run(test.name, func(t *testing.T) {
-			result, err := s.sc.FindTestResults(s.ctx, test.opts)
-			s.Error(err)
-			s.Nil(result)
-		})
-	}
-}
-
-func (s *testResultsConnectorSuite) TestFindTestResultEmpty() {
-	opts := TestResultsOptions{Execution: utility.ToIntPtr(1)}
-
-	result, err := s.sc.FindTestResults(s.ctx, opts)
-	s.Error(err)
-	s.Nil(result)
-}
-
-func (s *testResultsConnectorSuite) TestFindFailedTestResultsSampleExists() {
+func (s *testResultsConnectorSuite) TestGetFailedTestResultsSample() {
 	for _, test := range []struct {
 		name           string
 		opts           TestResultsOptions
 		expectedResult []string
+		hasErr         bool
 	}{
+		{
+			name:   "FailsWithEmptyOptions",
+			hasErr: true,
+		},
+		{
+			name:   "FailsWhenTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE"},
+			hasErr: true,
+		},
+		{
+			name:   "FailsWhenDisplayTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE", DisplayTask: true},
+			hasErr: true,
+		},
 		{
 			name: "TaskIDWithExecution",
 			opts: TestResultsOptions{
@@ -312,43 +318,96 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSampleExists() {
 		},
 	} {
 		s.T().Run(test.name, func(t *testing.T) {
-			actualResult, err := s.sc.FindFailedTestResultsSample(s.ctx, test.opts)
-			s.Require().NoError(err)
+			actualResult, err := s.sc.GetFailedTestResultsSample(s.ctx, test.opts)
 
-			s.Require().Len(actualResult, len(test.expectedResult))
-			for i := range actualResult {
-				s.Equal(test.expectedResult[i], actualResult[i])
+			if test.hasErr {
+				s.Nil(actualResult)
+				s.Error(err)
+			} else {
+				s.Require().NoError(err)
+
+				s.Require().Len(actualResult, len(test.expectedResult))
+				for i := range actualResult {
+					s.Equal(test.expectedResult[i], actualResult[i])
+				}
 			}
 		})
 	}
 }
 
-func (s *testResultsConnectorSuite) TestFindFailedTestResultsSampleDNE() {
+func (s *testResultsConnectorSuite) TestGetTestResultsStats() {
 	for _, test := range []struct {
-		name string
-		opts TestResultsOptions
+		name           string
+		opts           TestResultsOptions
+		expectedResult *model.APITestResultsStats
+		hasErr         bool
 	}{
 		{
-			name: "TaskID",
-			opts: TestResultsOptions{TaskID: "DNE"},
+			name:   "FailsWithEmptyOptions",
+			hasErr: true,
 		},
 		{
-			name: "DisplayTaskID",
-			opts: TestResultsOptions{TaskID: "DNE", DisplayTask: true},
+			name:   "FailsWhenTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE"},
+			hasErr: true,
+		},
+		{
+			name:   "FailsWhenDisplayTaskIDDNE",
+			opts:   TestResultsOptions{TaskID: "DNE", DisplayTask: true},
+			hasErr: true,
+		},
+		{
+			name: "TaskIDWithExecution",
+			opts: TestResultsOptions{
+				TaskID:    "task1",
+				Execution: utility.ToIntPtr(0),
+			},
+			expectedResult: &model.APITestResultsStats{
+				TotalCount:  3,
+				FailedCount: 3,
+			},
+		},
+		{
+			name: "TaskIDWithoutExecution",
+			opts: TestResultsOptions{TaskID: "task1"},
+			expectedResult: &model.APITestResultsStats{
+				TotalCount:  3,
+				FailedCount: 3,
+			},
+		},
+		{
+			name: "DisplayTaskIDWithExecution",
+			opts: TestResultsOptions{
+				TaskID:      "display_task1",
+				Execution:   utility.ToIntPtr(0),
+				DisplayTask: true,
+			},
+			expectedResult: &model.APITestResultsStats{
+				TotalCount:  6,
+				FailedCount: 6,
+			},
+		},
+		{
+			name: "DisplayTaskIDWithoutExecution",
+			opts: TestResultsOptions{
+				TaskID:      "display_task1",
+				DisplayTask: true,
+			},
+			expectedResult: &model.APITestResultsStats{
+				TotalCount:  3,
+				FailedCount: 3,
+			},
 		},
 	} {
 		s.T().Run(test.name, func(t *testing.T) {
-			result, err := s.sc.FindFailedTestResultsSample(s.ctx, test.opts)
-			s.Error(err)
-			s.Nil(result)
+			actualResult, err := s.sc.GetTestResultsStats(s.ctx, test.opts)
+
+			if test.hasErr {
+				s.Error(err)
+			} else {
+				s.Require().NoError(err)
+			}
+			s.Equal(test.expectedResult, actualResult)
 		})
 	}
-}
-
-func (s *testResultsConnectorSuite) TestFindFailedTestResultsSampleEmpty() {
-	opts := TestResultsOptions{Execution: utility.ToIntPtr(1)}
-
-	result, err := s.sc.FindFailedTestResultsSample(s.ctx, opts)
-	s.Error(err)
-	s.Nil(result)
 }

--- a/rest/model/test_results.go
+++ b/rest/model/test_results.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	dbmodel "github.com/evergreen-ci/cedar/model"
+	dbModel "github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
@@ -27,7 +27,7 @@ type APITestResult struct {
 // Import transforms a TestResult object into an APITestResult object.
 func (a *APITestResult) Import(i interface{}) error {
 	switch tr := i.(type) {
-	case dbmodel.TestResult:
+	case dbModel.TestResult:
 		a.TaskID = utility.ToStringPtr(tr.TaskID)
 		a.Execution = tr.Execution
 		a.TestName = utility.ToStringPtr(tr.TestName)
@@ -55,5 +55,26 @@ func (a *APITestResult) Import(i interface{}) error {
 	default:
 		return errors.New("incorrect type when converting to APITestResult type")
 	}
+
+	return nil
+}
+
+// APITTestResultsStats describes basic stats for a group of test results.
+type APITestResultsStats struct {
+	TotalCount  int `json:"total_count"`
+	FailedCount int `json:"failed_count"`
+}
+
+// Import transforms a TestResultsStats object into an APITestResultsStats
+// object.
+func (a *APITestResultsStats) Import(i interface{}) error {
+	switch stats := i.(type) {
+	case dbModel.TestResultsStats:
+		a.TotalCount = stats.TotalCount
+		a.FailedCount = stats.FailedCount
+	default:
+		return errors.New("incorrect type when converting to APITTestResultsStats type")
+	}
+
 	return nil
 }

--- a/rest/service.go
+++ b/rest/service.go
@@ -319,6 +319,7 @@ func (s *Service) addRoutes() {
 
 	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskID(s.sc))
 	s.app.AddRoute("/test_results/task_id/{task_id}/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSample(s.sc))
+	s.app.AddRoute("/test_results/task_id/{task_id}/stats").Version(1).Get().RouteHandler(makeGetTestResultsStats(s.sc))
 	// TODO: (EVG-15299) Remove these two routes once we are sure no one is
 	// using them. Keeping temporarily for backwards compatibility.
 	s.app.AddRoute("/test_results/display_task_id/{display_task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByDisplayTaskID(s.sc))

--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -106,9 +106,9 @@ func (h *testResultsGetFailedSampleHandler) Factory() gimlet.RouteHandler {
 
 // Run finds and returns the desired failed test results sample.
 func (h *testResultsGetFailedSampleHandler) Run(ctx context.Context) gimlet.Responder {
-	sample, err := h.sc.FindFailedTestResultsSample(ctx, h.opts)
+	sample, err := h.sc.GetFailedTestResultsSample(ctx, h.opts)
 	if err != nil {
-		err = errors.Wrapf(err, "problem getting test result by task_id '%s'", h.opts.TaskID)
+		err = errors.Wrapf(err, "problem getting failed test results sample by task_id '%s'", h.opts.TaskID)
 		grip.Error(message.WrapError(err, message.Fields{
 			"request":         gimlet.GetRequestID(ctx),
 			"method":          "GET",
@@ -120,6 +120,46 @@ func (h *testResultsGetFailedSampleHandler) Run(ctx context.Context) gimlet.Resp
 	}
 
 	return gimlet.NewJSONResponse(sample)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// GET /test_results/task_id/{task_id}/stats
+
+type testResultsGetStatsHandler struct {
+	sc data.Connector
+	testResultsBaseHandler
+}
+
+func makeGetTestResultsStats(sc data.Connector) gimlet.RouteHandler {
+	return &testResultsGetStatsHandler{
+		sc: sc,
+	}
+}
+
+// Factory returns a pointer to a new testResultsGetStatsHandler.
+func (h *testResultsGetStatsHandler) Factory() gimlet.RouteHandler {
+	return &testResultsGetStatsHandler{
+		sc: h.sc,
+	}
+}
+
+// Run finds and returns the desired failed test results stats.
+func (h *testResultsGetStatsHandler) Run(ctx context.Context) gimlet.Responder {
+	stats, err := h.sc.GetTestResultsStats(ctx, h.opts)
+	if err != nil {
+		err = errors.Wrapf(err, "problem getting test results stats by task_id '%s'", h.opts.TaskID)
+		grip.Error(message.WrapError(err, message.Fields{
+			"request":         gimlet.GetRequestID(ctx),
+			"method":          "GET",
+			"route":           "/testresults/task_id/{task_id}/stats",
+			"task_id":         h.opts.TaskID,
+			"is_display_task": h.opts.DisplayTask,
+		}))
+		return gimlet.MakeJSONInternalErrorResponder(err)
+	}
+
+	return gimlet.NewJSONResponse(stats)
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15303

- Add new function to fetch test results stats for a single task id or aggregate test results for tasks in a display task id.
- Add new rest data connector function to fetch test results stats
- Add new route
- Refactor some tests in the rest and rest/data package
- Rename `NumFailed` to `FailCount` for consistency