### PR TITLE
EVG-14837: Create cedar route to determine if perf data exists for a task

### DIFF
--- a/rest/model/perf.go
+++ b/rest/model/perf.go
@@ -10,8 +10,7 @@ import (
 // APIPerformanceResultExists describes a single result of a performance test from
 // Evergreen.
 type APIPerformanceResultExists struct {
-	Name   string `json:"name"`
-	Exists bool   `json:"exists"`
+	NumberOfResults int `json:"number_of_results"`
 }
 
 // APIPerformanceResult describes a single result of a performance test from

--- a/rest/model/perf.go
+++ b/rest/model/perf.go
@@ -7,9 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// APIPerformanceResultExists describes a single result of a performance test from
+// APIPerformanceResultCount describes a single result of a performance test from
 // Evergreen.
-type APIPerformanceResultExists struct {
+type APIPerformanceResultCount struct {
 	NumberOfResults int `json:"number_of_results"`
 }
 

--- a/rest/model/perf.go
+++ b/rest/model/perf.go
@@ -7,6 +7,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// APIPerformanceResultExists describes a single result of a performance test from
+// Evergreen.
+type APIPerformanceResultExists struct {
+	Name   string `json:"name"`
+	Exists bool   `json:"exists"`
+}
+
 // APIPerformanceResult describes a single result of a performance test from
 // Evergreen.
 type APIPerformanceResult struct {

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -191,7 +191,7 @@ func (h *perfCountByTaskIdHandler) Parse(_ context.Context, r *http.Request) err
 }
 
 // Run calls the data FindPerformanceResults function and returns the
-// number of PerformanceResults fount
+// number of PerformanceResults found
 func (h *perfCountByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -163,36 +163,36 @@ func (h *perfGetByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// GET /perf/task_id/{task_id}/exists
+// GET /perf/task_id/{task_id}/count
 
-type perfExistsByTaskIdHandler struct {
+type perfCountByTaskIdHandler struct {
 	opts data.PerformanceOptions
 	sc   data.Connector
 }
 
-func makeExistsPerfByTaskId(sc data.Connector) gimlet.RouteHandler {
-	return &perfExistsByTaskIdHandler{
+func makeCountPerfByTaskId(sc data.Connector) gimlet.RouteHandler {
+	return &perfCountByTaskIdHandler{
 		sc: sc,
 	}
 }
 
-// Factory returns a pointer to a new perfGetByTaskIdHandler.
-func (h *perfExistsByTaskIdHandler) Factory() gimlet.RouteHandler {
-	return &perfExistsByTaskIdHandler{
+// Factory returns a pointer to a new perfCountByTaskIdHandler.
+func (h *perfCountByTaskIdHandler) Factory() gimlet.RouteHandler {
+	return &perfCountByTaskIdHandler{
 		sc: h.sc,
 	}
 }
 
 // Parse fetches the task_id from the http request.
-func (h *perfExistsByTaskIdHandler) Parse(_ context.Context, r *http.Request) error {
+func (h *perfCountByTaskIdHandler) Parse(_ context.Context, r *http.Request) error {
 	h.opts.TaskID = gimlet.GetVars(r)["task_id"]
 	h.opts.Tags = r.URL.Query()[tags]
 	return nil
 }
 
 // Run calls the data FindPerformanceResults function and returns the
-// PerformanceResults from the provider.
-func (h *perfExistsByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
+// number of PerformanceResults fount
+func (h *perfCountByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by task id '%s'", h.opts.TaskID)
@@ -204,16 +204,10 @@ func (h *perfExistsByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 		}))
 		return gimlet.MakeJSONErrorResponder(err)
 	}
-	if len(perfResults) == 0 {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    "no perf results found",
-		})
-	}
-	existResult := model.APIPerformanceResultExists{
+	countResult := model.APIPerformanceResultCount{
 		NumberOfResults: len(perfResults),
 	}
-	return gimlet.NewJSONResponse(existResult)
+	return gimlet.NewJSONResponse(countResult)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -204,15 +204,16 @@ func (h *perfExistsByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 		}))
 		return gimlet.MakeJSONErrorResponder(err)
 	}
-	if len(perfResults) > 0 {
-		existResult := model.APIPerformanceResultExists{
-			Name:   h.opts.TaskID,
-			Exists: true,
-		}
-		return gimlet.NewJSONResponse(existResult)
+	if len(perfResults) == 0 {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    "no perf results found",
+		})
 	}
-
-	return gimlet.MakeTextErrorResponder(errors.New("no perf results found"))
+	existResult := model.APIPerformanceResultExists{
+		NumberOfResults: len(perfResults),
+	}
+	return gimlet.NewJSONResponse(existResult)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/rest/perf_routes_test.go
+++ b/rest/perf_routes_test.go
@@ -107,14 +107,14 @@ func (s *PerfHandlerSuite) setup() {
 		"def": []string{"jkl"},
 	}
 	s.rh = map[string]gimlet.RouteHandler{
-		"id":             makeGetPerfById(&s.sc),
-		"remove":         makeRemovePerfById(&s.sc),
-		"task_id":        makeGetPerfByTaskId(&s.sc),
-		"task_id_exists": makeExistsPerfByTaskId(&s.sc),
-		"task_name":      makeGetPerfByTaskName(&s.sc),
-		"version":        makeGetPerfByVersion(&s.sc),
-		"children":       makeGetPerfChildren(&s.sc),
-		"change_points":  makePerfSignalProcessingRecalculate(&s.sc),
+		"id":            makeGetPerfById(&s.sc),
+		"remove":        makeRemovePerfById(&s.sc),
+		"task_id":       makeGetPerfByTaskId(&s.sc),
+		"task_id_count": makeCountPerfByTaskId(&s.sc),
+		"task_name":     makeGetPerfByTaskName(&s.sc),
+		"version":       makeGetPerfByVersion(&s.sc),
+		"children":      makeGetPerfChildren(&s.sc),
+		"change_points": makePerfSignalProcessingRecalculate(&s.sc),
 	}
 	s.apiResults = map[string]datamodel.APIPerformanceResult{}
 	for key, val := range s.sc.CachedPerformanceResults {
@@ -191,11 +191,11 @@ func (s *PerfHandlerSuite) TestPerfGetByTaskIdHandlerNotFound() {
 	s.NotEqual(http.StatusOK, resp.Status())
 }
 
-func (s *PerfHandlerSuite) TestPerfExistsByTaskIdHandlerFound() {
-	rh := s.rh["task_id_exists"]
-	rh.(*perfExistsByTaskIdHandler).opts.TaskID = "123"
-	rh.(*perfExistsByTaskIdHandler).opts.Tags = []string{"d"}
-	expected := datamodel.APIPerformanceResultExists{
+func (s *PerfHandlerSuite) TestPerfCountByTaskIdHandlerFound() {
+	rh := s.rh["task_id_count"]
+	rh.(*perfCountByTaskIdHandler).opts.TaskID = "123"
+	rh.(*perfCountByTaskIdHandler).opts.Tags = []string{"d"}
+	expected := datamodel.APIPerformanceResultCount{
 		NumberOfResults: 1,
 	}
 
@@ -206,9 +206,9 @@ func (s *PerfHandlerSuite) TestPerfExistsByTaskIdHandlerFound() {
 	s.Equal(expected, resp.Data())
 }
 
-func (s *PerfHandlerSuite) TestPerfExistsByTaskIdHandlerNotFound() {
-	rh := s.rh["task_id_exists"]
-	rh.(*perfExistsByTaskIdHandler).opts.TaskID = "555"
+func (s *PerfHandlerSuite) TestPerfCountByTaskIdHandlerNotFound() {
+	rh := s.rh["task_id_count"]
+	rh.(*perfCountByTaskIdHandler).opts.TaskID = "555"
 
 	resp := rh.Run(context.TODO())
 	s.Require().NotNil(resp)

--- a/rest/service.go
+++ b/rest/service.go
@@ -305,6 +305,7 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/perf/{id}").Version(1).Delete().Wrap(checkUser).RouteHandler(makeRemovePerfById(s.sc))
 	s.app.AddRoute("/perf/children/{id}").Version(1).Get().RouteHandler(makeGetPerfChildren(s.sc))
 	s.app.AddRoute("/perf/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetPerfByTaskId(s.sc))
+	s.app.AddRoute("/perf/task_id/{task_id}/exists").Version(1).Get().RouteHandler(makeExistsPerfByTaskId(s.sc))
 	s.app.AddRoute("/perf/task_name/{task_name}").Version(1).Get().RouteHandler(makeGetPerfByTaskName(s.sc))
 	s.app.AddRoute("/perf/version/{version}").Version(1).Get().RouteHandler(makeGetPerfByVersion(s.sc))
 

--- a/rest/service.go
+++ b/rest/service.go
@@ -305,7 +305,7 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/perf/{id}").Version(1).Delete().Wrap(checkUser).RouteHandler(makeRemovePerfById(s.sc))
 	s.app.AddRoute("/perf/children/{id}").Version(1).Get().RouteHandler(makeGetPerfChildren(s.sc))
 	s.app.AddRoute("/perf/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetPerfByTaskId(s.sc))
-	s.app.AddRoute("/perf/task_id/{task_id}/exists").Version(1).Get().RouteHandler(makeExistsPerfByTaskId(s.sc))
+	s.app.AddRoute("/perf/task_id/{task_id}/count").Version(1).Get().RouteHandler(makeCountPerfByTaskId(s.sc))
 	s.app.AddRoute("/perf/task_name/{task_name}").Version(1).Get().RouteHandler(makeGetPerfByTaskName(s.sc))
 	s.app.AddRoute("/perf/version/{version}").Version(1).Get().RouteHandler(makeGetPerfByVersion(s.sc))
 


### PR DESCRIPTION
This sends a shortened message iff perf results exists, otherwise returning a 404 error.