### PR TITLE
EVG-15611: Reduce buildlogger DB writes 

### DIFF
--- a/model/buildlogger.go
+++ b/model/buildlogger.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/evergreen-ci/cedar"
 	"github.com/evergreen-ci/pail"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
@@ -36,7 +35,7 @@ func CreateLog(info LogInfo, artifactStorageType PailType) *Log {
 		Artifact: LogArtifactInfo{
 			Type:    artifactStorageType,
 			Prefix:  info.ID(),
-			Version: 0,
+			Version: 1,
 		},
 		populated: true,
 	}
@@ -139,8 +138,7 @@ func (l *Log) Remove(ctx context.Context) error {
 }
 
 // Append uploads a chunk of log lines to the offline blob storage bucket
-// configured for the log and updates the metadata in the database to reflect
-// the uploaded lines. The environment should not be nil.
+// configured for the log. The environment should not be nil.
 func (l *Log) Append(ctx context.Context, lines []LogLine) error {
 	if l.env == nil {
 		return errors.New("cannot not append log lines with a nil environment")
@@ -153,7 +151,6 @@ func (l *Log) Append(ctx context.Context, lines []LogLine) error {
 		})
 		return nil
 	}
-	key := fmt.Sprint(utility.UnixMilli(time.Now()))
 
 	lineBuffer := &bytes.Buffer{}
 	for _, line := range lines {
@@ -166,14 +163,14 @@ func (l *Log) Append(ctx context.Context, lines []LogLine) error {
 
 		_, err := lineBuffer.WriteString(prependPriorityAndTimestamp(line.Priority, line.Timestamp, line.Data))
 		if err != nil {
-			return errors.Wrap(err, "problem buffering lines")
+			return errors.Wrap(err, "buffering lines")
 		}
 	}
 
 	conf := &CedarConfig{}
 	conf.Setup(l.env)
 	if err := conf.Find(); err != nil {
-		return errors.Wrap(err, "problem getting application configuration")
+		return errors.Wrap(err, "getting application configuration")
 	}
 	bucket, err := l.Artifact.Type.Create(
 		ctx,
@@ -184,20 +181,12 @@ func (l *Log) Append(ctx context.Context, lines []LogLine) error {
 		true,
 	)
 	if err != nil {
-		return errors.Wrap(err, "problem creating bucket")
-	}
-	if err := bucket.Put(ctx, key, lineBuffer); err != nil {
-		return errors.Wrap(err, "problem uploading log lines to bucket")
+		return errors.Wrap(err, "creating bucket")
 	}
 
-	info := LogChunkInfo{
-		Key:      key,
-		NumLines: len(lines),
-		Start:    lines[0].Timestamp,
-		End:      lines[len(lines)-1].Timestamp,
-	}
-	if err = l.appendLogChunkInfo(ctx, info); err != nil {
-		return errors.Wrap(err, "problem updating log metadata during upload")
+	key := createBuildloggerChunkKey(lines[0].Timestamp, lines[len(lines)-1].Timestamp, len(lines))
+	if err := bucket.Put(ctx, key, lineBuffer); err != nil {
+		return errors.Wrap(err, "uploading log lines to bucket")
 	}
 
 	l.addToStatsCache(lines)
@@ -225,40 +214,6 @@ func (l *Log) addToStatsCache(lines []LogLine) {
 			"cache":   cedar.StatsCacheBuildlogger,
 		}))
 	}
-}
-
-// appendLogChunkInfo adds a new log chunk to the log's chunks array in the
-// database. The environment should not be nil.
-func (l *Log) appendLogChunkInfo(ctx context.Context, logChunk LogChunkInfo) error {
-	if l.env == nil {
-		return errors.New("cannot append to a log with a nil environment")
-	}
-
-	if l.ID == "" {
-		l.ID = l.Info.ID()
-	}
-
-	updateResult, err := l.env.GetDB().Collection(buildloggerCollection).UpdateOne(
-		ctx,
-		bson.M{"_id": l.ID},
-		bson.M{
-			"$push": bson.M{
-				bsonutil.GetDottedKeyName(logArtifactKey, logArtifactInfoChunksKey): logChunk,
-			},
-		},
-	)
-	grip.DebugWhen(err == nil, message.Fields{
-		"collection":   buildloggerCollection,
-		"id":           l.ID,
-		"updateResult": updateResult,
-		"logChunkInfo": logChunk,
-		"op":           "append log chunk info to buildlogger log",
-	})
-	if err == nil && updateResult.MatchedCount == 0 {
-		err = errors.Errorf("could not find log record with id %s in the database", l.ID)
-	}
-
-	return errors.Wrapf(err, "problem appending log chunk info to %s", l.ID)
 }
 
 // Close "closes out" the log by populating the completed_at and info.exit_code
