### PR TITLE
EVG-15587: verify that test results are produced

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -10,6 +10,7 @@ variables:
     # runs a build operations. The task name in evergreen should
     # correspond to a make target for the build operation.
     name: test
+    must_have_test_results: true
     commands:
       - func: run-make
         vars: { target: "${task_name}" }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15587

Since the `must_have_test_results` flag is available, we should confirm that our `test-` and `lint-` tasks actually produce test results.