### PR TITLE
EVG-16138: Production-Ready BSON to Parquet Backfill 

### DIFF
--- a/model/batch_job_controller.go
+++ b/model/batch_job_controller.go
@@ -14,7 +14,7 @@ import (
 const (
 	// BatchJobControllerCollection is the name of the database collection
 	// for batch job controller documents.
-	BatchJobControllerCollection = "batch_job_controller"
+	BatchJobControllerCollection = "batch_job_controllers"
 )
 
 // BatchJobController represents a set of handles for controlling automatic

--- a/model/batch_job_controller.go
+++ b/model/batch_job_controller.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"context"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/mongodb/anser/bsonutil"
+	"github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const (
+	batchJobControllerCollection = "batch_job_controller"
+)
+
+// BatchJobController represents a set of handles for controlling automatic
+// batch jobs run in Cedar without requiring a deploy/restart of the
+// application.
+type BatchJobController struct {
+	ID         string        `bson:"_id"`
+	Collection string        `bson:"collection,omitempty"`
+	BatchSize  int           `bson:"batch_size"`
+	Iterations int           `bson:"iterations,omitempty"`
+	Timeout    time.Duration `bson:"timeout,omitempty"`
+}
+
+var (
+	batchJobControllerIDKey         = bsonutil.MustHaveTag(BatchJobController{}, "ID")
+	batchJobControllelCollectioKey  = bsonutil.MustHaveTag(BatchJobController{}, "Collection")
+	batchJobControllelBatchSizeKey  = bsonutil.MustHaveTag(BatchJobController{}, "BatchSize")
+	batchJobControllelIterationsKey = bsonutil.MustHaveTag(BatchJobController{}, "Iterations")
+	batchJobControllelTimeoutKey    = bsonutil.MustHaveTag(BatchJobController{}, "Timeout")
+)
+
+// FindBatchJobController searches the database for the BatchJobController with
+// the given ID.
+func FindBatchJobController(ctx context.Context, env cedar.Environment, id string) (*BatchJobController, error) {
+	var controller BatchJobController
+	err := env.GetDB().Collection(batchJobControllerCollection).FindOne(ctx, bson.M{batchJobControllerIDKey: id}).Decode(&controller)
+	if db.ResultsNotFound(err) {
+		return nil, errors.Wrapf(err, "could not find batch job controller with id %s in the database", id)
+	} else if err != nil {
+		return nil, errors.Wrap(err, "finding batch job controller")
+	}
+
+	return &controller, nil
+}

--- a/model/batch_job_controller.go
+++ b/model/batch_job_controller.go
@@ -12,7 +12,9 @@ import (
 )
 
 const (
-	batchJobControllerCollection = "batch_job_controller"
+	// BatchJobControllerCollection is the name of the database collection
+	// for batch job controller documents.
+	BatchJobControllerCollection = "batch_job_controller"
 )
 
 // BatchJobController represents a set of handles for controlling automatic
