### PR TITLE
EVG-16037: Only send time series IDs to signal process service

### DIFF
--- a/model/perf.go
+++ b/model/perf.go
@@ -64,7 +64,7 @@ var (
 )
 
 // CreateUnanalyzedSeries converts the PerformanceResult into an
-// UnanalyzedPerformanceSeries for comminication with the signal processing
+// UnanalyzedPerformanceSeries for communication with the signal processing
 // service.
 func (result PerformanceResult) CreateUnanalyzedSeries() UnanalyzedPerformanceSeries {
 	measurements := make([]string, len(result.Rollups.Stats))

--- a/model/perf.go
+++ b/model/perf.go
@@ -7,6 +7,7 @@ import (
 	"hash"
 	"io"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/cedar"
@@ -392,6 +393,18 @@ func (args PerformanceArguments) MarshalBSONValue() (bsontype.Type, []byte, erro
 	})
 
 	return bson.MarshalValue(&sortedArgs)
+}
+
+func (args PerformanceArguments) String() string {
+	var sortedArgs []string
+	for key, value := range args {
+		sortedArgs = append(sortedArgs, fmt.Sprintf("%s:%d", key, value))
+	}
+	sort.Slice(sortedArgs, func(i, j int) bool {
+		return sortedArgs[i] < sortedArgs[j]
+	})
+
+	return fmt.Sprintf("[%s]", strings.Join(sortedArgs, " "))
 }
 
 // ID creates a unique hash for a performance result.

--- a/model/perf.go
+++ b/model/perf.go
@@ -73,11 +73,12 @@ func (result PerformanceResult) CreateUnanalyzedSeries() UnanalyzedPerformanceSe
 	}
 
 	return UnanalyzedPerformanceSeries{
-		Project:   result.Info.Project,
-		Variant:   result.Info.Variant,
-		Task:      result.Info.TaskName,
-		Test:      result.Info.TestName,
-		Arguments: result.Info.Arguments,
+		Project:      result.Info.Project,
+		Variant:      result.Info.Variant,
+		Task:         result.Info.TaskName,
+		Test:         result.Info.TestName,
+		Arguments:    result.Info.Arguments,
+		Measurements: measurements,
 	}
 }
 

--- a/model/perf.go
+++ b/model/perf.go
@@ -63,12 +63,21 @@ var (
 	perfVersionKey           = bsonutil.MustHaveTag(PerformanceResult{}, "Version")
 )
 
-func (info *PerformanceResultInfo) ToPerformanceResultSeriesID() PerformanceResultSeriesID {
-	return PerformanceResultSeriesID{
-		Project: info.Project,
-		Variant: info.Variant,
-		Task:    info.TaskName,
-		Test:    info.TestName,
+// CreateUnanalyzedSeries converts the PerformanceResult into an
+// UnanalyzedPerformanceSeries for comminication with the signal processing
+// service.
+func (result PerformanceResult) CreateUnanalyzedSeries() UnanalyzedPerformanceSeries {
+	measurements := make([]string, len(result.Rollups.Stats))
+	for i, stat := range result.Rollups.Stats {
+		measurements[i] = stat.Name
+	}
+
+	return UnanalyzedPerformanceSeries{
+		Project:   result.Info.Project,
+		Variant:   result.Info.Variant,
+		Task:      result.Info.TaskName,
+		Test:      result.Info.TestName,
+		Arguments: result.Info.Arguments,
 	}
 }
 
@@ -317,7 +326,6 @@ func (result *PerformanceResult) Close(ctx context.Context, completedAt time.Tim
 	}
 
 	return errors.Wrapf(err, "problem closing performance result with id %s", result.ID)
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/model/perf_test.go
+++ b/model/perf_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -455,6 +456,33 @@ func TestPerformanceArgumentsBSONMarshalValue(t *testing.T) {
 		require.NoError(t, bson.Unmarshal(data, &out))
 		assert.Nil(t, out.Arguments)
 	})
+}
+
+func TestPerformanceArgumentsStringer(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		args     PerformanceArguments
+		expected string
+	}{
+		{
+			name:     "UnsortedArguments",
+			args:     PerformanceArguments{"spruce": 2, "evergreen": 0, "cedar": 1},
+			expected: "[cedar:1 evergreen:0 spruce:2]",
+		},
+		{
+			name:     "EmptyArguments",
+			args:     PerformanceArguments{},
+			expected: "[]",
+		},
+		{
+			name:     "NilArguments",
+			expected: "[]",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, fmt.Sprintf("%s", test.args))
+		})
+	}
 }
 
 func getTestPerformanceResults() (*PerformanceResult, *PerformanceResult) {

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -29,7 +29,7 @@ type PerformanceResultSeriesID struct {
 	Task        string               `bson:"task"`
 	Test        string               `bson:"test"`
 	Measurement string               `bson:"measurement"`
-	Arguments   PerformanceArguments `bson:"args,omitempty"`
+	Arguments   PerformanceArguments `bson:"args"`
 }
 
 // String creates a string representation of a performance result series ID.
@@ -68,9 +68,18 @@ type UnanalyzedPerformanceSeries struct {
 	Variant      string               `bson:"variant"`
 	Task         string               `bson:"task"`
 	Test         string               `bson:"test"`
-	Measurements []string             `bson:"measurement"`
-	Arguments    PerformanceArguments `bson:"args,omitempty"`
+	Measurements []string             `bson:"measurements"`
+	Arguments    PerformanceArguments `bson:"args"`
 }
+
+var (
+	unanalyzedPerformanceSeriesProjectKey      = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Project")
+	unanalyzedPerformanceSeriesVariantKey      = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Variant")
+	unanalyzedPerformanceSeriesTaskKey         = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Task")
+	unanalyzedPerformanceSeriesTestKey         = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Test")
+	unanalyzedPerformanceSeriesMeasurementsKey = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Measurements")
+	unanalyzedPerformanceSeriesArgumentsKey    = bsonutil.MustHaveTag(UnanalyzedPerformanceSeries{}, "Arguments")
+)
 
 // CreateBaseSeriesID returns a PerformanceSeriesID without a measurement.
 func (s UnanalyzedPerformanceSeries) CreateBaseSeriesID() PerformanceResultSeriesID {
@@ -139,13 +148,13 @@ func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) 
 		{
 			"$group": bson.M{
 				"_id": bson.M{
-					"project": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
-					"variant": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
-					"task":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
-					"test":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
-					"args":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
+					unanalyzedPerformanceSeriesProjectKey:   "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
+					unanalyzedPerformanceSeriesVariantKey:   "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
+					unanalyzedPerformanceSeriesTaskKey:      "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
+					unanalyzedPerformanceSeriesTestKey:      "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
+					unanalyzedPerformanceSeriesArgumentsKey: "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
 				},
-				"measurements": bson.M{
+				unanalyzedPerformanceSeriesMeasurementsKey: bson.M{
 					"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
 				},
 			},
@@ -159,12 +168,12 @@ func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) 
 		{
 			"$replaceRoot": bson.M{
 				"newRoot": bson.M{
-					"project":      "$" + "_id.project",
-					"variant":      "$" + "_id.variant",
-					"task":         "$" + "_id.task",
-					"test":         "$" + "_id.test",
-					"args":         "$" + "_id.args",
-					"measurements": "$" + "measurements",
+					unanalyzedPerformanceSeriesProjectKey:      "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesProjectKey),
+					unanalyzedPerformanceSeriesVariantKey:      "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesVariantKey),
+					unanalyzedPerformanceSeriesTaskKey:         "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesTaskKey),
+					unanalyzedPerformanceSeriesTestKey:         "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesTestKey),
+					unanalyzedPerformanceSeriesArgumentsKey:    "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesArgumentsKey),
+					unanalyzedPerformanceSeriesMeasurementsKey: "$" + unanalyzedPerformanceSeriesMeasurementsKey,
 				},
 			},
 		},
@@ -202,13 +211,13 @@ func GetAllPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment
 		{
 			"$group": bson.M{
 				"_id": bson.M{
-					"project": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
-					"variant": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
-					"task":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
-					"test":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
-					"args":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
+					unanalyzedPerformanceSeriesProjectKey:   "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
+					unanalyzedPerformanceSeriesVariantKey:   "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
+					unanalyzedPerformanceSeriesTaskKey:      "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
+					unanalyzedPerformanceSeriesTestKey:      "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
+					unanalyzedPerformanceSeriesArgumentsKey: "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
 				},
-				"measurements": bson.M{
+				unanalyzedPerformanceSeriesMeasurementsKey: bson.M{
 					"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
 				},
 			},
@@ -216,12 +225,12 @@ func GetAllPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment
 		{
 			"$replaceRoot": bson.M{
 				"newRoot": bson.M{
-					"project":      "$" + "_id.project",
-					"variant":      "$" + "_id.variant",
-					"task":         "$" + "_id.task",
-					"test":         "$" + "_id.test",
-					"args":         "$" + "_id.args",
-					"measurements": "$" + "measurements",
+					unanalyzedPerformanceSeriesProjectKey:      "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesProjectKey),
+					unanalyzedPerformanceSeriesVariantKey:      "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesVariantKey),
+					unanalyzedPerformanceSeriesTaskKey:         "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesTaskKey),
+					unanalyzedPerformanceSeriesTestKey:         "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesTestKey),
+					unanalyzedPerformanceSeriesArgumentsKey:    "$" + bsonutil.GetDottedKeyName("_id", unanalyzedPerformanceSeriesArgumentsKey),
+					unanalyzedPerformanceSeriesMeasurementsKey: "$" + unanalyzedPerformanceSeriesMeasurementsKey,
 				},
 			},
 		},

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -133,7 +133,7 @@ func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) 
 		},
 		{
 			"$unwind": bson.M{
-				"path": bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey),
+				"path": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey),
 			},
 		},
 		{
@@ -208,9 +208,9 @@ func GetAllPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment
 					"test":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
 					"args":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
 				},
