### PR TITLE
EVG-16137, EVG-16136: Store test results in Parquet and fetch and compare

### DIFF
--- a/cmd/convert-bson-to-parquet/convert-bson-to-parquet.go
+++ b/cmd/convert-bson-to-parquet/convert-bson-to-parquet.go
@@ -128,7 +128,7 @@ func convertTestResults() cli.Command {
 				if err != nil {
 					return errors.Wrap(err, "creating bucket writer")
 				}
-				pw, err := writer.NewParquetWriterFromWriter(w, new(model.ParquetTestResults), 4)
+				pw, err := writer.NewParquetWriterFromWriter(w, new(model.ParquetTestResults), 1)
 				if err != nil {
 					return errors.Wrap(err, "creating new parquet writer")
 				}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 	github.com/xitongsys/parquet-go v1.6.2
+	github.com/xitongsys/parquet-go-source v0.0.0-20211228015320-b4f792c43cd0
 	go.mongodb.org/mongo-driver v1.8.2
 	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,9 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
+github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
@@ -43,10 +45,12 @@ github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/autorest v0.11.1/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
+github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
+github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
@@ -112,6 +116,19 @@ github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.42.44 h1:vPlF4cUsdN5ETfvb7ewZFbFZyB6Rsfndt3kS2XqLXKo=
 github.com/aws/aws-sdk-go v1.42.44/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go-v2 v1.7.1/go.mod h1:L5LuPC1ZgDr2xQS7AmIec/Jlc7O/Y1u2KxJyNVab250=
+github.com/aws/aws-sdk-go-v2/config v1.5.0/go.mod h1:RWlPOAW3E3tbtNAqTwvSW54Of/yP3oiZXMI0xfUdjyA=
+github.com/aws/aws-sdk-go-v2/credentials v1.3.1/go.mod h1:r0n73xwsIVagq8RsxmZbGSRQFj9As3je72C2WzUIToc=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.3.0/go.mod h1:2LAuqPx1I6jNfaGDucWfA2zqQCYCOMCDHiCOciALyNw=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.3.2/go.mod h1:qaqQiHSrOUVOfKe6fhgQ6UzhxjwqVW8aHNegd6Ws4w4=
+github.com/aws/aws-sdk-go-v2/internal/ini v1.1.1/go.mod h1:Zy8smImhTdOETZqfyn01iNOe0CNggVbPjCajyaz6Gvg=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.2.1/go.mod h1:v33JQ57i2nekYTA70Mb+O18KeH4KqhdqxTJZNK1zdRE=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.2.1/go.mod h1:zceowr5Z1Nh2WVP8bf/3ikB41IZW59E4yIYbg+pC6mw=
+github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.5.1/go.mod h1:6EQZIwNNvHpq/2/QSJnp4+ECvqIy55w95Ofs0ze+nGQ=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.11.1/go.mod h1:XLAGFrEjbvMCLvAtWLLP32yTv8GpBquCApZEycDLunI=
+github.com/aws/aws-sdk-go-v2/service/sso v1.3.1/go.mod h1:J3A3RGUvuCZjvSuZEcOpHDnzZP/sKbhDWV2T1EOzFIM=
+github.com/aws/aws-sdk-go-v2/service/sts v1.6.0/go.mod h1:q7o0j7d7HrJk/vr9uUt3BVRASvcU7gYZB9PUgPiByXg=
+github.com/aws/smithy-go v1.6.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -645,6 +662,7 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-ieproxy v0.0.1/go.mod h1:pYabZ6IHcRpFh7vIaLfK7rdcWgFEb3SFJ6/gNWuh88E=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
@@ -701,6 +719,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
+github.com/ncw/swift v1.0.52/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nwaples/rardecode v1.1.2 h1:Cj0yZY6T1Zx1R7AhTbyGSALm44/Mmq+BAPc4B/p/d3M=
 github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
@@ -928,8 +947,9 @@ github.com/xitongsys/parquet-go v1.5.1/go.mod h1:xUxwM8ELydxh4edHGegYq1pA8NnMKDx
 github.com/xitongsys/parquet-go v1.6.2 h1:MhCaXii4eqceKPu9BwrjLqyK10oX9WF+xGhwvwbw7xM=
 github.com/xitongsys/parquet-go v1.6.2/go.mod h1:IulAQyalCm0rPiZVNnCgm/PCL64X2tdSVGMQ/UeKqWA=
 github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5/go.mod h1:xxCx7Wpym/3QCo6JhujJX51dzSXrwmb0oH6FQb39SEA=
-github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0 h1:a742S4V5A15F93smuVxA60LQWsrCnN8bKeWDBARU1/k=
 github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod h1:HYhIKsdns7xz80OgkbgJYrtQY7FjHWHKH6cvN7+czGE=
+github.com/xitongsys/parquet-go-source v0.0.0-20211228015320-b4f792c43cd0 h1:ti/bIIF7mKX56sp90ByfAsJRkkmEkY71PWavIG+BGL4=
+github.com/xitongsys/parquet-go-source v0.0.0-20211228015320-b4f792c43cd0/go.mod h1:qLb2Itmdcp7KPa5KZKvhE9U1q5bYSOmgeOckF/H2rQA=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
@@ -982,6 +1002,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1056,6 +1077,7 @@ golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1138,6 +1160,7 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1164,6 +1187,7 @@ golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200817155316-9781c653f443/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/model/config.go
+++ b/model/config.go
@@ -186,6 +186,11 @@ type BucketConfig struct {
 	SystemMetricsBucketType PailType `bson:"system_metrics_bucket_type" json:"system_metrics_bucket_type" yaml:"system_metrics_bucket_type"`
 	TestResultsBucket       string   `bson:"test_results_bucket" json:"test_results_bucket" yaml:"test_results_bucket"`
 	TestResultsBucketType   PailType `bson:"test_results_bucket_type" json:"test_results_bucket_type" yaml:"test_results_bucket_type"`
+
+	PrestoAWSKey            string `bson:"presto_aws_key" json:"presto_aws_key" yaml:"presto_aws_key"`
+	PrestoAWSSecret         string `bson:"presto_aws_secret" json:"presto_aws_secret" yaml:"presto_aws_secret"`
+	PrestoBucket            string `bson:"presto_bucket" json:"presto_bucket" yaml:"presto_bucket"`
+	PrestoTestResultsPrefix string `bson:"presto_test_results_prefix" json:"presto_test_results_prefix" yaml:"presto_test_results_prefix"`
 }
 
 var (

--- a/model/config.go
+++ b/model/config.go
@@ -187,8 +187,6 @@ type BucketConfig struct {
 	TestResultsBucket       string   `bson:"test_results_bucket" json:"test_results_bucket" yaml:"test_results_bucket"`
 	TestResultsBucketType   PailType `bson:"test_results_bucket_type" json:"test_results_bucket_type" yaml:"test_results_bucket_type"`
 
-	PrestoAWSKey            string `bson:"presto_aws_key" json:"presto_aws_key" yaml:"presto_aws_key"`
-	PrestoAWSSecret         string `bson:"presto_aws_secret" json:"presto_aws_secret" yaml:"presto_aws_secret"`
 	PrestoBucket            string `bson:"presto_bucket" json:"presto_bucket" yaml:"presto_bucket"`
 	PrestoTestResultsPrefix string `bson:"presto_test_results_prefix" json:"presto_test_results_prefix" yaml:"presto_test_results_prefix"`
 }

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -376,9 +376,12 @@ func (t *TestResults) downloadParquet(ctx context.Context) ([]TestResult, error)
 		return nil, errors.Wrap(err, "getting Parquet test results")
 	}
 
+	catcher := grip.NewBasicCatcher()
 	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, errors.Wrap(err, "reading Parquet test results")
+	catcher.Wrap(err, "reading Parquet test results")
+	catcher.Wrap(r.Close(), "closing Presto bucket reader")
+	if err = catcher.Resolve(); err != nil {
+		return nil, err
 	}
 
 	pr, err := reader.NewParquetReader(buffer.NewBufferFileFromBytes(data), new(ParquetTestResults), 1)

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -199,7 +199,7 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 		return nil
 	}
 
