### PR TITLE
EVG-14303 adjust log level conditionally

### DIFF
--- a/rest/buildlogger_routes.go
+++ b/rest/buildlogger_routes.go
@@ -76,12 +76,12 @@ func (h *logGetByIDHandler) Run(ctx context.Context) gimlet.Responder {
 	data, next, paginated, err := h.sc.FindLogByID(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting log by id '%s'", h.opts.ID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/buildlogger/{id}",
 			"id":      h.opts.ID,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -121,12 +121,12 @@ func (h *logMetaGetByIDHandler) Run(ctx context.Context) gimlet.Responder {
 	apiLog, err := h.sc.FindLogMetadataByID(ctx, h.id)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting log metadata by id '%s'", h.id)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/buildlogger/{id}/meta",
 			"id":      h.id,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -194,12 +194,12 @@ func (h *logGetByTaskIDHandler) Run(ctx context.Context) gimlet.Responder {
 	data, next, paginated, err := h.sc.FindLogsByTaskID(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting logs by task id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/buildlogger/task_id/{task_id}",
 			"task_id": h.opts.TaskID,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -249,12 +249,12 @@ func (h *logMetaGetByTaskIDHandler) Run(ctx context.Context) gimlet.Responder {
 	apiLogs, err := h.sc.FindLogMetadataByTaskID(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting log metadata by task id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/buildlogger/task_id/{task_id}/meta",
 			"task_id": h.opts.TaskID,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -319,13 +319,13 @@ func (h *logGroupByTaskIDHandler) Run(ctx context.Context) gimlet.Responder {
 	data, next, paginated, err := h.sc.FindGroupedLogs(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting logs by task id '%s' and group id '%s'", h.opts.TaskID, h.opts.Group)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":  gimlet.GetRequestID(ctx),
 			"method":   "GET",
 			"route":    "/buildlogger/task_id/{task_id}/group/{group_id}",
 			"task_id":  h.opts.TaskID,
 			"group_id": h.opts.Group,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -390,13 +390,13 @@ func (h *logGetByTestNameHandler) Run(ctx context.Context) gimlet.Responder {
 	data, next, paginated, err := h.sc.FindLogsByTestName(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting logs by test name '%s'", h.opts.TestName)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":   gimlet.GetRequestID(ctx),
 			"method":    "GET",
 			"route":     "/buildlogger/test_name/{task_id}/{test_name}",
 			"task_id":   h.opts.TaskID,
 			"test_name": h.opts.TestName,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -447,13 +447,13 @@ func (h *logMetaGetByTestNameHandler) Run(ctx context.Context) gimlet.Responder 
 	testLogs, err := h.sc.FindLogMetadataByTestName(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting log metadata by test name '%s'", h.opts.TestName)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":   gimlet.GetRequestID(ctx),
 			"method":    "GET",
 			"route":     "/buildlogger/test_name/{task_id}/{test_name}/meta",
 			"task_id":   h.opts.TaskID,
 			"test_name": h.opts.TestName,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	h.opts.EmptyTestName = true
@@ -535,14 +535,14 @@ func (h *logGroupByTestNameHandler) Run(ctx context.Context) gimlet.Responder {
 		testLogs, err := h.sc.FindLogMetadataByTestName(ctx, h.opts)
 		if err != nil {
 			err = errors.Wrapf(err, "problem getting log metadata by test name '%s'", h.opts.TestName)
-			grip.Error(message.WrapError(err, message.Fields{
+			logFindError(err, message.Fields{
 				"request":   gimlet.GetRequestID(ctx),
 				"method":    "GET",
 				"route":     "/buildlogger/test_name/{task_id}/{test_name}/group/{group_id}",
 				"task_id":   h.opts.TaskID,
 				"test_name": h.opts.TestName,
 				"group_id":  h.opts.Group,
-			}))
+			})
 			return gimlet.MakeJSONErrorResponder(err)
 		}
 

--- a/rest/log_error.go
+++ b/rest/log_error.go
@@ -1,0 +1,18 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+)
+
+func logFindError(err error, fields message.Fields) {
+	logLevel := level.Error
+	if errResp, ok := err.(gimlet.ErrorResponse); ok && errResp.StatusCode == http.StatusNotFound {
+		logLevel = level.Info
+	}
+	grip.Log(logLevel, message.WrapError(err, fields))
+}

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -59,12 +59,12 @@ func (h *perfGetByIdHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResult, err := h.sc.FindPerformanceResultById(ctx, h.id)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance result by id '%s'", h.id)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/{id}",
 			"id":      h.id,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	return gimlet.NewJSONResponse(perfResult)
@@ -150,12 +150,12 @@ func (h *perfGetByTaskIdHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by task id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/task_id/{task_id}",
 			"task_id": h.opts.TaskID,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	return gimlet.NewJSONResponse(perfResults)
@@ -278,12 +278,12 @@ func (h *perfGetByTaskNameHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by task_name '%s'", h.opts.TaskName)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":   gimlet.GetRequestID(ctx),
 			"method":    "GET",
 			"route":     "/perf/task_name/{task_name}",
 			"task_name": h.opts.TaskName,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -343,12 +343,12 @@ func (h *perfGetByVersionHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance results by version '%s'", h.opts.Version)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/version/{version}",
 			"version": h.opts.Version,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -395,12 +395,12 @@ func (h *perfGetChildrenHandler) Run(ctx context.Context) gimlet.Responder {
 	perfResults, err := h.sc.FindPerformanceResultWithChildren(ctx, h.id, h.maxDepth, h.tags...)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting performance result and children by id '%s'", h.id)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/perf/children/{id}",
 			"id":      h.id,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	return gimlet.NewJSONResponse(perfResults)
@@ -434,11 +434,11 @@ func (h *perfSignalProcessingRecalculateHandler) Run(ctx context.Context) gimlet
 	err := h.sc.ScheduleSignalProcessingRecalculateJobs(ctx)
 	if err != nil {
 		err = errors.Wrapf(err, "Error scheduling signal processing recalculation jobs")
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "POST",
 			"route":   "/perf/change_points",
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	return gimlet.NewJSONResponse(struct{}{})

--- a/rest/system_metrics_routes.go
+++ b/rest/system_metrics_routes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/rest/data"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
@@ -72,13 +71,13 @@ func (h *systemMetricsGetByTypeHandler) Run(ctx context.Context) gimlet.Responde
 	data, nextIdx, err := h.sc.FindSystemMetricsByType(ctx, h.findOpts, h.downloadOpts)
 	if err != nil {
 		err = errors.Wrapf(err, "problem getting metric type '%s' for task id '%s'", h.downloadOpts.MetricType, h.findOpts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":     gimlet.GetRequestID(ctx),
 			"method":      "GET",
 			"route":       "/system_metrics/type/{task_id}/{type}",
 			"task_id":     h.findOpts.TaskID,
 			"metric_type": h.downloadOpts.MetricType,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 

--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -125,13 +125,13 @@ func (h *testResultsGetByTaskIDHandler) Run(ctx context.Context) gimlet.Responde
 	testResults, err := h.sc.FindTestResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "getting test results by task_id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":    gimlet.GetRequestID(ctx),
 			"method":     "GET",
 			"route":      "/test_results/task_id/{task_id}",
 			"task_id":    h.opts.TaskID,
 			"is_display": h.opts.DisplayTask,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
@@ -243,13 +243,13 @@ func (h *testResultsGetFailedSampleHandler) Run(ctx context.Context) gimlet.Resp
 	sample, err := h.sc.GetFailedTestResultsSample(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "getting failed test results sample by task_id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":         gimlet.GetRequestID(ctx),
 			"method":          "GET",
 			"route":           "/test_results/task_id/{task_id}/failed_sample",
 			"task_id":         h.opts.TaskID,
 			"is_display_task": h.opts.DisplayTask,
-		}))
+		})
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
@@ -283,13 +283,13 @@ func (h *testResultsGetStatsHandler) Run(ctx context.Context) gimlet.Responder {
 	stats, err := h.sc.GetTestResultsStats(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "getting test results stats by task_id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":         gimlet.GetRequestID(ctx),
 			"method":          "GET",
 			"route":           "/test_results/task_id/{task_id}/stats",
 			"task_id":         h.opts.TaskID,
 			"is_display_task": h.opts.DisplayTask,
-		}))
+		})
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
@@ -341,12 +341,12 @@ func (h *testResultsGetByDisplayTaskIDHandler) Run(ctx context.Context) gimlet.R
 	testResults, err := h.sc.FindTestResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "getting test results by display_task_id '%s'", h.opts.TaskID)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "GET",
 			"route":   "/test_results/display_task_id/{display_task_id}",
 			"task_id": h.opts.TaskID,
-		}))
+		})
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	return gimlet.NewJSONResponse(testResults.Results)
@@ -398,13 +398,13 @@ func (h *testResultGetByTestNameHandler) Run(ctx context.Context) gimlet.Respond
 	testResults, err := h.sc.FindTestResults(ctx, h.opts)
 	if err != nil {
 		err = errors.Wrapf(err, "getting test result by task_id '%s' and test_name '%s'", h.opts.TaskID, h.opts.FilterAndSort.TestName)
-		grip.Error(message.WrapError(err, message.Fields{
+		logFindError(err, message.Fields{
 			"request":   gimlet.GetRequestID(ctx),
 			"method":    "GET",
 			"route":     "/test_results/test_name/{task_id}/{test_name}",
 			"task_id":   h.opts.TaskID,
 			"test_name": h.opts.FilterAndSort.TestName,
-		}))
+		})
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-14303

Wrap all the rest/route level `grip.Error`s in a function that lowers the log level for 404s.
I figured we still need to return the 404s (like Kim's https://github.com/evergreen-ci/cedar/pull/410#discussion_r747814999) but it's not really an _error_ so the `Info` level makes more sense.