### PR TITLE
EVG-15612: set mongo driver max pool size to 1000

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -57,6 +57,7 @@ func NewEnvironment(ctx context.Context, name string, conf *Configuration) (Envi
 			SetConnectTimeout(conf.MongoDBDialTimeout).
 			SetSocketTimeout(conf.SocketTimeout).
 			SetServerSelectionTimeout(conf.SocketTimeout).
+			SetMaxPoolSize(1000).
 			SetMonitor(apm.NewLoggingMonitor(ctx, time.Minute, apm.NewBasicMonitor(&apm.MonitorConfig{AllTags: true})).DriverAPM())
 		if conf.HasAuth() {
 			credential := options.Credential{


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15612

The atlas cluster is currently an m200 tier, which has a max connection limit of 128k. Since certain loads can be write-heavy, we should increase the max connection pool size. The app servers each have a ulimit of 256k so they can also safely handle this. I picked 1000 kind of arbitrarily (the default is 100), but I think its enough, we can always increase if needed.