### PR TITLE
EVG-15386: Add scopes to time-series-update job 

### DIFF
--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -21,8 +21,8 @@ var (
 	perfAnalysisProcessedAtKey = bsonutil.MustHaveTag(PerfAnalysis{}, "ProcessedAt")
 )
 
-// PerformanceResultSeriesID is the ID of a group of performance results. It is
-// used to create a job to analyze the group for change points.
+// PerformanceResultSeriesID represents the set of fields used identify a
+// series of performance results for change point detection.
 type PerformanceResultSeriesID struct {
 	Project     string           `bson:"project"`
 	Variant     string           `bson:"variant"`
@@ -37,7 +37,8 @@ func (p PerformanceResultSeriesID) String() string {
 	return fmt.Sprintf("%s %s %s %s %v", p.Project, p.Variant, p.Task, p.Test, p.Arguments)
 }
 
-// TimeSeriesEntry is information about a single performance result.
+// TimeSeriesEntry represents information about a single performance result in
+// a series.
 type TimeSeriesEntry struct {
 	PerfResultID string  `bson:"perf_result_id"`
 	Value        float64 `bson:"value"`
@@ -45,8 +46,8 @@ type TimeSeriesEntry struct {
 	Version      string  `bson:"version"`
 }
 
-// PerformanceData contains information about a group of performance results
-// and their associated measurement data.
+// PerformanceData represents information about a performance result series and
+// its associated measurement data.
 type PerformanceData struct {
 	PerformanceResultId PerformanceResultSeriesID `bson:"_id"`
 	TimeSeries          []TimeSeriesEntry         `bson:"time_series"`
@@ -76,8 +77,8 @@ func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment
 }
 
 // GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate queries the database
-// and gets all the performance result series IDs that have results that have
-// not yet been analyzed.
+// and gets all the performance result series IDs that contain results that
+// have not yet been analyzed.
 func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, env cedar.Environment) ([]PerformanceResultSeriesID, error) {
 	cur, err := env.GetDB().Collection(perfResultCollection).Aggregate(ctx, []bson.M{
 		{
@@ -174,8 +175,8 @@ func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) (
 	return res, nil
 }
 
-// GetPerformanceData gets the performance result time series data associated
-// with the given series ID.
+// GetPerformanceData queries the database to get the performance result time
+// series data associated with the given series ID.
 func GetPerformanceData(ctx context.Context, env cedar.Environment, performanceResultId PerformanceResultSeriesID) ([]PerformanceData, error) {
 	pipe := []bson.M{
 		{

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -85,6 +85,7 @@ func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, e
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey):  bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): bson.M{"$exists": true},
+				bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey):    bson.M{"$not": bson.M{"$size": 0}},
 			},
 		},
 		{

--- a/rpc/internal/perf_service_test.go
+++ b/rpc/internal/perf_service_test.go
@@ -203,8 +203,9 @@ func TestCreateMetricSeries(t *testing.T) {
 			name: "TestRollupsNoArtifacts",
 			data: &ResultData{
 				Id: &ResultID{
-					Project: "testProject",
-					Version: "testVersion",
+					Project:  "testProject",
+					Version:  "testVersion",
+					Mainline: true,
 				},
 				Rollups: []*RollupValue{
 					{

--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -48,8 +48,10 @@ func makeTimeSeriesJob() *timeSeriesUpdateJob {
 // NewUpdateTimeSeriesJob creates a new amboy job to update a time series.
 func NewUpdateTimeSeriesJob(timeSeriesId model.PerformanceResultSeriesID) amboy.Job {
 	j := makeTimeSeriesJob()
-	timestamp := utility.RoundPartOfHour(0)
-	j.SetID(fmt.Sprintf("%s.%s.%s.%s.%s.%s", j.JobType.Name, timeSeriesId.Project, timeSeriesId.Variant, timeSeriesId.Task, timeSeriesId.Test, timestamp))
+	baseID := fmt.Sprintf("%s.%s.%s.%s.%s.%s", j.JobType.Name, timeSeriesId.Project, timeSeriesId.Variant, timeSeriesId.Task, timeSeriesId.Test)
+	j.SetID(fmt.Sprintf("%s.%s", baseID, utility.RoundPartOfHour(0)))
+	j.SetScopes([]string{baseID})
+	j.SetShouldApplyScopesOnEnqueue(true)
 	j.PerformanceResultId = timeSeriesId
 	return j
 }
@@ -67,24 +69,29 @@ func (j *timeSeriesUpdateJob) makeMessage(msg string, id model.PerformanceResult
 
 func (j *timeSeriesUpdateJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-	if j.conf == nil {
-		j.conf = model.NewCedarConfig(j.env)
-	}
-	if j.conf.Flags.DisableSignalProcessing {
-		grip.InfoWhen(sometimes.Percent(10), j.makeMessage("signal processing is disabled, skipping processing", j.PerformanceResultId))
-		return
-	}
+
 	if j.env == nil {
 		j.env = cedar.GetEnvironment()
 	}
-	if j.performanceAnalysisService == nil {
+
+	if j.conf == nil {
+		j.conf = model.NewCedarConfig(j.env)
 		err := j.conf.Find()
 		if err != nil {
 			j.AddError(errors.Wrap(err, "Unable to get cedar configuration"))
 			return
 		}
+	}
+
+	if j.conf.Flags.DisableSignalProcessing {
+		grip.InfoWhen(sometimes.Percent(10), j.makeMessage("signal processing is disabled, skipping processing", j.PerformanceResultId))
+		return
+	}
+
+	if j.performanceAnalysisService == nil {
 		j.performanceAnalysisService = perf.NewPerformanceAnalysisService(j.conf.ChangeDetector.URI, j.conf.ChangeDetector.User, j.conf.ChangeDetector.Token)
 	}
+
 	performanceData, err := model.GetPerformanceData(ctx, j.env, j.PerformanceResultId)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "Unable to aggregate time perfData %s", j.PerformanceResultId.String()))

--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -48,7 +48,7 @@ func makeTimeSeriesJob() *timeSeriesUpdateJob {
 // NewUpdateTimeSeriesJob creates a new amboy job to update a time series.
 func NewUpdateTimeSeriesJob(timeSeriesId model.PerformanceResultSeriesID) amboy.Job {
 	j := makeTimeSeriesJob()
-	baseID := fmt.Sprintf("%s.%s.%s.%s.%s.%s", j.JobType.Name, timeSeriesId.Project, timeSeriesId.Variant, timeSeriesId.Task, timeSeriesId.Test)
+	baseID := fmt.Sprintf("%s.%s.%s.%s.%s", j.JobType.Name, timeSeriesId.Project, timeSeriesId.Variant, timeSeriesId.Task, timeSeriesId.Test)
 	j.SetID(fmt.Sprintf("%s.%s", baseID, utility.RoundPartOfHour(0)))
 	j.SetScopes([]string{baseID})
 	j.SetShouldApplyScopesOnEnqueue(true)

--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -78,7 +78,7 @@ func (j *timeSeriesUpdateJob) Run(ctx context.Context) {
 		j.conf = model.NewCedarConfig(j.env)
 		err := j.conf.Find()
 		if err != nil {
-			j.AddError(errors.Wrap(err, "Unable to get cedar configuration"))
+			j.AddError(errors.Wrap(err, "getting cedar configuration"))
 			return
 		}
 	}
@@ -94,7 +94,7 @@ func (j *timeSeriesUpdateJob) Run(ctx context.Context) {
 
 	performanceData, err := model.GetPerformanceData(ctx, j.env, j.PerformanceResultId)
 	if err != nil {
-		j.AddError(errors.Wrapf(err, "Unable to aggregate time perfData %s", j.PerformanceResultId.String()))
+		j.AddError(errors.Wrapf(err, "aggregating time perfData %s", j.PerformanceResultId.String()))
 		return
 	}
 	if performanceData == nil {
@@ -129,7 +129,7 @@ func (j *timeSeriesUpdateJob) Run(ctx context.Context) {
 		}
 		err := j.performanceAnalysisService.ReportUpdatedTimeSeries(ctx, series)
 		if err != nil {
-			j.AddError(errors.Wrapf(err, "Unable to update time series for perfData %s", j.PerformanceResultId.String()))
+			j.AddError(errors.Wrapf(err, "updating time series for perfData %s", j.PerformanceResultId.String()))
 			return
 		}
 		j.AddError(model.MarkPerformanceResultsAsAnalyzed(ctx, j.env, perfData.PerformanceResultId))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15386

- This also fixes the periodic aggregation and creates a time-series-update job in `CreateMetricSeries` when there are rollups.