### PR TITLE
EVG-16140: Read test stats from new collection

### DIFF
--- a/model/historical_test_data.go
+++ b/model/historical_test_data.go
@@ -19,7 +19,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-const historicalTestDataCollection = "historical_test_data"
+const historicalTestDataCollection = "presto_historical_test_data"
 
 // HistoricalTestData describes aggregated test result data for a given date
 // range.


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-16140

We are moving all test stats to a new (unsharded) collection called `presto_historical_test_data`. The application should read from that collection when processing test stats requests.