### PR TITLE
EVG-16137: Add TaskName and RequestType fields to TestResults Parquet struct

### DIFF
--- a/model/config_flags.go
+++ b/model/config_flags.go
@@ -11,7 +11,9 @@ type OperationalFlags struct {
 	DisableInternalMetricsReporting bool `bson:"disable_internal_metrics_reporting" json:"disable_internal_metrics_reporting" yaml:"disable_internal_metrics_reporting"`
 	DisableSignalProcessing         bool `bson:"disable_signal_processing" json:"disable_signal_processing" yaml:"disable_signal_processing"`
 	DisableHistoricalTestData       bool `bson:"disable_historical_test_data" json:"disable_historical_test_data" yaml:"disable_historical_test_data"`
-	// TODO (EVG-16140): Remove this field once we do the BSON to Parquet cutover.
+
+	// TODO (EVG-16140): Remove these fields once we do the BSON to Parquet cutover.
+	DisableParquetTestResults  bool `bson:"disable_parquet_test_results" json:"disable_parquet_test_results" yaml:"disable_parquet_test_results"`
 	DisableTestResultsBackfill bool `bson:"disable_test_results_backfill" json:"disable_test_results_backfill" yaml:"disable_test_results_backfill"`
 
 	env cedar.Environment

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -269,6 +269,15 @@ func (t *TestResults) uploadBSON(ctx context.Context, results []TestResult) erro
 }
 
 func (t *TestResults) uploadParquet(ctx context.Context, results *ParquetTestResults) error {
+	conf := &CedarConfig{}
+	conf.Setup(t.env)
+	if err := conf.Find(); err != nil {
+		return nil, errors.Wrap(err, "getting application configuration")
+	}
+	if conf.Flags.DisableParquetTestResults {
+		return nil
+	}
+
 	bucket, err := t.GetPrestoBucket(ctx)
 	if err != nil {
 		return err

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -272,7 +272,7 @@ func (t *TestResults) uploadParquet(ctx context.Context, results *ParquetTestRes
 	conf := &CedarConfig{}
 	conf.Setup(t.env)
 	if err := conf.Find(); err != nil {
-		return nil, errors.Wrap(err, "getting application configuration")
+		return errors.Wrap(err, "getting application configuration")
 	}
 	if conf.Flags.DisableParquetTestResults {
 		return nil

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -507,12 +507,14 @@ func (t *TestResults) convertToParquet(results []TestResult) *ParquetTestResults
 	}
 
 	return &ParquetTestResults{
-		TaskID:    t.Info.TaskID,
-		Execution: int32(t.Info.Execution),
-		Variant:   t.Info.Variant,
-		Version:   t.Info.Version,
-		CreatedAt: types.TimeToTIMESTAMP_MILLIS(t.CreatedAt.UTC(), true),
-		Results:   convertedResults,
+		Version:     t.Info.Version,
+		Variant:     t.Info.Variant,
+		TaskName:    t.Info.TaskName,
+		TaskID:      t.Info.TaskID,
+		Execution:   int32(t.Info.Execution),
+		RequestType: t.Info.RequestType,
+		CreatedAt:   types.TimeToTIMESTAMP_MILLIS(t.CreatedAt.UTC(), true),
+		Results:     convertedResults,
 	}
 }
 
@@ -1310,12 +1312,14 @@ func FindTestResultsByProject(ctx context.Context, env cedar.Environment, opts F
 // ParquetTestResults describes a set of test results from a task execution to
 // be stored in Apache Parquet format.
 type ParquetTestResults struct {
-	Version   string              `parquet:"name=version, type=BYTE_ARRAY, convertedtype=UTF8"`
-	Variant   string              `parquet:"name=variant, type=BYTE_ARRAY, convertedtype=UTF8"`
-	TaskID    string              `parquet:"name=task_id, type=BYTE_ARRAY, convertedtype=UTF8"`
-	Execution int32               `parquet:"name=execution, type=INT32"`
-	CreatedAt int64               `parquet:"name=created_at, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
-	Results   []ParquetTestResult `parquet:"name=results, type=LIST"`
+	Version     string              `parquet:"name=version, type=BYTE_ARRAY, convertedtype=UTF8"`
+	Variant     string              `parquet:"name=variant, type=BYTE_ARRAY, convertedtype=UTF8"`
+	TaskName    string              `parquet:"name=task_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	TaskID      string              `parquet:"name=task_id, type=BYTE_ARRAY, convertedtype=UTF8"`
+	Execution   int32               `parquet:"name=execution, type=INT32"`
+	RequestType string              `parquet:"name=request_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	CreatedAt   int64               `parquet:"name=created_at, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true"`
+	Results     []ParquetTestResult `parquet:"name=results, type=LIST"`
 }
 
 func (r ParquetTestResults) convertToTestResultSlice() []TestResult {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16137

- Add fields that are necessary for the test stats API.
- Update tests and make testing more robust.
- Add a new operations flag `DisableParquetTestResults` to disable writing Parquet test results to the Presto bucket.