### PR TITLE
EVG-15729 use pointer to route options

### DIFF
--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -193,7 +193,7 @@ func (h *testResultsGetFilteredSamplesHandler) Parse(_ context.Context, r *http.
 	body := utility.NewRequestReader(r)
 	defer body.Close()
 
-	if err := utility.ReadJSON(body, h.options); err != nil {
+	if err := utility.ReadJSON(body, &h.options); err != nil {
 		return errors.Wrap(err, "argument read error")
 	}
 


### PR DESCRIPTION
[EVG-15729](https://jira.mongodb.org/browse/EVG-15729)

We need to pass in a pointer so the arguments will be read into it.