-			},
-			"measurements": bson.M{
-				"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
+				"measurements": bson.M{
+					"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
+				},
 			},
 		},
 		{

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -34,25 +34,7 @@ type PerformanceResultSeriesID struct {
 
 // String creates a string representation of a performance result series ID.
 func (p PerformanceResultSeriesID) String() string {
-	return fmt.Sprintf("%s %s %s %s %v", p.Project, p.Variant, p.Task, p.Test, p.Arguments)
-}
-
-// TimeSeriesEntry represents information about a single performance result in
-// a series.
-type TimeSeriesEntry struct {
-	PerfResultID string  `bson:"perf_result_id"`
-	Value        float64 `bson:"value"`
-	Order        int     `bson:"order"`
-	Version      string  `bson:"version"`
-	TaskID       string  `bson:"task_id"`
-	Execution    int     `bson:"execution"`
-}
-
-// PerformanceData represents information about a performance result series and
-// its associated measurement data.
-type PerformanceData struct {
-	PerformanceResultId PerformanceResultSeriesID `bson:"_id"`
-	TimeSeries          []TimeSeriesEntry         `bson:"time_series"`
+	return fmt.Sprintf("%s %s %s %s %s", p.Project, p.Variant, p.Task, p.Test, p.Arguments)
 }
 
 // MarkPerformanceResultsAsAnalyzed marks all the performance results with the
@@ -78,10 +60,50 @@ func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment
 	return nil
 }
 
-// GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate queries the database
-// and gets all the performance result series IDs that contain results that
-// have not yet been analyzed.
-func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, env cedar.Environment) ([]PerformanceResultSeriesID, error) {
+// UnanalyzedPerformanceSeries represents a set of series with the same
+// project/variant/task/test/args combination and varying measurements that
+// need to be analyzed by the signal processing service.
+type UnanalyzedPerformanceSeries struct {
+	Project      string               `bson:"project"`
+	Variant      string               `bson:"variant"`
+	Task         string               `bson:"task"`
+	Test         string               `bson:"test"`
+	Measurements []string             `bson:"measurement"`
+	Arguments    PerformanceArguments `bson:"args,omitempty"`
+}
+
+// CreateBaseSeriesID returns a PerformanceSeriesID without a measurement.
+func (s UnanalyzedPerformanceSeries) CreateBaseSeriesID() PerformanceResultSeriesID {
+	return PerformanceResultSeriesID{
+		Project:   s.Project,
+		Variant:   s.Variant,
+		Task:      s.Task,
+		Test:      s.Test,
+		Arguments: s.Arguments,
+	}
+}
+
+// CreateSeriesIDs unwinds the Measurements slice to create an individual
+// PerformanceResultSeriesID for each measurement.
+func (s UnanalyzedPerformanceSeries) CreateSeriesIDs() []PerformanceResultSeriesID {
+	ids := make([]PerformanceResultSeriesID, len(s.Measurements))
+	for i, measurement := range s.Measurements {
+		ids[i] = PerformanceResultSeriesID{
+			Project:     s.Project,
+			Variant:     s.Variant,
+			Task:        s.Task,
+			Test:        s.Test,
+			Measurement: measurement,
+			Arguments:   s.Arguments,
+		}
+	}
+
+	return ids
+}
+
+// GetUnanalyzedPerformanceSeries queries the database and gets all the
+// performance series that contain results that have not yet been analyzed.
+func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) ([]UnanalyzedPerformanceSeries, error) {
 	cur, err := env.GetDB().Collection(perfResultCollection).Aggregate(ctx, []bson.M{
 		{
 			"$match": bson.M{
@@ -110,12 +132,21 @@ func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, e
 			"$limit": 1000,
 		},
 		{
+			"$unwind": bson.M{
+				"path": bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey),
+			},
+		},
+		{
 			"$group": bson.M{
 				"_id": bson.M{
 					"project": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey),
 					"variant": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
 					"task":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
 					"test":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
+					"args":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
+				},
+				"measurements": bson.M{
+					"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
 				},
 			},
 		},
@@ -127,7 +158,14 @@ func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, e
 		},
 		{
 			"$replaceRoot": bson.M{
-				"newRoot": "$_id",
+				"newRoot": bson.M{
+					"project":      "$" + "_id.project",
+					"variant":      "$" + "_id.variant",
+					"task":         "$" + "_id.task",
+					"test":         "$" + "_id.test",
+					"args":         "$" + "_id.args",
+					"measurements": "$" + "measurements",
+				},
 			},
 		},
 	})
