### PR TITLE
EVG-16256: Only send mainline data to signal processing service

### DIFF
--- a/units/find_outdated_rollups_test.go
+++ b/units/find_outdated_rollups_test.go
@@ -38,7 +38,7 @@ func TestFindOutdatedRollupsJob(t *testing.T) {
 	require.Len(t, factories[1].Names(), 1)
 	require.Len(t, factories[2].Names(), 1)
 
-	resultInfo := model.PerformanceResultInfo{Project: "HasOutdatedRollups"}
+	resultInfo := model.PerformanceResultInfo{Project: "HasOutdatedRollups", Mainline: true}
 	outdatedResult := model.CreatePerformanceResult(resultInfo, []model.ArtifactInfo{ftdcArtifact}, nil)
 	outdatedResult.CreatedAt = time.Now().Add(-90*24*time.Hour + time.Hour)
 	outdatedResult.Rollups.Stats = append(

--- a/units/ftdc_rollups.go
+++ b/units/ftdc_rollups.go
@@ -145,7 +145,10 @@ func (j *ftdcRollupsJob) Run(ctx context.Context) {
 			j.AddError(errors.Wrapf(err, "adding rollup %s for perf result %s", r.Name, j.PerfID))
 		}
 	}
-	j.createSignalProcessingJob(ctx, result)
+
+	if result.Info.Mainline {
+		j.createSignalProcessingJob(ctx, result)
+	}
 }
 
 func (j *ftdcRollupsJob) createSignalProcessingJob(ctx context.Context, result *model.PerformanceResult) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16256

This fixes a small bug in the ftdc rollups amboy job that does not filter out non-mainline commits when creating the SPS notifier job.