### PR TITLE
EVG-16225 fix flakey tests

### DIFF
--- a/benchmarks/log_iterator_benchmarks.go
+++ b/benchmarks/log_iterator_benchmarks.go
@@ -136,7 +136,7 @@ func getLogIteratorBenchmarkSuite(ctx context.Context, artifact model.LogArtifac
 		EndAt:   artifact.Chunks[len(artifact.Chunks)-1].End,
 	}
 	return poplar.BenchmarkSuite{
-		{
+		&poplar.BenchmarkCase{
 			CaseName:         "SerializedIterator",
 			Bench:            getLogIteratorBenchmark(model.NewSerializedLogIterator(bucket, artifact.Chunks, tr)),
 			MinRuntime:       time.Millisecond,
@@ -147,7 +147,7 @@ func getLogIteratorBenchmarkSuite(ctx context.Context, artifact model.LogArtifac
 			MaxIterations:    2,
 			Recorder:         poplar.RecorderPerf,
 		},
-		{
+		&poplar.BenchmarkCase{
 
 			CaseName:         "ParallelizedIterator",
 			Bench:            getLogIteratorBenchmark(model.NewParallelizedLogIterator(bucket, artifact.Chunks, tr)),
@@ -159,7 +159,7 @@ func getLogIteratorBenchmarkSuite(ctx context.Context, artifact model.LogArtifac
 			MaxIterations:    2,
 			Recorder:         poplar.RecorderPerf,
 		},
-		{
+		&poplar.BenchmarkCase{
 
 			CaseName:         "BatchedIteratorBatchSize2",
 			Bench:            getLogIteratorBenchmark(model.NewBatchedLogIterator(bucket, artifact.Chunks, 2, tr)),

--- a/benchmarks/timber_benchmarks.go
+++ b/benchmarks/timber_benchmarks.go
@@ -83,7 +83,7 @@ func RunBasicSenderBenchmark(ctx context.Context) error {
 
 func getBasicSenderSuite(logSize int) poplar.BenchmarkSuite {
 	return poplar.BenchmarkSuite{
-		{
+		&poplar.BenchmarkCase{
 			CaseName:         "100KBBuffer",
 			Bench:            getBasicSenderBenchmark(logSize, 1e5),
 			MinRuntime:       time.Millisecond,
@@ -95,7 +95,7 @@ func getBasicSenderSuite(logSize int) poplar.BenchmarkSuite {
 			MaxIterations:    2,
 			Recorder:         poplar.RecorderPerf,
 		},
-		{
+		&poplar.BenchmarkCase{
 
 			CaseName:         "1MBBuffer",
 			Bench:            getBasicSenderBenchmark(logSize, 1e6),
@@ -108,7 +108,7 @@ func getBasicSenderSuite(logSize int) poplar.BenchmarkSuite {
 			MaxIterations:    2,
 			Recorder:         poplar.RecorderPerf,
 		},
-		{
+		&poplar.BenchmarkCase{
 
 			CaseName:         "10MBBuffer",
 			Bench:            getBasicSenderBenchmark(logSize, 1e7),
@@ -121,7 +121,7 @@ func getBasicSenderSuite(logSize int) poplar.BenchmarkSuite {
 			MaxIterations:    2,
 			Recorder:         poplar.RecorderPerf,
 		},
-		{
+		&poplar.BenchmarkCase{
 
 			CaseName:         "100MBBuffer",
 			Bench:            getBasicSenderBenchmark(logSize, 1e8),

--- a/model/log_iterator_test.go
+++ b/model/log_iterator_test.go
@@ -194,15 +194,10 @@ func TestLogIterator(t *testing.T) {
 func TestMergeLogIterator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tmpDir, err := ioutil.TempDir(".", "merge-logs-test")
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tmpDir))
-	}()
-	bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: tmpDir})
-	require.NoError(t, err)
 
 	t.Run("SingleLog", func(t *testing.T) {
+		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+		require.NoError(t, err)
 		chunks, lines, err := GenerateTestLog(ctx, bucket, 100, 10)
 		require.NoError(t, err)
 		timeRange := TimeRange{
@@ -227,6 +222,8 @@ func TestMergeLogIterator(t *testing.T) {
 		its := make([]LogIterator, numLogs)
 		lineMap := map[string]bool{}
 		for i := 0; i < numLogs; i++ {
+			bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+			require.NoError(t, err)
 			chunks, lines, err := GenerateTestLog(ctx, bucket, 100, 10)
 			require.NoError(t, err)
 
@@ -263,6 +260,8 @@ func TestMergeLogIterator(t *testing.T) {
 		its := make([]LogIterator, numLogs)
 		lineMap := map[string]bool{}
 		for i := 0; i < numLogs; i++ {
+			bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+			require.NoError(t, err)
 			chunks, lines, err := GenerateTestLog(ctx, bucket, 100, 10)
 			require.NoError(t, err)
 
@@ -294,6 +293,8 @@ func TestMergeLogIterator(t *testing.T) {
 		assert.NoError(t, it.Close())
 	})
 	t.Run("SomeExhausted", func(t *testing.T) {
+		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+		require.NoError(t, err)
 		chunks, _, err := GenerateTestLog(ctx, bucket, 100, 10)
 		require.NoError(t, err)
 		timeRange := TimeRange{

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -480,6 +480,8 @@ func TestTestResultsDownload(t *testing.T) {
 		}
 		w, err := testBucket.Writer(ctx, fmt.Sprintf("%s/%s", conf.Bucket.PrestoTestResultsPrefix, tr.PrestoPartitionKey()))
 		require.NoError(t, err)
+		defer func() { assert.NoError(t, w.Close()) }()
+
 		pw := floor.NewWriter(goparquet.NewFileWriter(w, goparquet.WithSchemaDefinition(parquetTestResultsSchemaDef)))
 		require.NoError(t, pw.Write(savedParquet))
 		require.NoError(t, pw.Close())

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -394,10 +394,8 @@ func TestTestResultsDownload(t *testing.T) {
 	db := env.GetDB()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tmpDir, err := ioutil.TempDir(".", "download-test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 	defer func() {
-		assert.NoError(t, os.RemoveAll(tmpDir))
 		assert.NoError(t, db.Collection(configurationCollection).Drop(ctx))
 		assert.NoError(t, db.Collection(testResultsCollection).Drop(ctx))
 	}()


### PR DESCRIPTION
[EVG-16225](https://jira.mongodb.org/browse/EVG-16225)

These are the tasks/tests that are somewhat consistently broken on the waterfall:


- [TestMergeLogIterator](https://github.com/evergreen-ci/cedar/blob/1e54beabc6b94e499b4322c875144a6bad55835f/model/log_iterator_test.go#L220) It seems like the issue is that the multiple log iterators have identical chunk keys when all the logs are created in the same millisecond (which is pretty likely) and if pail writes the second iterator's logs with the same key they get [overwritten](https://github.com/evergreen-ci/pail/blob/6bd16e3e14f02deb552e6a42a93c5a170f66ffbb/local.go#L123) ("truncated"). Giving each iterator its own backing tempdir solves this.
- [Lint for getLogIteratorBenchmarkSuite](https://github.com/evergreen-ci/cedar/blob/49eaa32561fb1089ef0bdc8db46a219a1f7dda92/benchmarks/log_iterator_benchmarks.go#L123). I'm not really sure what the issue is with bucket and tr [being declared and not used](https://evergreen.mongodb.com/test_log/sink_lint_lint_benchmarks_fcfb3872eebf6568f35d9de77c156a1f7b5765bd_22_10_03_16_43_13/0?test_name=output.benchmarks.lint&group_id=#L10). They're definitely used afaict. I also don't get why [it wants a type for the elements in the slice](https://evergreen.mongodb.com/test_log/sink_lint_lint_benchmarks_fcfb3872eebf6568f35d9de77c156a1f7b5765bd_22_10_03_16_43_13/0?test_name=output.benchmarks.lint&group_id=#L1). On the contrary, I thought we found them extraneous since we can figure it out from the slice type (the simplifycompositelit analyzer from gopls calls this out). 🤷 I added the type to this and a subsequent test. This seems to appease the linter.
- [TestTestResultsDownload](https://github.com/evergreen-ci/cedar/blob/d352b67c2861b84eb62c0ce60aa61d46879d8184/model/test_results_test.go#L392) defers removing the tempdir. The error is "[The process cannot access the file because it is being used by another process](https://evergreen.mongodb.com/test_log/sink_windows_test_model_03d368c75b39308729c07ff45db26537fe5565bb_22_10_03_15_20_48/0?test_name=output.model.test&group_id=#L809)". It seems like not closing the file in the same process is also included in this error. It's true that [windows won't let you delete a directory/file with open file handles](https://learn.microsoft.com/en-us/windows/win32/fileio/closing-and-deleting-files#:~:text=A%20file%20cannot%20be%20deleted%20until%20all%20handles%20to%20it%20are%20closed). I'm not sure why it doesn't always fail.