@@ -313,7 +268,7 @@ func (l *Log) Download(ctx context.Context, timeRange TimeRange) (LogIterator, e
 	conf := &CedarConfig{}
 	conf.Setup(l.env)
 	if err := conf.Find(); err != nil {
-		return nil, errors.Wrap(err, "problem getting application configuration")
+		return nil, errors.Wrap(err, "getting application configuration")
 	}
 
 	bucket, err := l.Artifact.Type.Create(
@@ -325,10 +280,47 @@ func (l *Log) Download(ctx context.Context, timeRange TimeRange) (LogIterator, e
 		false,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "problem creating bucket")
+		return nil, errors.Wrap(err, "creating bucket")
 	}
 
-	return NewBatchedLogIterator(bucket, l.Artifact.Chunks, 2, timeRange), nil
+	chunks, err := l.getChunks(ctx, bucket)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting chunks")
+	}
+
+	return NewBatchedLogIterator(bucket, chunks, 2, timeRange), nil
+}
+
+func (l *Log) getChunks(ctx context.Context, bucket pail.Bucket) ([]LogChunkInfo, error) {
+	var chunks []LogChunkInfo
+	switch l.Artifact.Version {
+	case 0:
+		chunks = l.Artifact.Chunks
+	case 1:
+		it, err := bucket.List(ctx, "")
+		if err != nil {
+			return nil, errors.Wrap(err, "listing chunks")
+		}
+
+		for it.Next(ctx) {
+			chunk, err := parseBuildloggerChunkKey(it.Item().Name())
+			if err != nil {
+				return nil, errors.Wrap(err, "parsing chunk key")
+			}
+			chunks = append(chunks, chunk)
+		}
+		if err = it.Err(); err != nil {
+			return nil, errors.Wrap(err, "iterating chunks")
+		}
+
+		sort.Slice(chunks, func(i, j int) bool {
+			return chunks[i].Start.Before(chunks[j].Start)
+		})
+	default:
+		return nil, errors.Errorf("invalid artifact version '%d'", l.Artifact.Version)
+	}
+
+	return chunks, nil
 }
 
 // LogInfo describes information unique to a single buildlogger log.

--- a/model/buildlogger_storage.go
+++ b/model/buildlogger_storage.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mongodb/anser/bsonutil"
@@ -62,3 +65,34 @@ var (
 	logLogChunkInfoStartKey    = bsonutil.MustHaveTag(LogChunkInfo{}, "Start")
 	logLogChunkInfoEndKey      = bsonutil.MustHaveTag(LogChunkInfo{}, "End")
 )
+
+func createBuildloggerChunkKey(start, end time.Time, numLines int) string {
+	return fmt.Sprintf("%d_%d_%d", start.UnixNano(), end.UnixNano(), numLines)
+}
+
+func parseBuildloggerChunkKey(key string) (LogChunkInfo, error) {
+	chunkInfo := strings.Split(key, "_")
+	if len(chunkInfo) != 3 {
+		return LogChunkInfo{}, errors.New("invalid buildlogger chunk key")
+	}
+
+	start, err := strconv.ParseInt(chunkInfo[0], 10, 64)
+	if err != nil {
+		return LogChunkInfo{}, errors.Wrap(err, "parsing buildlogger chunk start time")
+	}
+	end, err := strconv.ParseInt(chunkInfo[1], 10, 64)
+	if err != nil {
+		return LogChunkInfo{}, errors.Wrap(err, "parsing buildlogger chunk end time")
+	}
+	numLines, err := strconv.Atoi(chunkInfo[2])
+	if err != nil {
+		return LogChunkInfo{}, errors.Wrap(err, "parsing buildlogger chunk num lines")
+	}
+
+	return LogChunkInfo{
+		Key:      key,
+		NumLines: numLines,
+		Start:    time.Unix(0, start).UTC(),
+		End:      time.Unix(0, end).UTC(),
+	}, nil
+}

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -28,7 +29,7 @@ func TestCreateLog(t *testing.T) {
 	assert.True(t, time.Since(createdLog.CreatedAt) <= time.Second)
 	assert.Equal(t, PailS3, createdLog.Artifact.Type)
 	assert.Equal(t, log.ID, createdLog.Artifact.Prefix)
-	assert.Equal(t, 0, createdLog.Artifact.Version)
+	assert.Equal(t, 1, createdLog.Artifact.Version)
 	assert.True(t, createdLog.populated)
 }
 