@@ -135,7 +173,7 @@ func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, e
 		return nil, errors.Wrapf(err, "getting metrics needing change point detection")
 	}
 	defer cur.Close(ctx)
-	var res []PerformanceResultSeriesID
+	var res []UnanalyzedPerformanceSeries
 	err = cur.All(ctx, &res)
 	if err != nil {
 		return nil, errors.Wrapf(err, "decoding metrics needing change results")
@@ -143,9 +181,9 @@ func GetPerformanceResultSeriesIdsNeedingTimeSeriesUpdate(ctx context.Context, e
 	return res, nil
 }
 
-// GetPerformanceResultSeriesIDs finds all performance result series IDs in the
-// the database.
-func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) ([]PerformanceResultSeriesID, error) {
+// GetAllPerformanceResultSeriesIDs finds all performance result series in the
+// database.
+func GetAllPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) ([]UnanalyzedPerformanceSeries, error) {
 	cur, err := env.GetDB().Collection(perfResultCollection).Aggregate(ctx, []bson.M{
 		{
 			"$match": bson.M{
@@ -155,6 +193,7 @@ func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) (
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey): true,
+				bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey):    bson.M{"$not": bson.M{"$size": 0}},
 			},
 		},
 		{
@@ -167,12 +206,23 @@ func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) (
 					"variant": "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey),
 					"task":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey),
 					"test":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey),
+					"args":    "$" + bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey),
 				},
+			},
+			"measurements": bson.M{
+				"$addToSet": "$" + bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey),
 			},
 		},
 		{
 			"$replaceRoot": bson.M{
-				"newRoot": "$_id",
+				"newRoot": bson.M{
+					"project":      "$" + "_id.project",
+					"variant":      "$" + "_id.variant",
+					"task":         "$" + "_id.task",
+					"test":         "$" + "_id.test",
+					"args":         "$" + "_id.args",
+					"measurements": "$" + "measurements",
+				},
 			},
 		},
 	})
@@ -180,7 +230,7 @@ func GetPerformanceResultSeriesIDs(ctx context.Context, env cedar.Environment) (
 		return nil, errors.Wrap(err, "aggregating time series ids")
 	}
 	defer cur.Close(ctx)
-	var res []PerformanceResultSeriesID
+	var res []UnanalyzedPerformanceSeries
 	err = cur.All(ctx, &res)
 	if err != nil {
 		return nil, errors.Wrap(err, "decoding time series ids")

--- a/perf/time_series_updater.go
+++ b/perf/time_series_updater.go
@@ -15,33 +15,25 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TimeSeriesModel is the representation of the meta information that makes up
+// a time series.
+type TimeSeriesModel struct {
+	Project     string           `json:"project"`
+	Variant     string           `json:"variant"`
+	Task        string           `json:"task"`
+	Test        string           `json:"test"`
+	Measurement string           `json:"measurement"`
+	Arguments   []ArgumentsModel `json:"args"`
+}
+
 // ArgumentsModel is the structure of an arbitrary argument of a TimeSeries.
 type ArgumentsModel struct {
 	Name  string      `json:"name"`
 	Value interface{} `json:"value"`
 }
 
-// TimeSeriesDataModel is a single data point on a time series.
-type TimeSeriesDataModel struct {
-	PerformanceResultID string  `json:"cedar_perf_result_id"`
-	Order               int     `json:"order"`
-	Value               float64 `json:"value"`
-	Version             string  `json:"version"`
-	Execution           int     `json:"execution"`
-}
-
-// TimeSeriesModel is the representation of the meta information and data points that make up a time series.
-type TimeSeriesModel struct {
-	Project     string                `json:"project"`
-	Variant     string                `json:"variant"`
-	Task        string                `json:"task"`
-	Test        string                `json:"test"`
-	Measurement string                `json:"measurement"`
-	Arguments   []ArgumentsModel      `json:"args"`
-	Data        []TimeSeriesDataModel `json:"data"`
-}
-
-// PerformanceAnalysisService is the interface for the Performance Analysis Service.
+// PerformanceAnalysisService is the interface for the Performance Analysis
+// Service.
 type PerformanceAnalysisService interface {
 	ReportUpdatedTimeSeries(context.Context, TimeSeriesModel) error
 }
@@ -57,7 +49,8 @@ func NewPerformanceAnalysisService(baseURL, user string, token string) Performan
 	return &performanceAnalysisAndTriageClient{user: user, token: token, baseURL: baseURL}
 }
 
