### PR TITLE
EVG-16138: Run BSON to Parquet Test Results Backfill Job

### DIFF
--- a/model/config_flags.go
+++ b/model/config_flags.go
@@ -11,6 +11,8 @@ type OperationalFlags struct {
 	DisableInternalMetricsReporting bool `bson:"disable_internal_metrics_reporting" json:"disable_internal_metrics_reporting" yaml:"disable_internal_metrics_reporting"`
 	DisableSignalProcessing         bool `bson:"disable_signal_processing" json:"disable_signal_processing" yaml:"disable_signal_processing"`
 	DisableHistoricalTestData       bool `bson:"disable_historical_test_data" json:"disable_historical_test_data" yaml:"disable_historical_test_data"`
+	// TODO (EVG-16140): Remove this field once we do the BSON to Parquet cutover.
+	DisableTestResultsBackfill bool `bson:"disable_test_results_backfill" json:"disable_test_results_backfill" yaml:"disable_test_results_backfill"`
 
 	env cedar.Environment
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16138

- Add a new operations flag to the config to disable the job if needed.
- Run the job on each app server's local Amboy queue every minute.

