### PR TITLE
EVG-15449: use Dependabot for automated dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "10:00"
+    open-pull-requests-limit: 99
+    commit-message:
+      prefix: "CHORE: "
+    reviewers:
+      - kimchelly

--- a/makefile
+++ b/makefile
@@ -189,7 +189,7 @@ phony += get-mongodb start-mongod init-rs check-mongod
 
 # start cleanup targts
 clean:
-	rm -rf *.pb.go $(buildDir)
+	rm -rf *.pb.go $(name) $(buildDir)
 clean-results:
 	rm -rf $(buildDir)/output.*
 phony += clean


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15449

This enables Dependabot automatic upgrades for Go modules. Dependabot will periodically check all dependencies in `go.mod` for newer stable versions (it doesn't upgrade unversioned repos) and bump them if there's a newer one available. This initial merge will also trigger Dependabot to do an immediate check for new dependency versions, so merging this may trigger other Dependabot PRs to be opened.

* Check for updates monthly to make it minimally annoying.
* Increase the open PR limit from the default of 5. It's preferable to get all the available upgrades ASAP rather than have Dependabot incrementally give us a subset of all the available updates.
* I set myself as the reviewer on all the Dependabot PRs and merge the ones that appear every month. If they pass CI tests, they'll be merged. If not, I'll open tickets to triage, investigate, and fix so that we can upgrade.