### PR TITLE
EVG-15514: Marshal the PerformanceArguments type to the BSON null value when empty

### DIFF
--- a/model/perf.go
+++ b/model/perf.go
@@ -348,7 +348,7 @@ func (args PerformanceArguments) MarshalBSON() ([]byte, error) {
 	// If the arguments map is empty or only has one item, we can just use
 	// the default marshaler.
 	if len(args) < 2 {
-		return bson.Marshal(args)
+		return bson.Marshal(map[string]int32(args))
 	}
 
 	sortedArgs := bson.D{}

--- a/model/perf.go
+++ b/model/perf.go
@@ -350,7 +350,8 @@ func (args PerformanceArguments) MarshalBSONValue() (bsontype.Type, []byte, erro
 	// implementation of the bson.ValueMarshaler (see
 	// `https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/bson/bsoncodec/default_value_encoders.go#L767`
 	// for more information), when it is nil we need to first cast it to a
-	// map[string]int32 and then call bson.MarshalValue.
+	// map[string]int32 and then call bson.MarshalValue to get the desired
+	// null BSON value.
 	if args == nil {
 		return bson.MarshalValue(map[string]int32(args))
 	}

--- a/model/perf.go
+++ b/model/perf.go
@@ -345,6 +345,12 @@ var (
 type PerformanceArguments map[string]int32
 
 func (args PerformanceArguments) MarshalBSON() ([]byte, error) {
+	// If the arguments map is empty or only has one item, we can just use
+	// the default marshaler.
+	if len(args) < 2 {
+		return bson.Marshal(args)
+	}
+
 	sortedArgs := bson.D{}
 	for key, value := range args {
 		sortedArgs = append(sortedArgs, bson.E{Key: key, Value: value})

--- a/model/perf.go
+++ b/model/perf.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -332,23 +333,26 @@ var (
 )
 
 // PerformanceArguments wraps map[string]int32 and implements the
-// bson.Marshaler interface in order to have a unified ordering of keys. BSON
-// objects are only equal if the key/value pairs match AND are in the same
+// bson.ValueMarshler interface in order to have a unified ordering of keys.
+// BSON objects are only equal if the key/value pairs match AND are in the same
 // order. Since maps are not ordered but still marshalled into BSON objects,
 // marshalling two equal Go maps into BSON can result in two BSON objects that
-// are not equal. By implementing the bson.Marshal interface, we are able to
-// first sort the keys of the map and convert the key/value pairs into a bson.D
-// object, where ordered is preserved.
+// are not equal. By implementing the bson.ValueMarshaler interface, we are
+// able to first sort the keys of the map and convert the key/value pairs into
+// a bson.D object, where ordered is preserved.
 //
 // See: `https://docs.mongodb.com/manual/reference/bson-type-comparison-order/#objects`
 // for more information.
 type PerformanceArguments map[string]int32
 
-func (args PerformanceArguments) MarshalBSON() ([]byte, error) {
-	// If the arguments map is empty or only has one item, we can just use
-	// the default marshaler.
-	if len(args) < 2 {
-		return bson.Marshal(map[string]int32(args))
+func (args PerformanceArguments) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	// Since PerformanceArguments is never recognized as a nil
+	// implementation of the bson.ValueMarshaler (see
+	// `https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/bson/bsoncodec/default_value_encoders.go#L767`
+	// for more information), when it is nil we need to first cast it to a
+	// map[string]int32 and then call bson.MarshalValue.
+	if args == nil {
+		return bson.MarshalValue(map[string]int32(args))
 	}
 
 	sortedArgs := bson.D{}
@@ -359,7 +363,7 @@ func (args PerformanceArguments) MarshalBSON() ([]byte, error) {
 		return sortedArgs[i].Key < sortedArgs[j].Key
 	})
 
-	return bson.Marshal(&sortedArgs)
+	return bson.MarshalValue(&sortedArgs)
 }
 
 // ID creates a unique hash for a performance result.


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15514

This is causing a bug where we try to look up perf results with no args but instead pass in `info.args: {}` to the query.