@@ -149,92 +150,6 @@ func TestBuildloggerSaveNew(t *testing.T) {
 		}
 		l.Setup(env)
 		require.Error(t, l.SaveNew(ctx))
-	})
-}
-
-func TestBuildloggerAppendLogChunkInfo(t *testing.T) {
-	env := cedar.GetEnvironment()
-	db := env.GetDB()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	defer func() {
-		assert.NoError(t, db.Collection(buildloggerCollection).Drop(ctx))
-	}()
-	log1, log2 := getTestLogs(time.Now())
-
-	_, err := db.Collection(buildloggerCollection).InsertOne(ctx, log1)
-	require.NoError(t, err)
-	_, err = db.Collection(buildloggerCollection).InsertOne(ctx, log2)
-	require.NoError(t, err)
-
-	t.Run("NoEnv", func(t *testing.T) {
-		l := &Log{ID: log1.ID}
-		assert.Error(t, l.appendLogChunkInfo(ctx, LogChunkInfo{
-			Key:      "key",
-			NumLines: 100,
-		}))
-	})
-	t.Run("DNE", func(t *testing.T) {
-		l := &Log{ID: "DNE"}
-		l.Setup(env)
-		assert.Error(t, l.appendLogChunkInfo(ctx, LogChunkInfo{
-			Key:      "key",
-			NumLines: 100,
-		}))
-	})
-	t.Run("PushToEmptyArray", func(t *testing.T) {
-		chunks := []LogChunkInfo{
-			{
-				Key:      "key1",
-				NumLines: 100,
-				Start:    time.Date(2019, time.January, 1, 12, 0, 0, 0, time.UTC),
-				End:      time.Date(2019, time.January, 1, 13, 30, 0, 0, time.UTC),
-			},
-			{
-				Key:      "key2",
-				NumLines: 101,
-				Start:    time.Date(2019, time.January, 1, 13, 31, 0, 0, time.UTC),
-				End:      time.Date(2019, time.January, 1, 14, 31, 0, 0, time.UTC),
-			},
-		}
-		l := &Log{ID: log1.ID}
-		l.Setup(env)
-
-		require.NoError(t, l.appendLogChunkInfo(ctx, chunks[0]))
-		updatedLog := &Log{}
-		require.NoError(t, db.Collection(buildloggerCollection).FindOne(ctx, bson.M{"_id": log1.ID}).Decode(updatedLog))
-		assert.Equal(t, log1.ID, updatedLog.ID)
-		assert.Equal(t, log1.Info, updatedLog.Info)
-		assert.Equal(t, log1.Artifact.Prefix, updatedLog.Artifact.Prefix)
-		assert.Equal(t, log1.Artifact.Version, updatedLog.Artifact.Version)
-		assert.Equal(t, chunks[:1], updatedLog.Artifact.Chunks)
-
-		l.Setup(env)
-		require.NoError(t, l.appendLogChunkInfo(ctx, chunks[1]))
-		require.NoError(t, db.Collection(buildloggerCollection).FindOne(ctx, bson.M{"_id": log1.ID}).Decode(updatedLog))
-		assert.Equal(t, log1.ID, updatedLog.ID)
-		assert.Equal(t, log1.Info, updatedLog.Info)
-		assert.Equal(t, log1.Artifact.Prefix, updatedLog.Artifact.Prefix)
-		assert.Equal(t, log1.Artifact.Version, updatedLog.Artifact.Version)
-		assert.Equal(t, chunks, updatedLog.Artifact.Chunks)
-	})
-	t.Run("PushToExistingArray", func(t *testing.T) {
-		chunk := LogChunkInfo{
-			Key:      "key3",
-			NumLines: 1000,
-		}
-		l := &Log{ID: log2.ID}
-		l.Setup(env)
-
-		require.NoError(t, l.appendLogChunkInfo(ctx, chunk))
-		updatedLog := &Log{}
-		require.NoError(t, db.Collection(buildloggerCollection).FindOne(ctx, bson.M{"_id": log2.ID}).Decode(updatedLog))
-		assert.Equal(t, log2.ID, updatedLog.ID)
-		assert.Equal(t, log2.Info, updatedLog.Info)
-		assert.Equal(t, log2.Artifact.Prefix, updatedLog.Artifact.Prefix)
-		assert.Equal(t, log2.Artifact.Version, updatedLog.Artifact.Version)
-		assert.Equal(t, append(log2.Artifact.Chunks, chunk), updatedLog.Artifact.Chunks)
-
 	})
 }
 