-	allResults, err := t.downloadParquet(ctx)
+	allResults, err := t.downloadBSON(ctx)
 	if err != nil && !pail.IsKeyNotFoundError(err) {
 		return errors.Wrap(err, "getting uploaded test results")
 	}
@@ -669,9 +669,9 @@ func (t TestResult) convertToParquet() ParquetTestResult {
 		LogURL:          utility.ToStringPtr(t.LogURL),
 		RawLogURL:       utility.ToStringPtr(t.RawLogURL),
 		LineNum:         utility.ToInt32Ptr(int32(t.LineNum)),
-		TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(t.TaskCreateTime.UTC(), true),
-		TestStartTime:   types.TimeToTIMESTAMP_MILLIS(t.TestStartTime.UTC(), true),
-		TestEndTime:     types.TimeToTIMESTAMP_MILLIS(t.TestEndTime.UTC(), true),
+		TaskCreateTime:  utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(t.TaskCreateTime.UTC(), true)),
+		TestStartTime:   utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(t.TestStartTime.UTC(), true)),
+		TestEndTime:     utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(t.TestEndTime.UTC(), true)),
 	}
 }
 
@@ -1277,9 +1277,9 @@ func (r ParquetTestResults) convertToTestResultSlice() []TestResult {
 			LogURL:          utility.FromStringPtr(r.Results[i].LogURL),
 			RawLogURL:       utility.FromStringPtr(r.Results[i].RawLogURL),
 			LineNum:         int(utility.FromInt32Ptr(r.Results[i].LineNum)),
-			TaskCreateTime:  time.Unix(0, r.Results[i].TaskCreateTime*1e6).UTC(),
-			TestStartTime:   time.Unix(0, r.Results[i].TestStartTime*1e6).UTC(),
-			TestEndTime:     time.Unix(0, r.Results[i].TestEndTime*1e6).UTC(),
+			TaskCreateTime:  time.Unix(0, utility.FromInt64Ptr(r.Results[i].TaskCreateTime)*1e6).UTC(),
+			TestStartTime:   time.Unix(0, utility.FromInt64Ptr(r.Results[i].TestStartTime)*1e6).UTC(),
+			TestEndTime:     time.Unix(0, utility.FromInt64Ptr(r.Results[i].TestEndTime)*1e6).UTC(),
 		}
 	}
 
