### PR TITLE
EVG-15478: disable cgo

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,6 +21,12 @@ export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
 
 export GO111MODULE := off
+ifneq (,$(RACE_DETECTOR))
+# cgo is required for using the race detector.
+export CGO_ENABLED=1
+else
+export CGO_ENABLED=0
+endif
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
@@ -45,7 +51,7 @@ $(buildDir)/run-benchmarks:cmd/run-benchmarks/run-benchmarks.go
 $(name): $(buildDir)/$(name)
 	@[ -e $@ ] || ln -s $<
 $(buildDir)/$(name): .FORCE
-	$(gobin) build -ldflags "-w -X github.com/evergreen-ci/cedar.BuildRevision=`git rev-parse HEAD`" -o $@ cmd/$(name)/$(name).go
+	$(gobin) build -ldflags "-w -X github.com/evergreen-ci/cedar.BuildRevision=`git rev-parse HEAD`" -trimpath -o $@ cmd/$(name)/$(name).go
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
 	@GOOS="" GOARCH="" $(gobin) build -o $@ $<
 distContents := $(buildDir)/$(name)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15478

Evergreen is compiled without cgo so it's preferable to test/compile without cgo in all repos to avoid discrepancies in behavior.

* Disable cgo.
* Compile Cedar with `-trimpath`.