@@ -360,7 +275,7 @@ func TestBuildloggerAppend(t *testing.T) {
 	require.NoError(t, conf.Find())
 	conf.Bucket.BuildLogsBucket = tmpDir
 	require.NoError(t, conf.Save())
-	t.Run("AppendToBucketAndDB", func(t *testing.T) {
+	t.Run("AppendToBucket", func(t *testing.T) {
 		log.Setup(env)
 		require.NoError(t, log.Append(ctx, chunk1))
 		// We need to sleep for a ms here to avoid a key name collision
@@ -392,17 +307,8 @@ func TestBuildloggerAppend(t *testing.T) {
 		}
 		assert.Equal(t, expectedData, actualData)
 		assert.Len(t, filenames, 2)
-
-		l := &Log{}
-		require.NoError(t, db.Collection(buildloggerCollection).FindOne(ctx, bson.M{"_id": log.Info.ID()}).Decode(l))
-		assert.Len(t, l.Artifact.Chunks, 2)
-		chunks := [][]LogLine{chunk1, chunk2}
-		for i, chunk := range l.Artifact.Chunks {
-			assert.True(t, filenames[chunk.Key])
-			assert.Equal(t, len(chunks[i]), chunk.NumLines)
-			assert.Equal(t, chunks[i][0].Timestamp, chunk.Start)
-			assert.Equal(t, chunks[i][len(chunks[i])-1].Timestamp, chunk.End)
-		}
+		assert.True(t, filenames[createBuildloggerChunkKey(chunk1[0].Timestamp, chunk1[len(chunk1)-1].Timestamp, len(chunk1))])
+		assert.True(t, filenames[createBuildloggerChunkKey(chunk2[0].Timestamp, chunk2[len(chunk2)-1].Timestamp, len(chunk2))])
 	})
 }
 
@@ -479,10 +385,13 @@ func TestBuildloggerDownload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		chunks, err := log2.getChunks(ctx, expectedBucket)
+		require.NoError(t, err)
+
 		rawIt, ok := it.(*batchedIterator)
 		require.True(t, ok)
 		assert.Equal(t, expectedBucket, rawIt.bucket)
-		assert.Equal(t, log2.Artifact.Chunks, rawIt.chunks)
+		assert.Equal(t, chunks, rawIt.chunks)
 		assert.Equal(t, timeRange, rawIt.timeRange)
 		assert.Equal(t, 2, rawIt.batchSize)
 		assert.False(t, rawIt.reverse)
@@ -507,16 +416,94 @@ func TestBuildloggerDownload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		chunks, err := log2.getChunks(ctx, expectedBucket)
+		require.NoError(t, err)
+
 		rawIt, ok := it.(*batchedIterator)
 		require.True(t, ok)
 		assert.Equal(t, expectedBucket, rawIt.bucket)
-		assert.Equal(t, log2.Artifact.Chunks, rawIt.chunks)
+		assert.Equal(t, chunks, rawIt.chunks)
 		assert.Equal(t, timeRange, rawIt.timeRange)
 		assert.Equal(t, 2, rawIt.batchSize)
 		assert.False(t, rawIt.reverse)
 		assert.NoError(t, it.Err())
 		assert.NoError(t, it.Close())
 	})
