### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -43,7 +43,7 @@ functions:
       working_dir: cedar
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
       env:
         AUTH_USER: ${auth_user}
         AUTH_API_KEY: ${auth_api_key}
@@ -227,7 +227,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       RACE_DETECTOR: true
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.0.tgz
       GOROOT: /opt/golang/go1.16
@@ -240,7 +239,6 @@ buildvariants:
     display_name: Lint (Arch Linux)
     expansions:
       GOROOT: /opt/golang/go1.16
-      DISABLE_COVERAGE: true
     run_on:
       - archlinux-new-small
     tasks:
@@ -250,7 +248,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.0.tgz
       curator_build: linux-amd64
@@ -261,7 +258,6 @@ buildvariants:
   - name: macos
     display_name: macOS
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-4.2.0.tgz
       curator_build: darwin-amd64
@@ -278,7 +274,6 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       MONGODB_URL: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2012plus-4.2.0.zip
-      DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
       curator_build: windows-amd64
     tasks: [ "testGroup" ]

--- a/makefile
+++ b/makefile
@@ -123,9 +123,6 @@ lint-%:$(buildDir)/output.%.lint
 
 # start test and coverage artifacts
 testArgs := -v -timeout=20m
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif

--- a/makefile
+++ b/makefile
@@ -91,8 +91,8 @@ generate-points:$(buildDir)/generate-points
 testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
 lintOutput := $(foreach target,$(allPackages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
-.PRECIOUS: $(lintOutput) $(testOutput) $(coverageOutput) $(coverageHtmlOutput)
+htmlCoverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(lintOutput) $(testOutput) $(coverageOutput) $(htmlCoverageOutput)
 # end output files
 
 # start basic development targets
@@ -105,8 +105,8 @@ compile: $(buildDir)/$(name)
 benchmark: $(buildDir)/run-benchmarks .FORCE
 	./$(buildDir)/run-benchmarks
 coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
-phony += compile lint test coverage coverage-html proto benchmark
+html-coverage: $(htmlCoverageOutput)
+phony += compile lint test coverage html-coverage proto benchmark
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.