@@ -40,7 +42,7 @@ var (
 // the given ID.
 func FindBatchJobController(ctx context.Context, env cedar.Environment, id string) (*BatchJobController, error) {
 	var controller BatchJobController
-	err := env.GetDB().Collection(batchJobControllerCollection).FindOne(ctx, bson.M{batchJobControllerIDKey: id}).Decode(&controller)
+	err := env.GetDB().Collection(BatchJobControllerCollection).FindOne(ctx, bson.M{batchJobControllerIDKey: id}).Decode(&controller)
 	if db.ResultsNotFound(err) {
 		return nil, errors.Wrapf(err, "could not find batch job controller with id %s in the database", id)
 	} else if err != nil {

--- a/model/batch_job_controller.go
+++ b/model/batch_job_controller.go
@@ -24,14 +24,16 @@ type BatchJobController struct {
 	BatchSize  int           `bson:"batch_size"`
 	Iterations int           `bson:"iterations,omitempty"`
 	Timeout    time.Duration `bson:"timeout,omitempty"`
+	Version    int           `bson:"version"`
 }
 
 var (
 	batchJobControllerIDKey         = bsonutil.MustHaveTag(BatchJobController{}, "ID")
-	batchJobControllelCollectioKey  = bsonutil.MustHaveTag(BatchJobController{}, "Collection")
-	batchJobControllelBatchSizeKey  = bsonutil.MustHaveTag(BatchJobController{}, "BatchSize")
-	batchJobControllelIterationsKey = bsonutil.MustHaveTag(BatchJobController{}, "Iterations")
-	batchJobControllelTimeoutKey    = bsonutil.MustHaveTag(BatchJobController{}, "Timeout")
+	batchJobControllerCollectioKey  = bsonutil.MustHaveTag(BatchJobController{}, "Collection")
+	batchJobControllerBatchSizeKey  = bsonutil.MustHaveTag(BatchJobController{}, "BatchSize")
+	batchJobControllerIterationsKey = bsonutil.MustHaveTag(BatchJobController{}, "Iterations")
+	batchJobControllerTimeoutKey    = bsonutil.MustHaveTag(BatchJobController{}, "Timeout")
+	batchJobControllerVersionKey    = bsonutil.MustHaveTag(BatchJobController{}, "Version")
 )
 
 // FindBatchJobController searches the database for the BatchJobController with

--- a/model/batch_job_controller_test.go
+++ b/model/batch_job_controller_test.go
@@ -15,6 +15,8 @@ func TestFindBatchJobController(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	require.NoError(t, db.Collection(BatchJobControllerCollection).Drop(ctx))
 	defer func() {
 		assert.NoError(t, db.Collection(BatchJobControllerCollection).Drop(ctx))
 	}()

--- a/model/batch_job_controller_test.go
+++ b/model/batch_job_controller_test.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBatchJobController(t *testing.T) {
+	env := cedar.GetEnvironment()
+	db := env.GetDB()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer func() {
+		assert.NoError(t, db.Collection(batchJobControllerCollection).Drop(ctx))
+	}()
+
+	c1 := &BatchJobController{
+		ID:         "job1",
+		Collection: "collection1",
+		BatchSize:  1000,
+		Iterations: 10,
+		Timeout:    10 * time.Minute,
+	}
+	c2 := &BatchJobController{
+		ID:         "job2",
+		Collection: "collection2",
+		BatchSize:  2000,
+		Iterations: 20,
+		Timeout:    20 * time.Minute,
+	}
+	_, err := db.Collection(batchJobControllerCollection).InsertMany(ctx, []interface{}{c1, c2})
+	require.NoError(t, err)
+
+	t.Run("DNE", func(t *testing.T) {
+		controller, err := FindBatchJobController(ctx, env, "DNE")
+		assert.Nil(t, controller)
+		assert.Error(t, err)
+	})
+	t.Run("Exists", func(t *testing.T) {
+		controller, err := FindBatchJobController(ctx, env, c1.ID)
+		require.NoError(t, err)
+		assert.Equal(t, c1, controller)
+	})
+}

--- a/model/batch_job_controller_test.go
+++ b/model/batch_job_controller_test.go
@@ -16,7 +16,7 @@ func TestFindBatchJobController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	defer func() {
-		assert.NoError(t, db.Collection(batchJobControllerCollection).Drop(ctx))
+		assert.NoError(t, db.Collection(BatchJobControllerCollection).Drop(ctx))
 	}()
 
 	c1 := &BatchJobController{
@@ -33,7 +33,7 @@ func TestFindBatchJobController(t *testing.T) {
 		Iterations: 20,
 		Timeout:    20 * time.Minute,
 	}
-	_, err := db.Collection(batchJobControllerCollection).InsertMany(ctx, []interface{}{c1, c2})
+	_, err := db.Collection(BatchJobControllerCollection).InsertMany(ctx, []interface{}{c1, c2})
 	require.NoError(t, err)
 
 	t.Run("DNE", func(t *testing.T) {

--- a/model/migration_stats.go
+++ b/model/migration_stats.go
@@ -20,5 +20,5 @@ var (
 	MigrationStatsMigratorIDKey  = bsonutil.MustHaveTag(MigrationStats{}, "MigratorID")
 	MigrationStatsStartedAtKey   = bsonutil.MustHaveTag(MigrationStats{}, "StartedAt")
 	MigrationStatsCompletedAtKey = bsonutil.MustHaveTag(MigrationStats{}, "CompletedAt")
-	MigrationStatsVersionKey     = bsonutil.MustHaveTag(MigrationStats{}, "CompletedAt")
+	MigrationStatsVersionKey     = bsonutil.MustHaveTag(MigrationStats{}, "Version")
 )

--- a/model/migration_stats.go
+++ b/model/migration_stats.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"time"
+
+	"github.com/mongodb/anser/bsonutil"
+)
+
+// MigrationStats represents statistics for migration jobs done with documents
+// in the database. It should be used as a temporary sub-document within the
+// documents in question.
+type MigrationStats struct {
+	MigratorID  string    `bson:"migrator_id"`
+	StartedAt   time.Time `bson:"started_at"`
+	CompletedAt time.Time `bson:"completed_at"`
+	Version     int       `bson:"version"`
+}
+
+var (
+	MigrationStatsMigratorIDKey  = bsonutil.MustHaveTag(MigrationStats{}, "MigratorID")
+	MigrationStatsStartedAtKey   = bsonutil.MustHaveTag(MigrationStats{}, "StartedAt")
+	MigrationStatsCompletedAtKey = bsonutil.MustHaveTag(MigrationStats{}, "CompletedAt")
+	MigrationStatsVersionKey     = bsonutil.MustHaveTag(MigrationStats{}, "CompletedAt")
+)

--- a/model/migration_stats.go
+++ b/model/migration_stats.go
@@ -10,10 +10,10 @@ import (
 // typically should be used as a temporary sub-document within the relevant
 // documents in question.
 type MigrationStats struct {
-	MigratorID  string    `bson:"migrator_id"`
-	StartedAt   time.Time `bson:"started_at"`
-	CompletedAt time.Time `bson:"completed_at"`
-	Version     int       `bson:"version"`
+	MigratorID  string     `bson:"migrator_id"`
+	StartedAt   *time.Time `bson:"started_at"`
+	CompletedAt *time.Time `bson:"completed_at"`
+	Version     int        `bson:"version"`
 }
 
 var (

--- a/model/migration_stats.go
+++ b/model/migration_stats.go
@@ -6,8 +6,8 @@ import (
 	"github.com/mongodb/anser/bsonutil"
 )
 
-// MigrationStats represents statistics for migration jobs done with documents
-// in the database. It should be used as a temporary sub-document within the
+// MigrationStats represents statistics for batched migration jobs. It
+// typically should be used as a temporary sub-document within the relevant
 // documents in question.
 type MigrationStats struct {
 	MigratorID  string    `bson:"migrator_id"`

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -81,6 +81,11 @@ type TestResults struct {
 	// This is an optimization for Evergreen's UI features that display a
 	// limited number of failing tests for a task.
 	FailedTestsSample []string `bson:"failed_tests_sample"`
+	// Migration holds statistics for the BSON to Parquet backfill, it is
+	// only present in the temporary test results migration collection.
+	//
+	// TODO (EVG-16140): Remove once we do the  BSON to Parquet cutover.
+	Migration *MigrationStats `bson:"migration,omitempty"`
 
 	env                cedar.Environment
 	bucket             string
@@ -97,6 +102,8 @@ var (
 	testResultsArtifactKey          = bsonutil.MustHaveTag(TestResults{}, "Artifact")
 	testResultsStatsKey             = bsonutil.MustHaveTag(TestResults{}, "Stats")
 	testResultsFailedTestsSampleKey = bsonutil.MustHaveTag(TestResults{}, "FailedTestsSample")
+	// TODO (EVG-16140): Remove once we do the BSON to Parquet cutover.
+	TestResultsMigrationKey = bsonutil.MustHaveTag(TestResults{}, "Migration")
 )
 
 // CreateTestResults is an entry point for creating a new TestResults.
@@ -228,33 +235,8 @@ func (t *TestResults) Append(ctx context.Context, results []TestResult) error {
 		return errors.Wrap(err, "appending BSON test results")
 	}
 
-	bucket, err := t.GetPrestoBucket(ctx)
-	if err != nil {
-		return err
-	}
-	w, err := bucket.Writer(ctx, t.PrestoPartitionKey())
-	if err != nil {
-		return errors.Wrap(err, "creating Presto bucket writer")
-	}
-	var closedWriter bool
-	defer func() {
-		if !closedWriter {
-			_ = w.Close()
-		}
-	}()
-	pw, err := writer.NewParquetWriterFromWriter(w, new(ParquetTestResults), 1)
-	if err != nil {
-		return errors.Wrap(err, "creating new Parquet writer")
-	}
-	if err = pw.Write(t.convertToParquet(allResults)); err != nil {
-		return errors.Wrap(err, "writing Parquet test results")
-	}
-	if err = pw.WriteStop(); err != nil {
-		return errors.Wrap(err, "stopping Parquet writer")
-	}
-	closedWriter = true
-	if err := w.Close(); err != nil {
-		return errors.Wrap(err, "closing Presto bucket writer")
+	if err = t.uploadParquet(ctx, t.convertToParquet(allResults)); err != nil {
+		return errors.Wrap(err, "appending Parquet test results")
 	}
 
 	if err = t.env.GetStatsCache(cedar.StatsCacheTestResults).AddStat(cedar.Stat{
@@ -285,6 +267,36 @@ func (t *TestResults) uploadBSON(ctx context.Context, results []TestResult) erro
 	}
 
 	return errors.Wrap(bucket.Put(ctx, testResultsCollection, bytes.NewReader(data)), "uploading BSON test results")
+}
+
+func (t *TestResults) uploadParquet(ctx context.Context, results *ParquetTestResults) error {
+	bucket, err := t.GetPrestoBucket(ctx)
+	if err != nil {
+		return err
+	}
+	w, err := bucket.Writer(ctx, t.PrestoPartitionKey())
+	if err != nil {
+		return errors.Wrap(err, "creating Presto bucket writer")
+	}
+	var closedWriter bool
+	defer func() {
+		if !closedWriter {
+			_ = w.Close()
+		}
+	}()
+	pw, err := writer.NewParquetWriterFromWriter(w, new(ParquetTestResults), 1)
+	if err != nil {
+		return errors.Wrap(err, "creating new Parquet writer")
+	}
+	if err = pw.Write(results); err != nil {
+		return errors.Wrap(err, "writing Parquet test results")
+	}
+	if err = pw.WriteStop(); err != nil {
+		return errors.Wrap(err, "stopping Parquet writer")
+	}
+
+	closedWriter = true
+	return errors.Wrap(w.Close(), "closing Presto bucket writer")
 }
 
 func (t *TestResults) updateStatsAndFailedSample(ctx context.Context, results []TestResult) error {
@@ -460,14 +472,32 @@ func (t *TestResults) downloadBSON(ctx context.Context) ([]TestResult, error) {
 // DownloadAndConvertToParquet returns all of the test results stored in
 // offline blob storage converted to a ParquetTestResults struct for writing to
 // Apache Parquet format. The TestResults should be populated and the
-/// environment should not be nil.
+// environment should not be nil.
+//
+// TODO (EVG-16140): Remove this function once we do the BSON to Parquet
+// cutover.
 func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*ParquetTestResults, error) {
 	results, err := t.Download(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "downloading test results")
+		return nil, errors.Wrap(err, "downloading BSON test results")
 	}
 
 	return t.convertToParquet(results), nil
+}
+
+// DownloadConvertAndWriteParquet downloads existing BSON test results,
+// converts them to Apache Parquet format, and writes them to the Presto
+// bucket.
+//
+// TODO (EVG-16140): Remove this function once we do the BSON to Parquet
+// cutover.
+func (t *TestResults) DownloadConvertAndWriteParquet(ctx context.Context) error {
+	results, err := t.DownloadAndConvertToParquet(ctx)
+	if err != nil {
+		return err
+	}
+
+	return t.uploadParquet(ctx, results)
 }
 
 func (t *TestResults) convertToParquet(results []TestResult) *ParquetTestResults {

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -487,7 +487,8 @@ func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*Parquet
 
 // DownloadConvertAndWriteParquet downloads existing BSON test results,
 // converts them to Apache Parquet format, and writes them to the Presto
-// bucket.
+// bucket. The TestResults should be populated and the environment should not
+// be nil.
 //
 // TODO (EVG-16140): Remove this function once we do the BSON to Parquet
 // cutover.

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -84,7 +84,7 @@ type TestResults struct {
 	// Migration holds statistics for the BSON to Parquet backfill, it is
 	// only present in the temporary test results migration collection.
 	//
-	// TODO (EVG-16140): Remove once we do the  BSON to Parquet cutover.
+	// TODO (EVG-16140): Remove once we do the BSON to Parquet cutover.
 	Migration *MigrationStats `bson:"migration,omitempty"`
 
 	env                cedar.Environment

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -471,12 +471,12 @@ func (t *TestResults) downloadBSON(ctx context.Context) ([]TestResult, error) {
 
 // DownloadAndConvertToParquet returns all of the test results stored in
 // offline blob storage converted to a ParquetTestResults struct for writing to
-// Apache Parquet format. The TestResults should be populated and the
-// environment should not be nil.
+// Apache Parquet format. The environment should not be nil.
 //
 // TODO (EVG-16140): Remove this function once we do the BSON to Parquet
 // cutover.
 func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*ParquetTestResults, error) {
+	t.populated = true
 	results, err := t.Download(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "downloading BSON test results")
@@ -487,12 +487,12 @@ func (t *TestResults) DownloadAndConvertToParquet(ctx context.Context) (*Parquet
 
 // DownloadConvertAndWriteParquet downloads existing BSON test results,
 // converts them to Apache Parquet format, and writes them to the Presto
-// bucket. The TestResults should be populated and the environment should not
-// be nil.
+// bucket. The environment should not be nil.
 //
 // TODO (EVG-16140): Remove this function once we do the BSON to Parquet
 // cutover.
 func (t *TestResults) DownloadConvertAndWriteParquet(ctx context.Context) error {
+	t.populated = true
 	results, err := t.DownloadAndConvertToParquet(ctx)
 	if err != nil {
 		return err

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -495,13 +495,6 @@ func TestTestResultsDownloadAndConvertToParquet(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("NoEnv", func(t *testing.T) {
-		tr.populated = true
-		_, err = tr.DownloadAndConvertToParquet(ctx)
-		assert.Error(t, err)
-	})
-	t.Run("Unpopulated", func(t *testing.T) {
-		tr.populated = false
-		tr.Setup(env)
 		_, err = tr.DownloadAndConvertToParquet(ctx)
 		assert.Error(t, err)
 	})

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -47,8 +47,9 @@ func makeBSONToParquetBackfillJob() *bsonToParquetBackfillJob {
 	}
 }
 
-// NewBSONToParquetBackfillJob returns a new Amboy job that migrates, in
-// batches, BSON test results to the Presto Bucket in Apache Parquet format.
+// NewBSONToParquetBackfillJob returns a new Amboy job that does batched
+// migrations of existing BSON test results to Apache Parquet test results
+// stored in the Presto bucket.
 func NewBSONToParquetBackfillJob(id string) amboy.Job {
 	j := makeBSONToParquetBackfillJob()
 	j.SetID(fmt.Sprintf("%s.%s", bsonToParquetBackfillJobName, id))

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -27,7 +27,6 @@ type bsonToParquetBackfillJob struct {
 	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
 
 	env         cedar.Environment
-	queue       amboy.Queue
 	controller  *model.BatchJobController
 	migrationID string
 }
@@ -62,9 +61,6 @@ func (j *bsonToParquetBackfillJob) Run(ctx context.Context) {
 
 	if j.env == nil {
 		j.env = cedar.GetEnvironment()
-	}
-	if j.queue == nil {
-		j.queue = j.env.GetRemoteQueue()
 	}
 
 	controller, err := model.FindBatchJobController(ctx, j.env, bsonToParquetBackfillJobName)

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -102,14 +102,14 @@ func (j *bsonToParquetBackfillJob) runIteration(ctx context.Context) error {
 	for i := 0; i < j.controller.BatchSize; i++ {
 		updates[i] = mongo.NewUpdateOneModel().
 			SetFilter(bson.M{"$or": []bson.M{
-				bson.M{model.TestResultsMigrationKey: bson.M{"$exists": false}},
-				bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsVersionKey): bson.M{"$lt": j.controller.Version}},
-				bson.M{"$and": []bson.M{
-					bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsStartedAtKey): bson.M{"$and": []bson.M{
-						bson.M{"gt": time.Time{}},
-						bson.M{"lt": time.Now().Add(-j.controller.Timeout)},
+				{model.TestResultsMigrationKey: bson.M{"$exists": false}},
+				{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsVersionKey): bson.M{"$lt": j.controller.Version}},
+				{"$and": []bson.M{
+					{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsStartedAtKey): bson.M{"$and": []bson.M{
+						{"gt": time.Time{}},
+						{"lt": time.Now().Add(-j.controller.Timeout)},
 					}}},
-					bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsCompletedAtKey): time.Time{}},
+					{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsCompletedAtKey): time.Time{}},
 				}},
 			}}).
 			SetUpdate(bson.M{"$set": bson.M{

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -19,6 +19,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// TODO (EVG-16138): Remove this job once we do the BSON to Parquet cutover.
+
 const bsonToParquetBackfillJobName = "bson-to-parquet-backfill"
 
 type bsonToParquetBackfillJob struct {
@@ -45,6 +47,8 @@ func makeBSONToParquetBackfillJob() *bsonToParquetBackfillJob {
 	}
 }
 
+// NewBSONToParquetBackfillJob returns a new Amboy job that migrates, in
+// batches, BSON test results to the Presto Bucket in Apache Parquet format.
 func NewBSONToParquetBackfillJob(id string) amboy.Job {
 	j := makeBSONToParquetBackfillJob()
 	j.SetID(fmt.Sprintf("%s.%s", bsonToParquetBackfillJobName, id))

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -19,7 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// TODO (EVG-16138): Remove this job once we do the BSON to Parquet cutover.
+// TODO (EVG-16140): Remove this job once we do the BSON to Parquet cutover.
 
 const bsonToParquetBackfillJobName = "bson-to-parquet-backfill"
 
@@ -72,16 +72,9 @@ func (j *bsonToParquetBackfillJob) Run(ctx context.Context) {
 		j.AddError(errors.Wrap(err, "getting batch job controller"))
 		return
 	}
-	if controller.Iterations <= 0 {
-		controller.Iterations = 1
-	}
-	if controller.Timeout <= 0 {
-		controller.Timeout = time.Minute
-	}
 	j.controller = controller
 
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, j.controller.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, j.controller.Timeout)
 	defer cancel()
 
 	for i := 0; i < j.controller.Iterations; i++ {

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -40,7 +40,7 @@ func makeBSONToParquetBackfillJob() *bsonToParquetBackfillJob {
 	return &bsonToParquetBackfillJob{
 		Base: job.Base{
 			JobType: amboy.JobType{
-				Name:    findOutdatedRollupsJobName,
+				Name:    bsonToParquetBackfillJobName,
 				Version: 1,
 			},
 		},

--- a/units/bson_to_parquet_backfill.go
+++ b/units/bson_to_parquet_backfill.go
@@ -1,0 +1,178 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/model"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/anser/bsonutil"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const bsonToParquetBackfillJobName = "bson-to-parquet-backfill"
+
+type bsonToParquetBackfillJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+
+	env         cedar.Environment
+	queue       amboy.Queue
+	controller  *model.BatchJobController
+	migrationID string
+}
+
+func init() {
+	registry.AddJobType(bsonToParquetBackfillJobName, func() amboy.Job { return makeBSONToParquetBackfillJob() })
+}
+
+func makeBSONToParquetBackfillJob() *bsonToParquetBackfillJob {
+	return &bsonToParquetBackfillJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    findOutdatedRollupsJobName,
+				Version: 1,
+			},
+		},
+	}
+}
+
+func NewBSONToParquetBackfillJob(id string) amboy.Job {
+	j := makeBSONToParquetBackfillJob()
+	j.SetID(fmt.Sprintf("%s.%s", bsonToParquetBackfillJobName, id))
+	j.SetEnqueueAllScopes(true)
+
+	return j
+}
+
+func (j *bsonToParquetBackfillJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = cedar.GetEnvironment()
+	}
+	if j.queue == nil {
+		j.queue = j.env.GetRemoteQueue()
+	}
+
+	controller, err := model.FindBatchJobController(ctx, j.env, bsonToParquetBackfillJobName)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "getting batch job controller"))
+		return
+	}
+	if controller.Iterations <= 0 {
+		controller.Iterations = 1
+	}
+	j.controller = controller
+
+	if j.controller.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, j.controller.Timeout)
+		defer cancel()
+	}
+
+	for i := 0; i < j.controller.Iterations; i++ {
+		if err = j.runIteration(ctx); err != nil {
+			j.AddError(err)
+			return
+		}
+	}
+}
+
+func (j *bsonToParquetBackfillJob) runIteration(ctx context.Context) error {
+	start := time.Now().UTC()
+	collection := j.env.GetDB().Collection(j.controller.Collection)
+
+	// This is really ugly, but unfortunately Mongo does not allow setting
+	// limits on UpdateMany operations so we have to do a BulkWrite with
+	// the batch size number of UpdateOne operations.
+	updates := make([]mongo.WriteModel, j.controller.BatchSize)
+	for i := 0; i < j.controller.BatchSize; i++ {
+		updates[i] = mongo.NewUpdateOneModel().
+			SetFilter(bson.M{"$or": []bson.M{
+				bson.M{model.TestResultsMigrationKey: bson.M{"$exists": false}},
+				bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsVersionKey): bson.M{"$lt": j.controller.Version}},
+				bson.M{"$and": []bson.M{
+					bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsStartedAtKey): bson.M{"$and": []bson.M{
+						bson.M{"gt": time.Time{}},
+						bson.M{"lt": time.Now().Add(-j.controller.Timeout)},
+					}}},
+					bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsCompletedAtKey): time.Time{}},
+				}},
+			}}).
+			SetUpdate(bson.M{"$set": bson.M{
+				model.TestResultsMigrationKey: &model.MigrationStats{
+					MigratorID: j.ID(),
+					StartedAt:  start,
+					Version:    j.controller.Version,
+				},
+			}})
+	}
+	bulkWriteResult, err := collection.BulkWrite(ctx, updates)
+	if err != nil {
+		return errors.Wrap(err, "marking test results for migration in temporary collection")
+	}
+	if bulkWriteResult.MatchedCount == 0 {
+		grip.Info(message.Fields{
+			"job_name": bsonToParquetBackfillJobName,
+			"message":  "test results BSON to Parquet backfill complete",
+		})
+		return nil
+	}
+
+	cur, err := collection.Find(
+		ctx,
+		bson.M{
+			bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsMigratorIDKey):  j.ID(),
+			bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsCompletedAtKey): time.Time{},
+		},
+		options.Find().SetLimit(int64(j.controller.BatchSize)),
+	)
+	if err != nil {
+		return errors.Wrap(err, "getting test results from temporary collection")
+	}
+	defer func() {
+		j.AddError(errors.Wrap(cur.Close(ctx), "closing DB cursor"))
+	}()
+
+	var results []model.TestResults
+	if err = cur.All(ctx, &results); err != nil {
+		return errors.Wrap(err, "decoding test results from temporary collection")
+	}
+
+	toUpdate := make([]string, len(results))
+	for i, result := range results {
+		if err = result.DownloadConvertAndWriteParquet(ctx); err != nil {
+			return errors.Wrap(err, "downloading, converting, and writing Parquet test results")
+		}
+
+		toUpdate[i] = result.ID
+	}
+
+	// TODO: Should this be a bulk update? Or should we update each
+	// individual test result doc after a successful write to the Presto
+	// bucket above?
+	updateResult, err := collection.UpdateMany(
+		ctx,
+		bson.M{"_id": bson.M{"$in": toUpdate}},
+		bson.M{"$set": bson.M{
+			bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsCompletedAtKey): time.Now(),
+		}},
+	)
+	if err != nil {
+		return errors.Wrap(err, "marking migrated test results complete in temporary collection")
+	}
+	if updateResult.ModifiedCount != int64(len(toUpdate)) {
+		return errors.Errorf("expected to mark complete %d migrated test results documents from temporary collection, but marked %d instead", len(toUpdate), updateResult.ModifiedCount)
+	}
+
+	return nil
+}

--- a/units/bson_to_parquet_backfill_test.go
+++ b/units/bson_to_parquet_backfill_test.go
@@ -1,0 +1,205 @@
+package units
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/cedar"
+	"github.com/evergreen-ci/cedar/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/anser/bsonutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func TestBSONToParquetBackfillJob(t *testing.T) {
+	env := cedar.GetEnvironment()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tmpDir, err := ioutil.TempDir(".", "bson-to-parquet-test")
+	require.NoError(t, err)
+
+	defer func() {
+		assert.NoError(t, tearDownEnv(env))
+		assert.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	config := model.NewCedarConfig(env)
+	config.Bucket.TestResultsBucket = tmpDir
+	config.Bucket.PrestoBucket = tmpDir
+	config.Bucket.PrestoTestResultsPrefix = "presto-test-results"
+	require.NoError(t, config.Save())
+
+	controller := model.BatchJobController{
+		ID:         bsonToParquetBackfillJobName,
+		Collection: "backfill_test_results",
+		Iterations: 10,
+		BatchSize:  10,
+	}
+	numDocs := controller.Iterations * controller.BatchSize
+	updateController(t, ctx, env, controller)
+	populateTestResults(t, ctx, env, controller.Collection, numDocs)
+
+	j1 := NewBSONToParquetBackfillJob("all-nil")
+	j1.Run(ctx)
+	require.NoError(t, j1.Error())
+
+	cur, err := env.GetDB().Collection(controller.Collection).Find(
+		ctx,
+		bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsMigratorIDKey): j1.ID()},
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cur.Close(ctx))
+	}()
+	var results []model.TestResults
+	require.NoError(t, cur.All(ctx, &results))
+
+	assert.Len(t, results, controller.BatchSize*controller.Iterations)
+	for _, result := range results {
+		assert.NotNil(t, result.Migration.StartedAt)
+		assert.NotNil(t, result.Migration.CompletedAt)
+		assert.Equal(t, controller.Version, result.Migration.Version)
+	}
+
+	// Update batch controller version.
+	controller.Version = 1
+	updateController(t, ctx, env, controller)
+	j2 := NewBSONToParquetBackfillJob("new-version")
+	j2.Run(ctx)
+	require.NoError(t, j2.Error())
+
+	cur, err = env.GetDB().Collection(controller.Collection).Find(
+		ctx,
+		bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsMigratorIDKey): j2.ID()},
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cur.Close(ctx))
+	}()
+	require.NoError(t, cur.All(ctx, &results))
+
+	assert.Len(t, results, controller.BatchSize*controller.Iterations)
+	for _, result := range results {
+		assert.NotNil(t, result.Migration.StartedAt)
+		assert.NotNil(t, result.Migration.CompletedAt)
+		assert.Equal(t, controller.Version, result.Migration.Version)
+	}
+
+	// Inject stale docs.
+	numStaleDocs := numDocs / 2
+	controller.Timeout = time.Hour
+	updateController(t, ctx, env, controller)
+	startedAt := time.Now().Add(-2 * controller.Timeout)
+	updateMigrationStats(t, ctx, env, controller.Collection, numStaleDocs, model.MigrationStats{
+		MigratorID: "stale-docs",
+		StartedAt:  &startedAt,
+	})
+
+	j3 := NewBSONToParquetBackfillJob("some-stale")
+	j3.Run(ctx)
+	require.NoError(t, j3.Error())
+
+	cur, err = env.GetDB().Collection(controller.Collection).Find(
+		ctx,
+		bson.M{bsonutil.GetDottedKeyName(model.TestResultsMigrationKey, model.MigrationStatsMigratorIDKey): j3.ID()},
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cur.Close(ctx))
+	}()
+	require.NoError(t, cur.All(ctx, &results))
+
+	assert.Len(t, results, numStaleDocs)
+	for _, result := range results {
+		assert.NotNil(t, result.Migration.StartedAt)
+		assert.NotNil(t, result.Migration.CompletedAt)
+		assert.Equal(t, controller.Version, result.Migration.Version)
+	}
+}
+
+func updateController(t *testing.T, ctx context.Context, env cedar.Environment, controller model.BatchJobController) {
+	_, err := env.GetDB().Collection(model.BatchJobControllerCollection).UpdateOne(
+		ctx,
+		bson.M{"_id": controller.ID},
+		bson.M{"$set": &controller},
+		options.Update().SetUpsert(true),
+	)
+	require.NoError(t, err)
+}
+
+func populateTestResults(t *testing.T, ctx context.Context, env cedar.Environment, tempCollection string, numDocs int) {
+	for i := 0; i < numDocs; i++ {
+		tr := getTestResults()
+		tr.Setup(env)
+		require.NoError(t, tr.SaveNew(ctx))
+		_, err := env.GetDB().Collection(tempCollection).InsertOne(ctx, tr)
+		require.NoError(t, err)
+		results := make([]model.TestResult, 100)
+		for j := 0; j < len(results); j++ {
+			results[j] = getTestResult()
+			results[j].TaskID = tr.Info.TaskID
+			results[j].Execution = tr.Info.Execution
+		}
+		require.NoError(t, tr.Append(ctx, results))
+	}
+}
+
+func updateMigrationStats(t *testing.T, ctx context.Context, env cedar.Environment, tempCollection string, numDocs int, stats model.MigrationStats) {
+	cur, err := env.GetDB().Collection(tempCollection).Find(ctx, bson.M{}, options.Find().SetLimit(int64(numDocs)))
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cur.Close(ctx))
+	}()
+	var results []model.TestResults
+	require.NoError(t, cur.All(ctx, &results))
+	require.Len(t, results, numDocs)
+
+	for _, result := range results {
+		_, err := env.GetDB().Collection(tempCollection).UpdateOne(
+			ctx,
+			bson.M{"_id": result.ID},
+			bson.M{"$set": bson.M{model.TestResultsMigrationKey: &stats}},
+		)
+		require.NoError(t, err)
+	}
+}
+
+func getTestResults() *model.TestResults {
+	return model.CreateTestResults(
+		model.TestResultsInfo{
+			Project:                utility.RandomString(),
+			Version:                utility.RandomString(),
+			Variant:                utility.RandomString(),
+			TaskName:               utility.RandomString(),
+			TaskID:                 utility.RandomString(),
+			Execution:              rand.Intn(5),
+			RequestType:            utility.RandomString(),
+			HistoricalDataDisabled: true,
+		},
+		model.PailLocal,
+	)
+}
+
+func getTestResult() model.TestResult {
+	return model.TestResult{
+		TestName:        utility.RandomString(),
+		DisplayTestName: utility.RandomString(),
+		GroupID:         utility.RandomString(),
+		Trial:           rand.Intn(10),
+		Status:          "Pass",
+		LogTestName:     utility.RandomString(),
+		LogURL:          utility.RandomString(),
+		RawLogURL:       utility.RandomString(),
+		LineNum:         rand.Intn(1000),
+		TaskCreateTime:  time.Now().Add(-time.Hour).UTC().Round(time.Millisecond),
+		TestStartTime:   time.Now().Add(-30 * time.Hour).UTC().Round(time.Millisecond),
+		TestEndTime:     time.Now().UTC().Round(time.Millisecond),
+	}
+}

