### PR TITLE
EVG-14548 reformat stats logging

### DIFF
--- a/stats_cache.go
+++ b/stats_cache.go
@@ -122,9 +122,9 @@ func (s *statsCache) logStats() {
 		"message":    fmt.Sprintf("%s stats", s.cacheName),
 		"calls":      s.calls,
 		"total":      s.total,
-		"by_project": topNMap(s.byProject, topN),
-		"by_version": topNMap(s.byVersion, topN),
-		"by_task_id": topNMap(s.byTaskID, topN),
+		"by_project": topNItems(s.byProject, topN),
+		"by_version": topNItems(s.byVersion, topN),
+		"by_task_id": topNItems(s.byTaskID, topN),
 	})
 
 	s.resetCache()
@@ -141,24 +141,21 @@ func (s *statsCache) AddStat(newStat Stat) error {
 	}
 }
 
-func topNMap(fullMap map[string]int, n int) map[string]int {
-	type item struct {
-		identifier string
-		count      int
-	}
+type item struct {
+	Identifier string `json:"identifier"`
+	Count      int    `json:"count"`
+}
+
+func topNItems(fullMap map[string]int, n int) []item {
 	items := make([]item, 0, len(fullMap))
 	for identifier, count := range fullMap {
-		items = append(items, item{identifier: identifier, count: count})
+		items = append(items, item{Identifier: identifier, Count: count})
 	}
-	sort.Slice(items, func(i, j int) bool { return items[i].count > items[j].count })
+	sort.Slice(items, func(i, j int) bool { return items[i].Count > items[j].Count })
 
-	result := make(map[string]int, n)
-	for i, item := range items {
-		if i >= n {
-			break
-		}
-		result[item.identifier] = item.count
+	if len(items) < n {
+		n = len(items)
 	}
 
-	return result
+	return items[:n]
 }

--- a/stats_cache_test.go
+++ b/stats_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatsCache(t *testing.T) {
@@ -34,20 +35,20 @@ func TestStatsCache(t *testing.T) {
 		assert.Equal(t, cache.byVersion["abcdef"], 2)
 		assert.Equal(t, cache.byTaskID["t1"], 2)
 	})
-	t.Run("topNMap", func(t *testing.T) {
+	t.Run("topNItems", func(t *testing.T) {
 		t.Run("empty map", func(t *testing.T) {
-			assert.Empty(t, topNMap(map[string]int{}, 10))
+			assert.Empty(t, topNItems(map[string]int{}, 10))
 		})
 		t.Run("nil map", func(t *testing.T) {
-			assert.Empty(t, topNMap(nil, 10))
+			assert.Empty(t, topNItems(nil, 10))
 		})
 		t.Run("fewer than n", func(t *testing.T) {
 			fullMap := map[string]int{
 				"one": 1,
 			}
-			newMap := topNMap(fullMap, 10)
-			assert.Len(t, newMap, 1)
-			assert.Contains(t, newMap, "one")
+			items := topNItems(fullMap, 10)
+			require.Len(t, items, 1)
+			assert.Equal(t, items[0].Identifier, "one")
 		})
 		t.Run("greater than n", func(t *testing.T) {
 			fullMap := map[string]int{
@@ -55,10 +56,10 @@ func TestStatsCache(t *testing.T) {
 				"two":   2,
 				"three": 3,
 			}
-			newMap := topNMap(fullMap, 2)
-			assert.Len(t, newMap, 2)
-			assert.Contains(t, newMap, "two")
-			assert.Contains(t, newMap, "three")
+			items := topNItems(fullMap, 2)
+			require.Len(t, items, 2)
+			assert.Equal(t, items[0].Identifier, "three")
+			assert.Equal(t, items[1].Identifier, "two")
 		})
 	})
 }


### PR DESCRIPTION
[EVG-14548](https://jira.mongodb.org/browse/EVG-14548)

This changes the logging format from 
```
{
    "message": "",
...
    "by_project": {
          "project_1": 10000,
          "project_2": 341313,
...
     },
}
```

to 
```
{
    "message": "",
...
    "by_project": {
          {
              "identifier": "project_1",
              "count": 10000,
          },
          {
              "identifier": "project_2",
              "count": 341313,
          },
...
     },
}
```
This should make it more straightforward to sum them in Splunk. It has a nice side effect that the topN values are now sorted in descending order.

I tested the format [in staging](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22cedar-staging%22%20%22buildlogger%20stats%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1635192339&latest=1635192349.001&sid=1635192374.2733879).
It allows something like [this search](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22cedar-staging%22%20%22buildlogger%20stats%22%20%0A%7C%20spath%20%0A%7C%20rename%20by_project%7B%7D.identifier%20AS%20id%2C%20by_project%7B%7D.count%20AS%20count%20%0A%7C%20eval%20zip%3Dmvzip(id%2Ccount)%0A%7C%20fields%20_time%2Czip%7C%20mvexpand%20zip%7Ceval%20splitted%3Dsplit(zip%2C%22%2C%22)%7Ceval%20id%3Dmvindex(splitted%2C0)%7Ceval%20count%3Dmvindex(splitted%2C1)%0A%7C%20timechart%20sum(count)%20by%20id&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1635191995&latest=1635192595.001&display.page.search.tab=visualizations&display.general.type=visualizations&display.visualizations.charting.chart=line&sid=1635195492.2737483).