+}
+
+func TestBuildloggerGetChunks(t *testing.T) {
+	env := cedar.GetEnvironment()
+	db := env.GetDB()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tmpDir, err := ioutil.TempDir(".", "append-test")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(tmpDir))
+		assert.NoError(t, db.Collection(buildloggerCollection).Drop(ctx))
+		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
+	}()
+
+	log := Log{populated: true}
+	log.ID = log.Info.ID()
+	log.Artifact = LogArtifactInfo{
+		Type:    PailLocal,
+		Prefix:  log.Info.ID(),
+		Version: 1,
+	}
+	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: log.Artifact.Prefix})
+	require.NoError(t, err)
+	chunk1 := []LogLine{
+		{
+			Priority:  level.Debug,
+			Timestamp: time.Now().Add(-time.Hour).Round(time.Millisecond).UTC(),
+			Data:      "This is not a test.",
+		},
+		{
+			Priority:  level.Emergency,
+			Timestamp: time.Now().Add(-59 * time.Minute).Round(time.Millisecond).UTC(),
+			Data:      "This is a test.",
+		},
+	}
+	key1 := createBuildloggerChunkKey(chunk1[0].Timestamp, chunk1[len(chunk1)-1].Timestamp, len(chunk1))
+	require.NoError(t, testBucket.Put(ctx, key1, bytes.NewReader([]byte("some data"))))
+	chunk2 := []LogLine{
+		{
+			Priority:  level.Info,
+			Timestamp: time.Now().Add(-57 * time.Minute).Round(time.Millisecond).UTC(),
+			Data:      "Logging is fun.",
+		},
+		{
+			Priority:  level.Info,
+			Timestamp: time.Now().Add(-56 * time.Minute).Round(time.Millisecond).UTC(),
+			Data:      "Buildlogger logging logs.",
+		},
+
+		{
+			Priority:  level.Info,
+			Timestamp: time.Now().Add(-55 * time.Minute).Round(time.Millisecond).UTC(),
+			Data:      "Finished logging.",
+		},
+	}
+	key2 := createBuildloggerChunkKey(chunk2[0].Timestamp, chunk2[len(chunk2)-1].Timestamp, len(chunk2))
+	require.NoError(t, testBucket.Put(ctx, key2, bytes.NewReader([]byte("some more data"))))
+
+	chunks, err := log.getChunks(ctx, testBucket)
+	require.NoError(t, err)
+	assert.Equal(t, []LogChunkInfo{
+		{
+			Key:      key1,
+			NumLines: len(chunk1),
+			Start:    chunk1[0].Timestamp,
+			End:      chunk1[len(chunk1)-1].Timestamp,
+		},
+		{
+			Key:      key2,
+			NumLines: len(chunk2),
+			Start:    chunk2[0].Timestamp,
+			End:      chunk2[len(chunk2)-1].Timestamp,
+		},
+	}, chunks)
 }
 
 func TestBuildloggerClose(t *testing.T) {
@@ -1002,7 +989,7 @@ func getTestLogs(start time.Time) (*Log, *Log) {
 		Artifact: LogArtifactInfo{
 			Type:    PailLocal,
 			Prefix:  "log1",
-			Version: 1,
+			Version: 0,
 			Chunks: []LogChunkInfo{
 				{
 					Key:      "key1",

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -458,66 +457,14 @@ func TestBuildloggerGetChunks(t *testing.T) {
 		assert.Equal(t, log.Artifact.Chunks, chunks)
 	})
 	t.Run("ArtifactVersion1", func(t *testing.T) {
-		log := Log{populated: true}
-		log.ID = log.Info.ID()
-		log.Artifact = LogArtifactInfo{
-			Type:    PailLocal,
-			Prefix:  log.Info.ID(),
-			Version: 1,
-		}
-		testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: log.Artifact.Prefix})
+		log, _ := getTestLogs(time.Now())
+		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: log.Artifact.Prefix})
 		require.NoError(t, err)
-		chunk1 := []LogLine{
-			{
-				Priority:  level.Debug,
-				Timestamp: time.Now().Add(-time.Hour).Round(time.Millisecond).UTC(),
-				Data:      "This is not a test.",
-			},
-			{
-				Priority:  level.Emergency,
-				Timestamp: time.Now().Add(-59 * time.Minute).Round(time.Millisecond).UTC(),
-				Data:      "This is a test.",
-			},
-		}
-		key1 := createBuildloggerChunkKey(chunk1[0].Timestamp, chunk1[len(chunk1)-1].Timestamp, len(chunk1))
-		require.NoError(t, testBucket.Put(ctx, key1, bytes.NewReader([]byte("some data"))))
-		chunk2 := []LogLine{
-			{
-				Priority:  level.Info,
-				Timestamp: time.Now().Add(-57 * time.Minute).Round(time.Millisecond).UTC(),
-				Data:      "Logging is fun.",
-			},
-			{
-				Priority:  level.Info,
-				Timestamp: time.Now().Add(-56 * time.Minute).Round(time.Millisecond).UTC(),
-				Data:      "Buildlogger logging logs.",
-			},
+		chunks, _, err := GenerateTestLog(ctx, bucket, 100, 10)
 
-			{
-				Priority:  level.Info,
-				Timestamp: time.Now().Add(-55 * time.Minute).Round(time.Millisecond).UTC(),
-				Data:      "Finished logging.",
-			},
-		}
-		key2 := createBuildloggerChunkKey(chunk2[0].Timestamp, chunk2[len(chunk2)-1].Timestamp, len(chunk2))
-		require.NoError(t, testBucket.Put(ctx, key2, bytes.NewReader([]byte("some more data"))))
-
-		chunks, err := log.getChunks(ctx, testBucket)
+		bucketChunks, err := log.getChunks(ctx, bucket)
 		require.NoError(t, err)
-		assert.Equal(t, []LogChunkInfo{
-			{
-				Key:      key1,
-				NumLines: len(chunk1),
-				Start:    chunk1[0].Timestamp,
-				End:      chunk1[len(chunk1)-1].Timestamp,
-			},
-			{
-				Key:      key2,
-				NumLines: len(chunk2),
-				Start:    chunk2[0].Timestamp,
-				End:      chunk2[len(chunk2)-1].Timestamp,
-			},
-		}, chunks)
+		assert.Equal(t, chunks, bucketChunks)
 	})
 }
 

