### PR TITLE
EVG-15573: ensure cache environment variables are set and standardize test success check

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,7 +51,6 @@ $(shell mkdir -p $(buildDir))
 .DEFAULT_GOAL := $(name)
 
 # start lint setup targets
-lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
 	@curl  --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint $(buildDir)
@@ -147,7 +146,7 @@ ifneq (go,$(gobin))
 # binary in it, the linter won't work properly.
 lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
 endif
-$(buildDir)/output.%.lint: $(lintDeps) .FORCE
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
 	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15573

* Make sure that the cache environment variables are defined if they're unset. If the environment already explicitly defines them, then use those. Otherwise, fall back to caching within the build directory.
* Standardize the check for test success/failure.