### PR TITLE
EVG-15354: Make sure time range is valid when fetching grouped logs

### DIFF
--- a/rest/buildlogger_routes.go
+++ b/rest/buildlogger_routes.go
@@ -555,6 +555,9 @@ func (h *logGroupByTestNameHandler) Run(ctx context.Context) gimlet.Responder {
 				h.opts.TimeRange.EndAt = time.Time(log.CompletedAt)
 			}
 		}
+		if h.opts.TimeRange.EndAt.IsZero() {
+			h.opts.TimeRange.EndAt = time.Now()
+		}
 	}
 
 	data, next, paginated, err := h.sc.FindGroupedLogs(ctx, h.opts)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15354

This occurs when a test log was not able to close out so the `completed_at` field is zero, for example, when a resmoke test timeouts.