-// ReportUpdatedTimeSeries takes a TimeSeriesModel and tries to report its data to a PerformanceAnalysisService.
+// ReportUpdatedTimeSeries takes a TimeSeriesModel and tries to report its data
+// to a PerformanceAnalysisService.
 func (spc *performanceAnalysisAndTriageClient) ReportUpdatedTimeSeries(ctx context.Context, series TimeSeriesModel) error {
 	startAt := time.Now()
 
@@ -66,7 +59,7 @@ func (spc *performanceAnalysisAndTriageClient) ReportUpdatedTimeSeries(ctx conte
 	}
 
 	grip.Debug(message.Fields{
-		"message":       "Reported updated time series to performance analysis and triage service",
+		"message":       "reported updated time series to performance analysis and triage service",
 		"update":        series,
 		"duration_secs": time.Since(startAt).Seconds(),
 	})
@@ -93,7 +86,8 @@ func (spc *performanceAnalysisAndTriageClient) doRequest(method, route string, c
 			http.MethodPatch,
 		},
 		Statuses: []int{
-			// status code for timeouts from ELB in AWS (Kanopy infrastructure)
+			// Status code for timeouts from ELB in AWS
+			// (Kanopy infrastructure).
 			499,
 			http.StatusBadGateway,
 			http.StatusServiceUnavailable,
@@ -105,8 +99,9 @@ func (spc *performanceAnalysisAndTriageClient) doRequest(method, route string, c
 			http.StatusExpectationFailed,
 		},
 		Errors: []error{
-			// If a connection gets cut by the ELB, sometimes the client doesn't get an actual error
-			// The client only receives a nil body leading to an EOF
+			// If a connection gets cut by the ELB, sometimes the
+			// client doesn't get an actual error The client only
+			// receives a nil body leading to an EOF.
 			io.EOF,
 		},
 	}
@@ -129,12 +124,12 @@ func (spc *performanceAnalysisAndTriageClient) doRequest(method, route string, c
 
 	if resp.StatusCode != 200 {
 		grip.Warning(message.Fields{
-			"message":   "Failed to report time series update to performance analysis and triage service",
+			"message":   "failed to report time series update to performance analysis and triage service",
 			"status":    http.StatusText(resp.StatusCode),
 			"url":       route,
 			"auth_user": spc.user,
 		})
-		return errors.Errorf("Failed to report time series update to performance analysis and triage service, status: %q, url: %q, auth_user: %q", http.StatusText(resp.StatusCode), route, spc.user)
+		return errors.Errorf("failed to report time series update to performance analysis and triage service, status: %q, url: %q, auth_user: %q", http.StatusText(resp.StatusCode), route, spc.user)
 	}
 	return nil
 }

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -178,14 +178,14 @@ func (dbc *DBConnector) ScheduleSignalProcessingRecalculateJobs(ctx context.Cont
 		job := units.NewUpdateTimeSeriesJob(series)
 		err := amboy.EnqueueUniqueJob(ctx, queue, job)
 		if err != nil {
-			catcher.Add(errors.New(message.WrapError(err, message.Fields{
+			catcher.Add(message.WrapError(err, message.Fields{
 				"message": "Unable to enqueue recalculation job for metric",
 				"project": series.Project,
 				"variant": series.Variant,
 				"task":    series.Task,
 				"test":    series.Test,
 				"args":    series.Arguments,
-			}).String()))
+			}))
 		}
 	}
 	return catcher.Resolve()

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -179,7 +179,7 @@ func (dbc *DBConnector) ScheduleSignalProcessingRecalculateJobs(ctx context.Cont
 		err := amboy.EnqueueUniqueJob(ctx, queue, job)
 		if err != nil {
 			catcher.Add(message.WrapError(err, message.Fields{
-				"message": "Unable to enqueue recalculation job for metric",
+				"message": "unable to enqueue recalculation job for metric",
 				"project": series.Project,
 				"variant": series.Variant,
 				"task":    series.Task,

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -176,8 +176,7 @@ func (dbc *DBConnector) ScheduleSignalProcessingRecalculateJobs(ctx context.Cont
 
 	for _, series := range allSeries {
 		job := units.NewUpdateTimeSeriesJob(series)
-		err := amboy.EnqueueUniqueJob(ctx, queue, job)
-		if err != nil {
+		if err := amboy.EnqueueUniqueJob(ctx, queue, job); err != nil {
 			catcher.Add(message.WrapError(err, message.Fields{
 				"message": "unable to enqueue recalculation job for metric",
 				"project": series.Project,

--- a/rest/data/perf.go
+++ b/rest/data/perf.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sort"
 	"time"
@@ -165,12 +164,12 @@ func (dbc *DBConnector) FindPerformanceResultWithChildren(ctx context.Context, i
 }
 
 // ScheduleSignalProcessingRecalculateJobs schedules signal processing recalculation jobs for
-// each project/version/task/test combination
+// each project/version/task/test/args combination.
 func (dbc *DBConnector) ScheduleSignalProcessingRecalculateJobs(ctx context.Context) error {
 	queue := dbc.env.GetRemoteQueue()
 	allSeries, err := model.GetAllPerformanceResultSeriesIDs(ctx, dbc.env)
 	if err != nil {
-		return gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: fmt.Sprint("Failed to get time series ids")}
+		return gimlet.ErrorResponse{StatusCode: http.StatusInternalServerError, Message: errors.Wrap(err, "failed to get time series ids").Error()}
 	}
 
 	catcher := grip.NewBasicCatcher()

--- a/rest/perf_routes.go
+++ b/rest/perf_routes.go
@@ -433,7 +433,7 @@ func (h *perfSignalProcessingRecalculateHandler) Parse(_ context.Context, r *htt
 func (h *perfSignalProcessingRecalculateHandler) Run(ctx context.Context) gimlet.Responder {
 	err := h.sc.ScheduleSignalProcessingRecalculateJobs(ctx)
 	if err != nil {
-		err = errors.Wrapf(err, "Error scheduling signal processing recalculation jobs")
+		err = errors.Wrapf(err, "error scheduling signal processing recalculation jobs")
 		logFindError(err, message.Fields{
 			"request": gimlet.GetRequestID(ctx),
 			"method":  "POST",

--- a/rpc/internal/perf_service.go
+++ b/rpc/internal/perf_service.go
@@ -58,7 +58,7 @@ func (srv *perfService) CreateMetricSeries(ctx context.Context, result *ResultDa
 	}
 
 	if record.Info.Mainline && len(record.Rollups.Stats) > 0 {
-		processingJob := units.NewUpdateTimeSeriesJob(record.Info.ToPerformanceResultSeriesID())
+		processingJob := units.NewUpdateTimeSeriesJob(record.CreateUnanalyzedSeries())
 		err := amboy.EnqueueUniqueJob(ctx, srv.env.GetRemoteQueue(), processingJob)
 
 		if err != nil {
@@ -130,7 +130,7 @@ func (srv *perfService) AttachRollups(ctx context.Context, rollupData *RollupDat
 	}
 
 	if record.Info.Mainline {
-		processingJob := units.NewUpdateTimeSeriesJob(record.Info.ToPerformanceResultSeriesID())
+		processingJob := units.NewUpdateTimeSeriesJob(record.CreateUnanalyzedSeries())
 		err := amboy.EnqueueUniqueJob(ctx, srv.env.GetRemoteQueue(), processingJob)
 
 		if err != nil {

--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -19,11 +19,12 @@ import (
 )
 
 type timeSeriesUpdateJob struct {
-	*job.Base                  `bson:"metadata" json:"metadata" yaml:"metadata"`
-	env                        cedar.Environment
-	conf                       *model.CedarConfig
-	PerformanceResultId        model.PerformanceResultSeriesID `bson:"time_series_id" json:"time_series_id" yaml:"time_series_id"`
-	performanceAnalysisService perf.PerformanceAnalysisService
+	Series    model.UnanalyzedPerformanceSeries `bson:"series" json:"series" yaml:"series"`
+	*job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+
+	env     cedar.Environment
+	conf    *model.CedarConfig
+	service perf.PerformanceAnalysisService
 }
 
 func init() {
@@ -44,24 +45,33 @@ func makeTimeSeriesJob() *timeSeriesUpdateJob {
 }
 
 // NewUpdateTimeSeriesJob creates a new amboy job to update a time series.
-func NewUpdateTimeSeriesJob(timeSeriesId model.PerformanceResultSeriesID) amboy.Job {
+func NewUpdateTimeSeriesJob(series model.UnanalyzedPerformanceSeries) amboy.Job {
 	j := makeTimeSeriesJob()
-	baseID := fmt.Sprintf("%s.%s.%s.%s.%s", j.JobType.Name, timeSeriesId.Project, timeSeriesId.Variant, timeSeriesId.Task, timeSeriesId.Test)
+	baseID := fmt.Sprintf(
+		"%s.%s.%s.%s.%s.%s",
+		j.JobType.Name,
+		series.Project,
+		series.Variant,
+		series.Task,
+		series.Test,
+		series.Arguments,
+	)
 	j.SetID(fmt.Sprintf("%s.%s", baseID, time.Now().UTC()))
 	j.SetScopes([]string{baseID})
 	j.SetEnqueueAllScopes(true)
-	j.PerformanceResultId = timeSeriesId
+	j.Series = series
 	return j
 }
 
-func (j *timeSeriesUpdateJob) makeMessage(msg string, id model.PerformanceResultSeriesID) message.Fields {
+func (j *timeSeriesUpdateJob) makeMessage(msg string) message.Fields {
 	return message.Fields{
-		"job_id":  j.ID(),
-		"message": msg,
-		"project": id.Project,
-		"variant": id.Variant,
-		"task":    id.Task,
-		"test":    id.Test,
+		"job_id":    j.ID(),
+		"message":   msg,
+		"project":   j.Series.Project,
+		"variant":   j.Series.Variant,
+		"task_name": j.Series.Task,
+		"test_name": j.Series.Test,
+		"args":      j.Series.Arguments,
 	}
 }
 
@@ -81,75 +91,45 @@ func (j *timeSeriesUpdateJob) Run(ctx context.Context) {
 		}
 	}
 
+	baseID := j.Series.CreateBaseSeriesID()
+
 	if j.conf.Flags.DisableSignalProcessing {
-		grip.InfoWhen(sometimes.Percent(10), j.makeMessage("signal processing is disabled, skipping processing", j.PerformanceResultId))
+		grip.InfoWhen(sometimes.Percent(10), j.makeMessage("signal processing is disabled, skipping processing"))
 		return
 	}
 
-	if j.performanceAnalysisService == nil {
-		j.performanceAnalysisService = perf.NewPerformanceAnalysisService(j.conf.ChangeDetector.URI, j.conf.ChangeDetector.User, j.conf.ChangeDetector.Token)
+	if j.service == nil {
+		j.service = perf.NewPerformanceAnalysisService(j.conf.ChangeDetector.URI, j.conf.ChangeDetector.User, j.conf.ChangeDetector.Token)
 	}
 
-	performanceData, err := model.GetPerformanceData(ctx, j.env, j.PerformanceResultId)
-	if err != nil {
-		j.AddError(errors.Wrapf(err, "aggregating time perfData %s", j.PerformanceResultId.String()))
-		return
-	}
-	if performanceData == nil {
-		j.AddError(model.MarkPerformanceResultsAsAnalyzed(ctx, j.env, j.PerformanceResultId))
-		return
-	}
-	for _, perfData := range performanceData {
-		sort.Slice(perfData.TimeSeries, func(i, j int) bool {
-			return perfData.TimeSeries[i].Order < perfData.TimeSeries[j].Order
-		})
-		series := perf.TimeSeriesModel{
-			Project:     perfData.PerformanceResultId.Project,
-			Variant:     perfData.PerformanceResultId.Variant,
-			Task:        perfData.PerformanceResultId.Task,
-			Test:        perfData.PerformanceResultId.Test,
-			Measurement: perfData.PerformanceResultId.Measurement,
-		}
-		series.Arguments = []perf.ArgumentsModel{}
-		for k, v := range perfData.PerformanceResultId.Arguments {
-			series.Arguments = append(series.Arguments, perf.ArgumentsModel{
-				Name:  k,
-				Value: v,
-			})
-		}
-		filteredData := filterOldExecutions(perfData.TimeSeries)
-		for _, item := range filteredData {
-			series.Data = append(series.Data, perf.TimeSeriesDataModel{
-				PerformanceResultID: item.PerfResultID,
-				Order:               item.Order,
-				Value:               item.Value,
-				Version:             item.Version,
-				Execution:           item.Execution,
-			})
-		}
-		err := j.performanceAnalysisService.ReportUpdatedTimeSeries(ctx, series)
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "updating time series for perfData %s", j.PerformanceResultId.String()))
+	for _, id := range j.Series.CreateSeriesIDs() {
+		if err := j.service.ReportUpdatedTimeSeries(ctx, createTimeSeriesModel(id)); err != nil {
+			j.AddError(errors.Wrapf(err, "updating time series for perfData %s", baseID))
 			return
 		}
-		j.AddError(model.MarkPerformanceResultsAsAnalyzed(ctx, j.env, perfData.PerformanceResultId))
 	}
+
+	j.AddError(model.MarkPerformanceResultsAsAnalyzed(ctx, j.env, baseID))
 }
 
-func filterOldExecutions(timeSeries []model.TimeSeriesEntry) []model.TimeSeriesEntry {
-	maxExecutionMap := make(map[string]int)
-	for _, item := range timeSeries {
-		if item.Execution > maxExecutionMap[item.TaskID] {
-			maxExecutionMap[item.TaskID] = item.Execution
-		}
+func createTimeSeriesModel(id model.PerformanceResultSeriesID) perf.TimeSeriesModel {
+	series := perf.TimeSeriesModel{
+		Project:     id.Project,
+		Variant:     id.Variant,
+		Task:        id.Task,
+		Test:        id.Test,
+		Measurement: id.Measurement,
 	}
-
-	filtered := make([]model.TimeSeriesEntry, 0, len(timeSeries))
-	for _, item := range timeSeries {
-		if item.Execution == maxExecutionMap[item.TaskID] {
-			filtered = append(filtered, item)
-		}
+	series.Arguments = []perf.ArgumentsModel{}
+	for k, v := range id.Arguments {
+		series.Arguments = append(series.Arguments, perf.ArgumentsModel{
+			Name:  k,
+			Value: v,
+		})
 	}
+	sort.Slice(series.Arguments, func(i, j int) bool {
+		return series.Arguments[i].Name < series.Arguments[j].Name
+	})
 
-	return filtered
+	return series
 }

--- a/units/time_series_update_periodic.go
+++ b/units/time_series_update_periodic.go
@@ -63,8 +63,7 @@ func (j *periodicTimeSeriesJob) Run(ctx context.Context) {
 	}
 
 	for _, series := range outdatedSeries {
-		err := amboy.EnqueueUniqueJob(ctx, j.queue, NewUpdateTimeSeriesJob(series))
-		if err != nil {
+		if err := amboy.EnqueueUniqueJob(ctx, j.queue, NewUpdateTimeSeriesJob(series)); err != nil {
 			j.AddError(err)
 			return
 		}

--- a/units/time_series_update_periodic_test.go
+++ b/units/time_series_update_periodic_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/mongodb/amboy/queue"
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,21 +75,21 @@ func generateDistinctRandoms(existing []int, min, max, num int) []int {
 	}
 	return newVals
 }
+
 func makePerfResultsWithChangePoints(unique string, seed int64) ([]testResultsAndRollups, [][]int) {
-	// deterministic testing on failure
-	grip.Debug("Seed for recalculate test: " + strconv.FormatInt(seed, 10))
+	// Deterministic testing on failure.
 	rand.Seed(seed)
 	numTimeSeries := rand.Intn(10) + 1
 	timeSeriesLengths := make([]int, numTimeSeries)
 	timeSeriesChangePoints := make([][]int, numTimeSeries)
 	timeSeries := make([][]int, numTimeSeries)
 
-	// generate series of random length in range [100, 300]
+	// Generate series of random length in range [100, 300].
 	for i := 0; i < numTimeSeries; i++ {
 		timeSeriesLengths[i] = rand.Intn(201) + 100
 	}
 
-	// sprinkle in some random change points
+	// Sprinkle in some random change points.
 	for measurement, length := range timeSeriesLengths {
 		remainingPoints := length
 		for remainingPoints > 0 {
@@ -98,14 +97,15 @@ func makePerfResultsWithChangePoints(unique string, seed int64) ([]testResultsAn
 				remainingPoints = 0
 				continue
 			}
-			// make sure there are 10 points on either side of the cp
+			// Make sure there are 10 points on either side of the
+			// change point.
 			changePoint := rand.Intn(remainingPoints-20) + 10
 			timeSeriesChangePoints[measurement] = append(timeSeriesChangePoints[measurement], changePoint+length-remainingPoints)
 			remainingPoints = remainingPoints - changePoint
 		}
 	}
 
-	// let's create our time series
+	// Create the time series.
 	for measurement, length := range timeSeriesLengths {
 		changePoints := timeSeriesChangePoints[measurement]
 		startingPoint := 0
@@ -123,16 +123,18 @@ func makePerfResultsWithChangePoints(unique string, seed int64) ([]testResultsAn
 		}
 	}
 
-	// measurements/rollups can be added/removed over time, so we should chop up and group our time series randomly
+	// Measurements/rollups can be added/removed over time, so we should
+	// chop up and group our time series randomly.
 	consumed := make([]int, numTimeSeries)
 	var finishedConsuming []int
 	var rollups []testResultsAndRollups
 
 	i := 0
 	for len(finishedConsuming) != numTimeSeries {
-		// Let's record a random number of measurements this run, drawn from [1, numTimeSeries-len(finishedConsuming)]
+		// Record a random number of measurements this run, drawn from
+		// [1, numTimeSeries-len(finishedConsuming)].
 		measurementsThisRun := rand.Intn(numTimeSeries-len(finishedConsuming)) + 1
-		// Get measurements that aren't yet finished being persisted
+		// Get measurements that aren't yet finished being persisted.
 		measurements := generateDistinctRandoms(finishedConsuming, 0, numTimeSeries-1, measurementsThisRun)
 
 		newRollup := testResultsAndRollups{

--- a/units/time_series_update_periodic_test.go
+++ b/units/time_series_update_periodic_test.go
@@ -2,14 +2,19 @@ package units
 
 import (
 	"context"
+	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/mongodb/amboy/queue"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/model"
 )
 
 func setupPeriodic() {
@@ -35,6 +40,133 @@ func tearDownPeriodicTest(env cedar.Environment) error {
 	return errors.WithStack(session.DB(conf.DatabaseName).DropDatabase())
 }
 
+func provisionDb(ctx context.Context, env cedar.Environment, rollups []testResultsAndRollups) {
+	for _, result := range rollups {
+		performanceResult := model.CreatePerformanceResult(*result.info, nil, result.rollups)
+		performanceResult.CreatedAt = time.Now().Add(time.Second * -1)
+		performanceResult.Setup(env)
+		err := performanceResult.SaveNew(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+type testResultsAndRollups struct {
+	info    *model.PerformanceResultInfo
+	rollups []model.PerfRollupValue
+}
+
+func generateDistinctRandoms(existing []int, min, max, num int) []int {
+	var newVals []int
+	exists := map[int]bool{}
+	for _, v := range existing {
+		exists[v] = true
+	}
+	randoms := rand.Perm(max - min + 1)
+	for _, v := range randoms {
+		v += min
+		if !exists[v] {
+			exists[v] = true
+			newVals = append(newVals, v)
+			if len(newVals) == num {
+				break
+			}
+		}
+	}
+	return newVals
+}
+func makePerfResultsWithChangePoints(unique string, seed int64) ([]testResultsAndRollups, [][]int) {
+	// deterministic testing on failure
+	grip.Debug("Seed for recalculate test: " + strconv.FormatInt(seed, 10))
+	rand.Seed(seed)
+	numTimeSeries := rand.Intn(10) + 1
+	timeSeriesLengths := make([]int, numTimeSeries)
+	timeSeriesChangePoints := make([][]int, numTimeSeries)
+	timeSeries := make([][]int, numTimeSeries)
+
+	// generate series of random length in range [100, 300]
+	for i := 0; i < numTimeSeries; i++ {
+		timeSeriesLengths[i] = rand.Intn(201) + 100
+	}
+
+	// sprinkle in some random change points
+	for measurement, length := range timeSeriesLengths {
+		remainingPoints := length
+		for remainingPoints > 0 {
+			if remainingPoints < 30 {
+				remainingPoints = 0
+				continue
+			}
+			// make sure there are 10 points on either side of the cp
+			changePoint := rand.Intn(remainingPoints-20) + 10
+			timeSeriesChangePoints[measurement] = append(timeSeriesChangePoints[measurement], changePoint+length-remainingPoints)
+			remainingPoints = remainingPoints - changePoint
+		}
+	}
+
+	// let's create our time series
+	for measurement, length := range timeSeriesLengths {
+		changePoints := timeSeriesChangePoints[measurement]
+		startingPoint := 0
+		stableValue := 1001
+		for _, cp := range changePoints {
+			stableValue = generateDistinctRandoms([]int{stableValue}, 0, 1000, 1)[0]
+			for i := startingPoint; i < cp; i++ {
+				timeSeries[measurement] = append(timeSeries[measurement], stableValue)
+			}
+			startingPoint = cp
+		}
+		stableValue = generateDistinctRandoms([]int{stableValue}, 0, 1000, 1)[0]
+		for i := startingPoint; i < length; i++ {
+			timeSeries[measurement] = append(timeSeries[measurement], stableValue)
+		}
+	}
+
+	// measurements/rollups can be added/removed over time, so we should chop up and group our time series randomly
+	consumed := make([]int, numTimeSeries)
+	var finishedConsuming []int
+	var rollups []testResultsAndRollups
+
+	i := 0
+	for len(finishedConsuming) != numTimeSeries {
+		// Let's record a random number of measurements this run, drawn from [1, numTimeSeries-len(finishedConsuming)]
+		measurementsThisRun := rand.Intn(numTimeSeries-len(finishedConsuming)) + 1
+		// Get measurements that aren't yet finished being persisted
+		measurements := generateDistinctRandoms(finishedConsuming, 0, numTimeSeries-1, measurementsThisRun)
+
+		newRollup := testResultsAndRollups{
+			info: &model.PerformanceResultInfo{
+				Project:   "project" + unique,
+				Variant:   "variant",
+				Version:   "version" + strconv.Itoa(i+1),
+				Order:     i + 1,
+				TestName:  "test",
+				TaskName:  "task",
+				Arguments: map[string]int32{"thread_level": 20},
+				Mainline:  true,
+			},
+		}
+
+		for _, measurement := range measurements {
+			newRollup.rollups = append(newRollup.rollups, model.PerfRollupValue{
+				Name:       "measurement_" + strconv.Itoa(measurement),
+				Value:      timeSeries[measurement][consumed[measurement]],
+				Version:    0,
+				MetricType: "sum",
+			})
+			consumed[measurement]++
+			if consumed[measurement] == timeSeriesLengths[measurement] {
+				finishedConsuming = append(finishedConsuming, measurement)
+			}
+		}
+		rollups = append(rollups, newRollup)
+		i++
+	}
+
+	return rollups, timeSeries
+}
+
 func TestPeriodicTimeSeriesUpdateJob(t *testing.T) {
 	setupPeriodic()
 	env := cedar.GetEnvironment()
@@ -56,8 +188,9 @@ func TestPeriodicTimeSeriesUpdateJob(t *testing.T) {
 		job.queue = queue.NewLocalLimitedSize(1, 100)
 		assert.NoError(t, job.queue.Start(ctx))
 		j.Run(ctx)
+		require.NoError(t, j.Error())
 		assert.True(t, j.Status().Completed)
-		assert.Equal(t, job.queue.Stats(ctx).Total, 2)
+		assert.Equal(t, 2, job.queue.Stats(ctx).Total)
 
 	})
 }

--- a/units/time_series_update_test.go
+++ b/units/time_series_update_test.go
@@ -26,7 +26,7 @@ func TestUpdateTimeSeriesJob(t *testing.T) {
 	defer cancel()
 
 	t.Run("ReportsTimeSeries", func(t *testing.T) {
-		_ = env.GetDB().Drop(ctx)
+		require.NoError(t, env.GetDB().Drop(ctx))
 		series := model.UnanalyzedPerformanceSeries{
 			Project:      "project",
 			Variant:      "variant",

--- a/units/time_series_update_test.go
+++ b/units/time_series_update_test.go
@@ -53,7 +53,6 @@ func TestUpdateTimeSeriesJob(t *testing.T) {
 			require.Equal(t, series.Measurements[i], call.Measurement)
 		}
 	})
-
 	t.Run("DoesNothingWhenDisabled", func(t *testing.T) {
 		j := NewUpdateTimeSeriesJob(model.UnanalyzedPerformanceSeries{
 			Project: "projecta",

--- a/units/time_series_update_test.go
+++ b/units/time_series_update_test.go
@@ -2,157 +2,13 @@ package units
 
 import (
 	"context"
-	"math/rand"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cedar"
 	"github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/perf"
-	"github.com/mongodb/grip"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
-
-type testResultsAndRollups struct {
-	info    *model.PerformanceResultInfo
-	rollups []model.PerfRollupValue
-}
-
-func generateDistinctRandoms(existing []int, min, max, num int) []int {
-	var newVals []int
-	exists := map[int]bool{}
-	for _, v := range existing {
-		exists[v] = true
-	}
-	randoms := rand.Perm(max - min + 1)
-	for _, v := range randoms {
-		v += min
-		if !exists[v] {
-			exists[v] = true
-			newVals = append(newVals, v)
-			if len(newVals) == num {
-				break
-			}
-		}
-	}
-	return newVals
-}
-
-func makePerfResultsWithChangePoints(unique string, seed int64) ([]testResultsAndRollups, [][]int) {
-	// deterministic testing on failure
-	grip.Debug("Seed for recalculate test: " + strconv.FormatInt(seed, 10))
-	rand.Seed(seed)
-	numTimeSeries := rand.Intn(10) + 1
-	timeSeriesLengths := make([]int, numTimeSeries)
-	timeSeriesChangePoints := make([][]int, numTimeSeries)
-	timeSeries := make([][]int, numTimeSeries)
-
-	// generate series of random length in range [100, 300]
-	for i := 0; i < numTimeSeries; i++ {
-		timeSeriesLengths[i] = rand.Intn(201) + 100
-	}
-
-	// sprinkle in some random change points
-	for measurement, length := range timeSeriesLengths {
-		remainingPoints := length
-		for remainingPoints > 0 {
-			if remainingPoints < 30 {
-				remainingPoints = 0
-				continue
-			}
-			// make sure there are 10 points on either side of the cp
-			changePoint := rand.Intn(remainingPoints-20) + 10
-			timeSeriesChangePoints[measurement] = append(timeSeriesChangePoints[measurement], changePoint+length-remainingPoints)
-			remainingPoints = remainingPoints - changePoint
-		}
-	}
-
-	// let's create our time series
-	for measurement, length := range timeSeriesLengths {
-		changePoints := timeSeriesChangePoints[measurement]
-		startingPoint := 0
-		stableValue := 1001
-		for _, cp := range changePoints {
-			stableValue = generateDistinctRandoms([]int{stableValue}, 0, 1000, 1)[0]
-			for i := startingPoint; i < cp; i++ {
-				timeSeries[measurement] = append(timeSeries[measurement], stableValue)
-			}
-			startingPoint = cp
-		}
-		stableValue = generateDistinctRandoms([]int{stableValue}, 0, 1000, 1)[0]
-		for i := startingPoint; i < length; i++ {
-			timeSeries[measurement] = append(timeSeries[measurement], stableValue)
-		}
-	}
-
-	// measurements/rollups can be added/removed over time, so we should chop up and group our time series randomly
-	consumed := make([]int, numTimeSeries)
-	var finishedConsuming []int
-	var rollups []testResultsAndRollups
-
-	i := 0
-	for len(finishedConsuming) != numTimeSeries {
-		// Let's record a random number of measurements this run, drawn from [1, numTimeSeries-len(finishedConsuming)]
-		measurementsThisRun := rand.Intn(numTimeSeries-len(finishedConsuming)) + 1
-		// Get measurements that aren't yet finished being persisted
-		measurements := generateDistinctRandoms(finishedConsuming, 0, numTimeSeries-1, measurementsThisRun)
-
-		newRollup := testResultsAndRollups{
-			info: &model.PerformanceResultInfo{
-				Project:   "project" + unique,
-				Variant:   "variant",
-				Version:   "version" + strconv.Itoa(i+1),
-				Order:     i + 1,
-				TestName:  "test",
-				TaskName:  "task",
-				Arguments: map[string]int32{"thread_level": 20},
-				Mainline:  true,
-			},
-		}
-
-		for _, measurement := range measurements {
-			newRollup.rollups = append(newRollup.rollups, model.PerfRollupValue{
-				Name:       "measurement_" + strconv.Itoa(measurement),
-				Value:      timeSeries[measurement][consumed[measurement]],
-				Version:    0,
-				MetricType: "sum",
-			})
-			consumed[measurement]++
-			if consumed[measurement] == timeSeriesLengths[measurement] {
-				finishedConsuming = append(finishedConsuming, measurement)
-			}
-		}
-		rollups = append(rollups, newRollup)
-		i++
-	}
-
-	return rollups, timeSeries
-}
-
-func setupChangePointsTest() {
-	dbName := "test_cedar_signal_processing"
-	env, err := cedar.NewEnvironment(context.Background(), dbName, &cedar.Configuration{
-		MongoDBURI:    "mongodb://localhost:27017",
-		DatabaseName:  dbName,
-		SocketTimeout: time.Minute,
-		NumWorkers:    2,
-	})
-	if err != nil {
-		panic(err)
-	}
-	cedar.SetEnvironment(env)
-}
-
-func tearDown(env cedar.Environment) error {
-	conf, session, err := cedar.GetSessionWithConfig(env)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer session.Close()
-	return errors.WithStack(session.DB(conf.DatabaseName).DropDatabase())
-}
 
 type MockPerformanceAnalysisService struct {
 	Calls   []perf.TimeSeriesModel
@@ -164,27 +20,10 @@ func (m *MockPerformanceAnalysisService) ReportUpdatedTimeSeries(ctx context.Con
 	return nil
 }
 
-func provisionDb(ctx context.Context, env cedar.Environment, rollups []testResultsAndRollups) {
-	for _, result := range rollups {
-		performanceResult := model.CreatePerformanceResult(*result.info, nil, result.rollups)
-		performanceResult.CreatedAt = time.Now().Add(time.Second * -1)
-		performanceResult.Setup(env)
-		err := performanceResult.SaveNew(ctx)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
 func TestUpdateTimeSeriesJob(t *testing.T) {
-	setupChangePointsTest()
 	env := cedar.GetEnvironment()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	defer func() {
-		require.NoError(t, tearDown(env))
-	}()
 
 	t.Run("ReportsTimeSeries", func(t *testing.T) {
 		_ = env.GetDB().Drop(ctx)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16072

The SPS is now using the analytics node to run aggregations that fetch performance result time series data so we only need to send the time series ID rather than running the aggregation in amboy jobs and sending all of the time series data.
