### PR TITLE
EVG-16988 Update FindTestResults to handle new execution task logic

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -727,8 +727,11 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts FindTestRe
 		return nil, errors.Wrap(err, "invalid find options")
 	}
 
-	var cur *mongo.Cursor
-	var err error
+	var (
+		cur *mongo.Cursor
+		err error
+	)
+
 	if opts.DisplayTask {
 		pipeline := opts.createPipelineForDisplayTasks()
 		cur, err = env.GetDB().Collection(testResultsCollection).Aggregate(ctx, pipeline)

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -699,19 +699,66 @@ func TestFindTestResults(t *testing.T) {
 		}
 		assert.Equal(t, 2, count)
 	})
+	t.Run("WithDisplayTaskIDAndRestartedExecution", func(t *testing.T) {
+		opts := FindTestResultsOptions{
+			TaskID:      "display",
+			Execution:   utility.ToIntPtr(1),
+			DisplayTask: true,
+		}
+		results, err := FindTestResults(ctx, env, opts)
+		require.NoError(t, err)
+		count := 0
+		for _, result := range results {
+			if result.ID == tr2.ID {
+				assert.Equal(t, tr2.ID, result.ID)
+				assert.Equal(t, tr2.Info, result.Info)
+				assert.Equal(t, tr2.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
+				count++
+			}
+			if result.ID == tr3.ID {
+				assert.Equal(t, tr3.ID, result.ID)
+				assert.Equal(t, tr3.Info, result.Info)
+				assert.Equal(t, tr3.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
+				count++
+			}
+		}
+		assert.Equal(t, 2, count)
+	})
 	t.Run("WithDisplayTaskIDWithoutExecution", func(t *testing.T) {
+		randomTask := getTestResults()
+		randomTask.Info.Execution = 1
+		_, err := db.Collection(testResultsCollection).InsertOne(ctx, randomTask)
+		require.NoError(t, err)
 		opts := FindTestResultsOptions{
 			TaskID:      "display",
 			DisplayTask: true,
 		}
 		results, err := FindTestResults(ctx, env, opts)
 		require.NoError(t, err)
-		require.Len(t, results, 1)
-		assert.Equal(t, tr2.ID, results[0].ID)
-		assert.Equal(t, tr2.Info, results[0].Info)
-		assert.Equal(t, tr2.Artifact, results[0].Artifact)
-		assert.True(t, results[0].populated)
-		assert.Equal(t, env, results[0].env)
+		count := 0
+		for _, result := range results {
+			if result.ID == tr2.ID {
+				assert.Equal(t, tr2.ID, result.ID)
+				assert.Equal(t, tr2.Info, result.Info)
+				assert.Equal(t, tr2.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
+				count++
+			}
+			if result.ID == tr3.ID {
+				assert.Equal(t, tr3.ID, result.ID)
+				assert.Equal(t, tr3.Info, result.Info)
+				assert.Equal(t, tr3.Artifact, result.Artifact)
+				assert.True(t, result.populated)
+				assert.Equal(t, env, result.env)
+				count++
+			}
+		}
+		assert.Equal(t, 2, count)
 	})
 }
 

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -980,8 +980,8 @@ func TestGetTestResultsStats(t *testing.T) {
 				DisplayTask: true,
 			},
 			expectedStats: TestResultsStats{
-				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount,
-				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount,
+				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount + tr4.Stats.TotalCount,
+				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount + tr4.Stats.FailedCount,
 			},
 		},
 	} {

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -230,14 +230,17 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 				DisplayTask: true,
 			},
 			stats: model.APITestResultsStats{
-				TotalCount:    3,
-				FailedCount:   3,
-				FilteredCount: utility.ToIntPtr(3),
+				TotalCount:    6,
+				FailedCount:   6,
+				FilteredCount: utility.ToIntPtr(6),
 			},
 			resultMap: map[string]model.APITestResult{
 				"task1_1_test0": s.apiResults["task1_1_test0"],
 				"task1_1_test1": s.apiResults["task1_1_test1"],
 				"task1_1_test2": s.apiResults["task1_1_test2"],
+				"task2_0_test0": s.apiResults["task2_0_test0"],
+				"task2_0_test1": s.apiResults["task2_0_test1"],
+				"task2_0_test2": s.apiResults["task2_0_test2"],
 			},
 		},
 		{
@@ -342,7 +345,14 @@ func (s *testResultsConnectorSuite) TestGetFailedTestResultsSample() {
 				TaskID:      "display_task1",
 				DisplayTask: true,
 			},
-			expectedResult: []string{"test0", "test1", "test2"},
+			expectedResult: []string{
+				"test0",
+				"test1",
+				"test2",
+				"test0",
+				"test1",
+				"test2",
+			},
 		},
 	} {
 		s.T().Run(test.name, func(t *testing.T) {
@@ -422,8 +432,8 @@ func (s *testResultsConnectorSuite) TestGetTestResultsStats() {
 				DisplayTask: true,
 			},
 			expectedResult: &model.APITestResultsStats{
-				TotalCount:  3,
-				FailedCount: 3,
+				TotalCount:  6,
+				FailedCount: 6,
 			},
 		},
 	} {

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -257,7 +257,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIDHandler() {
 					FailedCount:   6,
 					FilteredCount: utility.ToIntPtr(6),
 				},
-				Results: append(s.apiResults["def"], s.apiResults["ghi"]...),
+				Results: append(append([]model.APITestResult{}, s.apiResults["def"]...), s.apiResults["ghi"]...),
 			},
 		},
 		{
@@ -272,7 +272,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIDHandler() {
 					FailedCount:   6,
 					FilteredCount: utility.ToIntPtr(6),
 				},
-				Results: append(s.apiResults["def"], s.apiResults["ghi"]...),
+				Results: append(append([]model.APITestResult{}, s.apiResults["def"]...), s.apiResults["ghi"]...),
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIDHandler() {
 					FailedCount:   6,
 					FilteredCount: utility.ToIntPtr(2),
 				},
-				Results: append(s.apiResults["def"][1:2], s.apiResults["ghi"][1:2]...),
+				Results: []model.APITestResult{s.apiResults["def"][1], s.apiResults["ghi"][1]},
 			},
 		},
 	} {


### PR DESCRIPTION
find test results will now do an aggregation for execution tasks and return previous executions as well 

example 
display_task {
    et1: execution 0
    et2: execution 0, 1
}

findTestResults(execution = 1) -> returns et1 exec0, et2 exec 1
findTestResults(execution = empty) -> returns et1 exec0, et2 exec 1 (latest for all exec tasks)
findTestResults(execution = 0) -> returns et1 exec0, et2 exec 0


This changes the return value for execution tasks so I'm not sure if this will break things on evergreen? 