@@ -1298,7 +1298,7 @@ type ParquetTestResult struct {
 	LogURL          *string `parquet:"name=log_url, type=BYTE_ARRAY, convertedtype=UTF8"`
 	RawLogURL       *string `parquet:"name=raw_log_url, type=BYTE_ARRAY, convertedtype=UTF8"`
 	LineNum         *int32  `parquet:"name=line_num, type=INT32"`
-	TaskCreateTime  int64   `parquet:"name=task_Create_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
-	TestStartTime   int64   `parquet:"name=test_start_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
-	TestEndTime     int64   `parquet:"name=test_end_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
+	TaskCreateTime  *int64  `parquet:"name=task_Create_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
+	TestStartTime   *int64  `parquet:"name=test_start_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
+	TestEndTime     *int64  `parquet:"name=test_end_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
 }

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -355,7 +355,7 @@ func (t *TestResults) Download(ctx context.Context) ([]TestResult, error) {
 		if err != nil && !pail.IsKeyNotFoundError(err) {
 			return nil, err
 		} else if err == nil && invalidParquetAlertCount < 5 {
-			if reflect.DeepEqual(parquetResults, bsonResults) {
+			if !reflect.DeepEqual(parquetResults, bsonResults) {
 				grip.Warning(message.Fields{
 					"message":   "BSON and Parquet test results differ",
 					"task_id":   t.Info.TaskID,

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"reflect"
 
 	"hash"
 	"io"
@@ -25,7 +26,10 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
+	"github.com/xitongsys/parquet-go-source/buffer"
+	"github.com/xitongsys/parquet-go/reader"
 	"github.com/xitongsys/parquet-go/types"
+	"github.com/xitongsys/parquet-go/writer"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -54,9 +58,11 @@ type TestResults struct {
 	// limited number of failing tests for a task.
 	FailedTestsSample []string `bson:"failed_tests_sample"`
 
-	env       cedar.Environment
-	bucket    string
-	populated bool
+	env                cedar.Environment
+	bucket             string
+	prestoBucket       string
+	prestoBucketPrefix string
+	populated          bool
 }
 
 var (
@@ -93,7 +99,7 @@ func (t *TestResults) IsNil() bool { return !t.populated }
 
 // PrestoPartitionKey returns the partition key for the S3 bucket in Presto.
 func (t *TestResults) PrestoPartitionKey() string {
-	return fmt.Sprintf("task_create_iso=%s/project=%s/%s", t.CreatedAt.UTC().Format(parquetDateFormat), t.Info.Project, t.ID)
+	return fmt.Sprintf("task_create_iso=%s/project=%s/%s", t.CreatedAt.UTC().Format(parquetDateFormat), t.Info.Project, t.Artifact.Prefix)
 }
 
 // Find searches the database for the TestResults. The environment should not be
@@ -186,40 +192,38 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 		return nil
 	}
 
-	bucket, err := t.GetBucket(ctx)
-	if err != nil {
-		return err
-	}
-
-	var allResults testResultsDoc
-	r, err := bucket.Get(ctx, testResultsCollection)
+	allResults, err := t.downloadParquet(ctx)
 	if err != nil && !pail.IsKeyNotFoundError(err) {
 		return errors.Wrap(err, "getting uploaded test results")
 	}
-	if err == nil {
-		catcher := grip.NewBasicCatcher()
+	allResults = append(allResults, results...)
 
-		data, err := ioutil.ReadAll(r)
-		catcher.Add(r.Close())
-		if err != nil {
-			catcher.Wrap(err, "reading uploaded test results")
-			return catcher.Resolve()
-		}
-
-		if err = bson.Unmarshal(data, &allResults); err != nil {
-			catcher.Wrap(err, "unmarshalling uploaded test results")
-			return catcher.Resolve()
-		}
+	// TODO (EVG-16140): Stop calling this once we do the BSON to Parquet
+	// cutover.
+	if err := t.uploadBSON(ctx, allResults); err != nil {
+		return errors.Wrap(err, "appending BSON test results")
 	}
-	allResults.Results = append(allResults.Results, results...)
 
-	data, err := bson.Marshal(&allResults)
+	bucket, err := t.GetPrestoBucket(ctx)
 	if err != nil {
-		return errors.Wrap(err, "marshalling test results")
+		return err
 	}
-
-	if err := bucket.Put(ctx, testResultsCollection, bytes.NewReader(data)); err != nil {
-		return errors.Wrap(err, "uploading test results")
+	w, err := bucket.Writer(ctx, t.PrestoPartitionKey())
+	if err != nil {
+		return errors.Wrap(err, "creating Presto bucket writer")
+	}
+	pw, err := writer.NewParquetWriterFromWriter(w, new(ParquetTestResults), 1)
+	if err != nil {
+		return errors.Wrap(err, "creating new Parquet writer")
+	}
+	if err = pw.Write(t.convertToParquet(allResults)); err != nil {
+		return errors.Wrap(err, "writing Parquet test results")
+	}
+	if err = pw.WriteStop(); err != nil {
+		return errors.Wrap(err, "stopping Parquet writer")
+	}
+	if err := w.Close(); err != nil {
+		return errors.Wrap(err, "closing Presto bucket writer")
 	}
 
 	if err = t.env.GetStatsCache(cedar.StatsCacheTestResults).AddStat(cedar.Stat{
@@ -235,6 +239,21 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 	}
 
 	return t.updateStatsAndFailedSample(ctx, results)
+}
+
+// TODO (EVG-16140): Remove this once we do the BSON to Parquet cutover.
+func (t *TestResults) uploadBSON(ctx context.Context, results []TestResult) error {
+	bucket, err := t.GetBucket(ctx)
+	if err != nil {
+		return err
+	}
+
+	data, err := bson.Marshal(&testResultsDoc{Results: results})
+	if err != nil {
+		return errors.Wrap(err, "marshalling BSON test results")
+	}
+
+	return errors.Wrap(bucket.Put(ctx, testResultsCollection, bytes.NewReader(data)), "uploading BSON test results")
 }
 
 func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []TestResult) error {
@@ -295,42 +314,111 @@ func (t *TestResults) Download(ctx context.Context) ([]TestResult, error) {
 		t.ID = t.Info.ID()
 	}
 
-	var results testResultsDoc
-	catcher := grip.NewBasicCatcher()
+	switch t.Artifact.Version {
+	case 0:
+		catcher := grip.NewBasicCatcher()
+		bucket, err := t.GetBucket(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var results []TestResult
+		iter := NewTestResultsIterator(bucket)
+		for iter.Next(ctx) {
+			results = append(results, iter.Item())
+		}
+		catcher.Wrap(iter.Err(), "iterating test results")
+		catcher.Wrap(iter.Close(), "closing test results iterator")
+
+		return results, catcher.Resolve()
+	case 1:
+		bsonResults, err := t.downloadBSON(ctx)
+		if err != nil {
+			return nil, err
+		}
+		parquetResults, err := t.downloadParquet(ctx)
+		if err != nil && !pail.IsKeyNotFoundError(err) {
+			return nil, err
+		} else if err == nil {
+			if reflect.DeepEqual(parquetResults, bsonResults) {
+				grip.Warning(message.Fields{
+					"message":   "BSON and Parquet test results differ",
+					"task_id":   t.Info.TaskID,
+					"execution": t.Info.Execution,
+				})
+			}
+		}
+
+		return bsonResults, nil
+	default:
+		return nil, errors.Errorf("unsupported test results artifact version '%d'", t.Artifact.Version)
+	}
+}
+
+// TODO (EVG-16140): Move this to Download (above) once we do the BSON to
+// Parquet cutover.
+func (t *TestResults) downloadParquet(ctx context.Context) ([]TestResult, error) {
+	prestoBucket, err := t.GetPrestoBucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := prestoBucket.Get(ctx, t.PrestoPartitionKey())
+	if err != nil {
+		return nil, errors.Wrap(err, "getting Parquet test results")
+	}
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading Parquet test results")
+	}
+
+	pr, err := reader.NewParquetReader(buffer.NewBufferFileFromBytes(data), new(ParquetTestResults), 1)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating Parquet reader")
+	}
+
+	parquetResults := make([]ParquetTestResults, pr.GetNumRows())
+	if err := pr.Read(&parquetResults); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling Parquet test results")
+	}
+	pr.ReadStop()
+
+	var results []TestResult
+	for _, result := range parquetResults {
+		results = append(results, result.convertToTestResultSlice()...)
+	}
+
+	return results, nil
+}
+
+// TODO (EVG-16140): Remove this function once we do the BSON to Parquet
+// cutover.
+func (t *TestResults) downloadBSON(ctx context.Context) ([]TestResult, error) {
 	bucket, err := t.GetBucket(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	switch t.Artifact.Version {
-	case 0:
-		iter := NewTestResultsIterator(bucket)
-		for iter.Next(ctx) {
-			results.Results = append(results.Results, iter.Item())
-		}
-
-		catcher.Wrap(iter.Err(), "iterating test results")
-		catcher.Wrap(iter.Close(), "closing test results iterator")
-	case 1:
-		r, err := bucket.Get(ctx, testResultsCollection)
-		if err != nil {
-			catcher.Wrap(err, "getting test results")
-			break
-		}
-
-		data, err := ioutil.ReadAll(r)
-		catcher.Add(r.Close())
-		if err != nil {
-			catcher.Wrap(err, "reading test results")
-			break
-		}
-
-		catcher.Wrap(bson.Unmarshal(data, &results), "unmarshalling test results")
-	default:
-		catcher.Errorf("unsupported test results artifact version '%d'", t.Artifact.Version)
+	r, err := bucket.Get(ctx, testResultsCollection)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting BSON test results")
 	}
 
-	return results.Results, catcher.Resolve()
+	data, err := ioutil.ReadAll(r)
+	catcher := grip.NewBasicCatcher()
+	catcher.Wrap(err, "reading BSON test results")
+	catcher.Wrap(r.Close(), "closing BSON test results bucket reader")
+	if err := catcher.Resolve(); err != nil {
+		return nil, err
+	}
+
+	var resultsDoc testResultsDoc
+	if err = bson.Unmarshal(data, &resultsDoc); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling BSON test results")
+	}
+
+	return resultsDoc.Results, nil
 }
 
 // DownloadAndConvertToParquet returns all of the test results stored in
@@ -343,6 +431,10 @@ func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*Parquet
 		return nil, errors.Wrap(err, "downloading test results")
 	}
 
+	return t.convertToParquet(results), nil
+}
+
+func (t *TestResults) convertToParquet(results []TestResult) *ParquetTestResults {
 	convertedResults := make([]ParquetTestResult, len(results))
 	for i, result := range results {
 		convertedResults[i] = result.convertToParquet()
@@ -355,7 +447,7 @@ func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*Parquet
 		Version:   t.Info.Version,
 		CreatedAt: types.TimeToTIMESTAMP_MILLIS(t.CreatedAt.UTC(), true),
 		Results:   convertedResults,
-	}, nil
+	}
 }
 
 // Close "closes out" by populating the completed_at field. The environment
@@ -393,8 +485,8 @@ func (t *TestResults) Close(ctx context.Context) error {
 	return errors.Wrapf(err, "problem closing test result record with id %s", t.ID)
 }
 
-// GetBucket returns a bucket of all test results specified by the TestResults metadata
-// object it's called on. The environment should not be nil.
+// GetBucket returns a bucket of all test results specified by the TestResults
+// metadata object it's called on. The environment should not be nil.
 func (t *TestResults) GetBucket(ctx context.Context) (pail.Bucket, error) {
 	if t.bucket == "" {
 		conf := &CedarConfig{}
@@ -402,6 +494,7 @@ func (t *TestResults) GetBucket(ctx context.Context) (pail.Bucket, error) {
 		if err := conf.Find(); err != nil {
 			return nil, errors.Wrap(err, "getting application configuration")
 		}
+
 		t.bucket = conf.Bucket.TestResultsBucket
 	}
 
@@ -412,6 +505,39 @@ func (t *TestResults) GetBucket(ctx context.Context) (pail.Bucket, error) {
 		t.Artifact.Prefix,
 		string(pail.S3PermissionsPrivate),
 		true,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating bucket")
+	}
+
+	return bucket, nil
+}
+
+// GetPrestoBucket returns an S3 bucket of all test results specified by the
+// TestResults metadata object it's called on to be used with Presto. The
+// environment should not be nil.
+//
+// TODO (EVG-16140): Remove this and use GetBucket (above) once we do the BSON
+// to Parquet cutover.
+func (t *TestResults) GetPrestoBucket(ctx context.Context) (pail.Bucket, error) {
+	if t.prestoBucket == "" {
+		conf := &CedarConfig{}
+		conf.Setup(t.env)
+		if err := conf.Find(); err != nil {
+			return nil, errors.Wrap(err, "getting application configuration")
+		}
+
+		t.prestoBucket = conf.Bucket.PrestoBucket
+		t.prestoBucketPrefix = conf.Bucket.PrestoTestResultsPrefix
+	}
+
+	bucket, err := t.Artifact.Type.Create(
+		ctx,
+		t.env,
+		t.prestoBucket,
+		t.prestoBucketPrefix,
+		string(pail.S3PermissionsPrivate),
+		false,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating bucket")
@@ -535,6 +661,7 @@ func (t TestResult) convertToParquet() ParquetTestResult {
 		LogURL:          utility.ToStringPtr(t.LogURL),
 		RawLogURL:       utility.ToStringPtr(t.RawLogURL),
 		LineNum:         utility.ToInt32Ptr(int32(t.LineNum)),
+		TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(t.TaskCreateTime.UTC(), true),
 		TestStartTime:   types.TimeToTIMESTAMP_MILLIS(t.TestStartTime.UTC(), true),
 		TestEndTime:     types.TimeToTIMESTAMP_MILLIS(t.TestEndTime.UTC(), true),
 	}
@@ -1127,6 +1254,30 @@ type ParquetTestResults struct {
 	Results   []ParquetTestResult `parquet:"name=results, type=LIST"`
 }
 
+func (r ParquetTestResults) convertToTestResultSlice() []TestResult {
+	results := make([]TestResult, len(r.Results))
+	for i := range r.Results {
+		results[i] = TestResult{
+			TaskID:          r.TaskID,
+			Execution:       int(r.Execution),
+			TestName:        r.Results[i].TestName,
+			DisplayTestName: utility.FromStringPtr(r.Results[i].DisplayTestName),
+			GroupID:         utility.FromStringPtr(r.Results[i].GroupID),
+			Trial:           int(utility.FromInt32Ptr(r.Results[i].Trial)),
+			Status:          r.Results[i].Status,
+			LogTestName:     utility.FromStringPtr(r.Results[i].LogTestName),
+			LogURL:          utility.FromStringPtr(r.Results[i].LogURL),
+			RawLogURL:       utility.FromStringPtr(r.Results[i].RawLogURL),
+			LineNum:         int(utility.FromInt32Ptr(r.Results[i].LineNum)),
+			TaskCreateTime:  time.Unix(0, r.Results[i].TaskCreateTime*1e6).UTC(),
+			TestStartTime:   time.Unix(0, r.Results[i].TestStartTime*1e6).UTC(),
+			TestEndTime:     time.Unix(0, r.Results[i].TestEndTime*1e6).UTC(),
+		}
+	}
+
+	return results
+}
+
 // ParquetTestResult describes a single test result to be stored in Apache
 // Parquet file format.
 type ParquetTestResult struct {
@@ -1139,6 +1290,7 @@ type ParquetTestResult struct {
 	LogURL          *string `parquet:"name=log_url, type=BYTE_ARRAY, convertedtype=UTF8"`
 	RawLogURL       *string `parquet:"name=raw_log_url, type=BYTE_ARRAY, convertedtype=UTF8"`
 	LineNum         *int32  `parquet:"name=line_num, type=INT32"`
+	TaskCreateTime  int64   `parquet:"name=task_Create_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
 	TestStartTime   int64   `parquet:"name=test_start_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
 	TestEndTime     int64   `parquet:"name=test_end_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
 }

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -419,9 +419,9 @@ func TestTestResultsDownload(t *testing.T) {
 				LogURL:          utility.ToStringPtr(result.LogURL),
 				RawLogURL:       utility.ToStringPtr(result.RawLogURL),
 				LineNum:         utility.ToInt32Ptr(int32(result.LineNum)),
-				TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true),
-				TestStartTime:   types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true),
-				TestEndTime:     types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true),
+				TaskCreateTime:  utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true)),
+				TestStartTime:   utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true)),
+				TestEndTime:     utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true)),
 			}
 		}
 
@@ -521,6 +521,7 @@ func TestTestResultsDownloadAndConvertToParquet(t *testing.T) {
 	})
 	conf.Bucket.TestResultsBucket = tmpDir
 	conf.Bucket.PrestoBucket = tmpDir
+	conf.Bucket.PrestoTestResultsPrefix = "presto-test-results"
 	require.NoError(t, conf.Save())
 	t.Run("DownloadFromBucket", func(t *testing.T) {
 		savedResults := testResultsDoc{}
@@ -549,9 +550,9 @@ func TestTestResultsDownloadAndConvertToParquet(t *testing.T) {
 				LogURL:          utility.ToStringPtr(result.LogURL),
 				RawLogURL:       utility.ToStringPtr(result.RawLogURL),
 				LineNum:         utility.ToInt32Ptr(int32(result.LineNum)),
-				TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true),
-				TestStartTime:   types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true),
-				TestEndTime:     types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true),
+				TaskCreateTime:  utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true)),
+				TestStartTime:   utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true)),
+				TestEndTime:     utility.ToInt64Ptr(types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true)),
 			})
 		}
 
@@ -772,8 +773,9 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	}()
 	conf := &CedarConfig{
 		Bucket: BucketConfig{
-			TestResultsBucket: tmpDir,
-			PrestoBucket:      tmpDir,
+			TestResultsBucket:       tmpDir,
+			PrestoBucket:            tmpDir,
+			PrestoTestResultsPrefix: "presto-test-results",
 		},
 		populated: true,
 	}
@@ -1098,8 +1100,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 	}()
 	conf := &CedarConfig{
 		Bucket: BucketConfig{
-			TestResultsBucket: tmpDir,
-			PrestoBucket:      tmpDir,
+			TestResultsBucket:       tmpDir,
+			PrestoBucket:            tmpDir,
+			PrestoTestResultsPrefix: "presto-test-results",
 		},
 		populated: true,
 	}

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -15,7 +15,10 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xitongsys/parquet-go-source/buffer"
+	"github.com/xitongsys/parquet-go/reader"
 	"github.com/xitongsys/parquet-go/types"
+	"github.com/xitongsys/parquet-go/writer"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -231,7 +234,10 @@ func TestTestResultsAppend(t *testing.T) {
 	tr.populated = true
 	results := []TestResult{}
 	for i := 0; i < 10; i++ {
-		results = append(results, getTestResult())
+		result := getTestResult()
+		result.TaskID = tr.Info.TaskID
+		result.Execution = tr.Info.Execution
+		results = append(results, result)
 	}
 
 	t.Run("NoEnv", func(t *testing.T) {
@@ -254,23 +260,40 @@ func TestTestResultsAppend(t *testing.T) {
 		tr.Setup(env)
 		assert.Error(t, tr.Append(ctx, results))
 	})
-	conf.Setup(env)
-	require.NoError(t, conf.Find())
 	conf.Bucket.TestResultsBucket = tmpDir
+	conf.Bucket.PrestoBucket = tmpDir
+	conf.Bucket.PrestoTestResultsPrefix = "presto-test-results"
 	require.NoError(t, conf.Save())
-	t.Run("AppendToBucket", func(t *testing.T) {
+	t.Run("AppendToBuckets", func(t *testing.T) {
 		tr.Setup(env)
 		require.NoError(t, tr.Append(ctx, results[0:5]))
 		require.NoError(t, tr.Append(ctx, results[5:]))
 
-		var savedResults testResultsDoc
+		// Check BSON data.
+		var bsonResults testResultsDoc
 		r, err := testBucket.Get(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection))
 		require.NoError(t, err)
 		data, err := ioutil.ReadAll(r)
 		assert.NoError(t, r.Close())
 		require.NoError(t, err)
-		require.NoError(t, bson.Unmarshal(data, &savedResults))
-		assert.Equal(t, results, savedResults.Results)
+		require.NoError(t, bson.Unmarshal(data, &bsonResults))
+		assert.Equal(t, results, bsonResults.Results)
+
+		// Check Parquet data.
+		r, err = testBucket.Get(ctx, fmt.Sprintf("%s/%s", conf.Bucket.PrestoTestResultsPrefix, tr.PrestoPartitionKey()))
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(r)
+		assert.NoError(t, r.Close())
+		require.NoError(t, err)
+		pr, err := reader.NewParquetReader(buffer.NewBufferFileFromBytes(data), new(ParquetTestResults), 1)
+		require.NoError(t, err)
+		parquetResults := make([]ParquetTestResults, pr.GetNumRows())
+		require.NoError(t, pr.Read(&parquetResults))
+		pr.ReadStop()
+		require.Len(t, parquetResults, 1)
+		assert.Equal(t, results, parquetResults[0].convertToTestResultSlice())
+
+		// Check metadata.
 		var saved TestResults
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
 		assert.Equal(t, len(results), saved.Stats.TotalCount)
@@ -280,19 +303,38 @@ func TestTestResultsAppend(t *testing.T) {
 		failedResults := make([]TestResult, 2*FailedTestsSampleSize)
 		for i := 0; i < 2*FailedTestsSampleSize; i++ {
 			failedResults[i] = getTestResult()
+			failedResults[i].TaskID = tr.Info.TaskID
+			failedResults[i].Execution = tr.Info.Execution
 			failedResults[i].Status = "fail"
 		}
 		tr.Setup(env)
 		require.NoError(t, tr.Append(ctx, failedResults[0:3]))
 		require.NoError(t, tr.Append(ctx, failedResults[3:]))
 
+		// Check BSON data.
 		r, err = testBucket.Get(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection))
 		require.NoError(t, err)
 		data, err = ioutil.ReadAll(r)
 		assert.NoError(t, r.Close())
 		require.NoError(t, err)
-		require.NoError(t, bson.Unmarshal(data, &savedResults))
-		assert.Equal(t, append(results, failedResults...), savedResults.Results)
+		require.NoError(t, bson.Unmarshal(data, &bsonResults))
+		assert.Equal(t, append(results, failedResults...), bsonResults.Results)
+
+		// Check Parquet data.
+		r, err = testBucket.Get(ctx, fmt.Sprintf("%s/%s", conf.Bucket.PrestoTestResultsPrefix, tr.PrestoPartitionKey()))
+		require.NoError(t, err)
+		data, err = ioutil.ReadAll(r)
+		assert.NoError(t, r.Close())
+		require.NoError(t, err)
+		pr, err = reader.NewParquetReader(buffer.NewBufferFileFromBytes(data), new(ParquetTestResults), 1)
+		require.NoError(t, err)
+		parquetResults = make([]ParquetTestResults, pr.GetNumRows())
+		require.NoError(t, pr.Read(&parquetResults))
+		pr.ReadStop()
+		require.Len(t, parquetResults, 1)
+		assert.Equal(t, append(results, failedResults...), parquetResults[0].convertToTestResultSlice())
+
+		// Check metadata.
 		require.NoError(t, db.Collection(testResultsCollection).FindOne(ctx, bson.M{"_id": tr.ID}).Decode(&saved))
 		assert.Equal(t, len(results)+len(failedResults), saved.Stats.TotalCount)
 		assert.Equal(t, len(failedResults), saved.Stats.FailedCount)
@@ -317,7 +359,7 @@ func TestTestResultsDownload(t *testing.T) {
 	}()
 
 	tr := getTestResults()
-	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr.ID})
+	testBucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir})
 	require.NoError(t, err)
 
 	t.Run("NoEnv", func(t *testing.T) {
@@ -348,28 +390,69 @@ func TestTestResultsDownload(t *testing.T) {
 	conf.Setup(env)
 	require.NoError(t, conf.Find())
 	conf.Bucket.TestResultsBucket = tmpDir
+	conf.Bucket.PrestoBucket = tmpDir
+	conf.Bucket.PrestoTestResultsPrefix = "presto-test-results"
 	require.NoError(t, conf.Save())
 	t.Run("DownloadFromBucketVersion1", func(t *testing.T) {
-		savedResults := testResultsDoc{}
-		savedResults.Results = make([]TestResult, 10)
-		for i := 0; i < 10; i++ {
-			savedResults.Results[i] = getTestResult()
+		savedBSON := testResultsDoc{}
+		savedBSON.Results = make([]TestResult, 10)
+		savedParquet := ParquetTestResults{
+			Version:   tr.Info.Version,
+			Variant:   tr.Info.Variant,
+			TaskID:    tr.Info.TaskID,
+			Execution: int32(tr.Info.Execution),
+			CreatedAt: types.TimeToTIMESTAMP_MILLIS(tr.CreatedAt.UTC(), true),
+			Results:   make([]ParquetTestResult, 10),
 		}
-		data, err := bson.Marshal(&savedResults)
+		for i := 0; i < 10; i++ {
+			result := getTestResult()
+			savedBSON.Results[i] = result
+			savedBSON.Results[i].TaskID = tr.Info.TaskID
+			savedBSON.Results[i].Execution = tr.Info.Execution
+			savedParquet.Results[i] = ParquetTestResult{
+				TestName:        result.TestName,
+				DisplayTestName: utility.ToStringPtr(result.DisplayTestName),
+				GroupID:         utility.ToStringPtr(result.GroupID),
+				Trial:           utility.ToInt32Ptr(int32(result.Trial)),
+				Status:          result.Status,
+				LogTestName:     utility.ToStringPtr(result.LogTestName),
+				LogURL:          utility.ToStringPtr(result.LogURL),
+				RawLogURL:       utility.ToStringPtr(result.RawLogURL),
+				LineNum:         utility.ToInt32Ptr(int32(result.LineNum)),
+				TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true),
+				TestStartTime:   types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true),
+				TestEndTime:     types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true),
+			}
+		}
+
+		// Check BSON.
+		data, err := bson.Marshal(&savedBSON)
 		require.NoError(t, err)
-		require.NoError(t, testBucket.Put(ctx, testResultsCollection, bytes.NewReader(data)))
+		require.NoError(t, testBucket.Put(ctx, fmt.Sprintf("%s/%s", tr.ID, testResultsCollection), bytes.NewReader(data)))
 
 		tr.Setup(env)
 		results, err := tr.Download(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, savedResults.Results, results)
+		assert.Equal(t, savedBSON.Results, results)
+
+		// Check Parquet.
+		w, err := testBucket.Writer(ctx, fmt.Sprintf("%s/%s", conf.Bucket.PrestoTestResultsPrefix, tr.PrestoPartitionKey()))
+		require.NoError(t, err)
+		pw, err := writer.NewParquetWriterFromWriter(w, new(ParquetTestResults), 1)
+		require.NoError(t, err)
+		require.NoError(t, pw.Write(savedParquet))
+		require.NoError(t, pw.WriteStop())
+		require.NoError(t, w.Close())
+
+		tr.Setup(env)
+		results, err = tr.downloadParquet(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, savedBSON.Results, results)
 	})
 	t.Run("DownloadFromBucketVersion0", func(t *testing.T) {
 		tr0 := getTestResults()
 		tr0.populated = true
 		tr0.Artifact.Version = 0
-		testBucket0, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir, Prefix: tr0.ID})
-		require.NoError(t, err)
 		resultMap := map[string]TestResult{}
 		for i := 0; i < 10; i++ {
 			result := getTestResult()
@@ -377,7 +460,7 @@ func TestTestResultsDownload(t *testing.T) {
 			var data []byte
 			data, err = bson.Marshal(result)
 			require.NoError(t, err)
-			require.NoError(t, testBucket0.Put(ctx, result.TestName, bytes.NewReader(data)))
+			require.NoError(t, testBucket.Put(ctx, fmt.Sprintf("%s/%s", tr0.ID, result.TestName), bytes.NewReader(data)))
 		}
 
 		tr0.Setup(env)
@@ -437,6 +520,7 @@ func TestTestResultsDownloadAndConvertToParquet(t *testing.T) {
 		assert.Error(t, err)
 	})
 	conf.Bucket.TestResultsBucket = tmpDir
+	conf.Bucket.PrestoBucket = tmpDir
 	require.NoError(t, conf.Save())
 	t.Run("DownloadFromBucket", func(t *testing.T) {
 		savedResults := testResultsDoc{}
@@ -465,6 +549,7 @@ func TestTestResultsDownloadAndConvertToParquet(t *testing.T) {
 				LogURL:          utility.ToStringPtr(result.LogURL),
 				RawLogURL:       utility.ToStringPtr(result.RawLogURL),
 				LineNum:         utility.ToInt32Ptr(int32(result.LineNum)),
+				TaskCreateTime:  types.TimeToTIMESTAMP_MILLIS(result.TaskCreateTime.UTC(), true),
 				TestStartTime:   types.TimeToTIMESTAMP_MILLIS(result.TestStartTime.UTC(), true),
 				TestEndTime:     types.TimeToTIMESTAMP_MILLIS(result.TestEndTime.UTC(), true),
 			})
@@ -686,7 +771,10 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()
 	conf := &CedarConfig{
-		Bucket:    BucketConfig{TestResultsBucket: tmpDir},
+		Bucket: BucketConfig{
+			TestResultsBucket: tmpDir,
+			PrestoBucket:      tmpDir,
+		},
 		populated: true,
 	}
 	conf.Setup(env)
@@ -1009,7 +1097,10 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()
 	conf := &CedarConfig{
-		Bucket:    BucketConfig{TestResultsBucket: tmpDir},
+		Bucket: BucketConfig{
+			TestResultsBucket: tmpDir,
+			PrestoBucket:      tmpDir,
+		},
 		populated: true,
 	}
 	conf.Setup(env)

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -42,7 +42,11 @@ func (s *testResultsConnectorSuite) setupData() {
 	s.tempDir, err = ioutil.TempDir(".", "testResults_connector")
 	s.Require().NoError(err)
 	conf := dbModel.NewCedarConfig(s.env)
-	conf.Bucket = dbModel.BucketConfig{TestResultsBucket: s.tempDir}
+	conf.Bucket = dbModel.BucketConfig{
+		TestResultsBucket:       s.tempDir,
+		PrestoBucket:            s.tempDir,
+		PrestoTestResultsPrefix: "presto-test-results",
+	}
 	s.Require().NoError(conf.Save())
 
 	testResultInfos := []dbModel.TestResultsInfo{

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -71,7 +71,11 @@ func (s *TestResultsHandlerSuite) setup(tempDir string) {
 
 	s.Require().NoError(err)
 	conf := dbModel.NewCedarConfig(s.env)
-	conf.Bucket = dbModel.BucketConfig{TestResultsBucket: tempDir}
+	conf.Bucket = dbModel.BucketConfig{
+		TestResultsBucket:       tempDir,
+		PrestoBucket:            tempDir,
+		PrestoTestResultsPrefix: "presto-test-results",
+	}
 	s.Require().NoError(conf.Save())
 
 	s.sc = data.CreateNewDBConnector(s.env, "")

--- a/rpc/internal/test_results_service_test.go
+++ b/rpc/internal/test_results_service_test.go
@@ -178,6 +178,8 @@ func TestAddTestResults(t *testing.T) {
 				conf.Bucket.TestResultsBucket = ""
 			} else {
 				conf.Bucket.TestResultsBucket = tmpDir
+				conf.Bucket.PrestoBucket = tmpDir
+				conf.Bucket.PrestoTestResultsPrefix = "presto-test-results"
 			}
 			require.NoError(t, conf.Save())
 
@@ -337,6 +339,8 @@ func TestStreamTestResults(t *testing.T) {
 				conf.Bucket.TestResultsBucket = ""
 			} else {
 				conf.Bucket.TestResultsBucket = tmpDir
+				conf.Bucket.PrestoBucket = tmpDir
+				conf.Bucket.PrestoTestResultsPrefix = "presto-test-results"
 			}
 			require.NoError(t, conf.Save())
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16137, https://jira.mongodb.org/browse/EVG-16136

Store test results in both BSON and Parquet, when fetching results pull both Parquet and BSON and compare.