--- a/model/buildlogger_test.go
+++ b/model/buildlogger_test.go
@@ -461,6 +461,7 @@ func TestBuildloggerGetChunks(t *testing.T) {
 		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: log.Artifact.Prefix})
 		require.NoError(t, err)
 		chunks, _, err := GenerateTestLog(ctx, bucket, 100, 10)
+		require.NoError(t, err)
 
 		bucketChunks, err := log.getChunks(ctx, bucket)
 		require.NoError(t, err)

--- a/rpc/internal/buildlogger_service_test.go
+++ b/rpc/internal/buildlogger_service_test.go
@@ -271,9 +271,13 @@ func TestAppendLogLines(t *testing.T) {
 				l.Setup(env)
 				require.NoError(t, l.Find(ctx))
 				assert.Equal(t, log.ID, log.Info.ID())
-				assert.Len(t, l.Artifact.Chunks, 1)
-				_, err := bucket.Get(ctx, l.Artifact.Chunks[0].Key)
+				iter, err := bucket.List(ctx, "")
 				assert.NoError(t, err)
+				var chunkCount int
+				for iter.Next(ctx) {
+					chunkCount++
+				}
+				assert.Equal(t, 1, chunkCount)
 			}
 		})
 	}
@@ -510,12 +514,13 @@ func TestStreamLogLines(t *testing.T) {
 				l.Setup(env)
 				require.NoError(t, l.Find(ctx))
 				assert.Equal(t, log.ID, log.Info.ID())
-				assert.Len(t, l.Artifact.Chunks, len(test.lines))
-				for _, chunk := range l.Artifact.Chunks {
-					r, err := bucket.Get(ctx, chunk.Key)
-					assert.NoError(t, err)
-					assert.NoError(t, r.Close())
+				iter, err := bucket.List(ctx, "")
+				assert.NoError(t, err)
+				var chunkCount int
+				for iter.Next(ctx) {
+					chunkCount++
 				}
+				assert.Equal(t, len(test.lines), chunkCount)
 			}
 		})
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15611

Since we are now quite confident that Cedar's scaling issues are directly correlated to the sheer number of writes to the database, it would help for the short-term to reduce the number of writes. For buildlogger, which requires an update to each log document when a chunk of log lines are appended, the underlying architecture now just stores those chunks in s3 without updating the corresponding document. 

The chunk metadata `LogChunkInfo` is necessary for fetching logs: in it we store the start time, end time, and number of lines for each chunk. Now, that data is simply stored as the key for each chunk in s3 as `<start_time_unix_nano>_<end_time_unix_nano>_<num_lines>`. Using pail's `List` functionality, we can just list the filenames in a log's s3 directory, sort them by start time, and convert them into `[]LogChunkInfo`.

I tested this in staging.