--- a/units/bson_to_parquet_backfill_test.go
+++ b/units/bson_to_parquet_backfill_test.go
@@ -39,8 +39,9 @@ func TestBSONToParquetBackfillJob(t *testing.T) {
 	controller := model.BatchJobController{
 		ID:         bsonToParquetBackfillJobName,
 		Collection: "backfill_test_results",
-		Iterations: 10,
 		BatchSize:  10,
+		Iterations: 10,
+		Timeout:    time.Minute,
 	}
 	numDocs := controller.Iterations * controller.BatchSize
 	updateController(t, ctx, env, controller)

--- a/units/ftdc_rollups_test.go
+++ b/units/ftdc_rollups_test.go
@@ -5,42 +5,15 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/cedar"
 	"github.com/evergreen-ci/cedar/model"
 	"github.com/evergreen-ci/cedar/perf"
 	"github.com/mongodb/amboy/queue"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 )
-
-const testDBName = "cedar_test_config"
-
-func init() {
-	env, err := cedar.NewEnvironment(context.Background(), testDBName, &cedar.Configuration{
-		MongoDBURI:    "mongodb://localhost:27017",
-		DatabaseName:  testDBName,
-		SocketTimeout: time.Minute,
-		NumWorkers:    2,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	cedar.SetEnvironment(env)
-}
-
-func tearDownEnv(env cedar.Environment) error {
-	conf, session, err := cedar.GetSessionWithConfig(env)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer session.Close()
-	return errors.WithStack(session.DB(conf.DatabaseName).DropDatabase())
-}
 
 func TestFTDCRollupsJob(t *testing.T) {
 	if runtime.GOOS == "darwin" && os.Getenv("EVR_TASK_ID") != "" {

--- a/units/units_test.go
+++ b/units/units_test.go
@@ -1,13 +1,42 @@
 package units
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/cedar"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
+
+const testDBName = "cedar_test_units"
+
+func init() {
+	env, err := cedar.NewEnvironment(context.Background(), testDBName, &cedar.Configuration{
+		MongoDBURI:    "mongodb://localhost:27017",
+		DatabaseName:  testDBName,
+		SocketTimeout: time.Minute,
+		NumWorkers:    2,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	cedar.SetEnvironment(env)
+}
+
+func tearDownEnv(env cedar.Environment) error {
+	conf, session, err := cedar.GetSessionWithConfig(env)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer session.Close()
+	return errors.WithStack(session.DB(conf.DatabaseName).DropDatabase())
+}
 
 func TestAllRegisteredUnitsAreRemoteSafe(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16138

- Create a new Amboy job that migrates BSON test result data from our S3 bucket to Parquet format and writes it to the Presto bucket.
- Add a new `BatchJobController` model to enable controlling batch jobs without requiring app restarts/deploys.
- Add a new `MigrationStats` model, used as a sub-document in the `TestResults` docs in the temporary backfill collection for keeping track of the batch job stats and enabling versioning (in case we need to rerun the migration).
- Clean up some test files in the `units` package.

Testing
- I added unit tests, and we will test in this staging. The job itself will not be run yet in production.