### PR TITLE
EVG-18423: update Dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-      time: "10:00"
+      time: "06:00"
+      timezone:  "America/New_York"
     open-pull-requests-limit: 99
     commit-message:
       prefix: "CHORE: "
     reviewers:
-      - kimchelly
+      - evg-plt


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18423

Change the Dependabot PR reviewers to team review. I've historically maintained Dependabot upgrades for PLT repos. The way it works is that, once per month on the first day of the month, Dependabot will search all our dependencies in our `go.mod` that use Go semantic versioning. It would then open PRs for those modules that have an updated version available, which are then manually reviewed and merged. I used a script to manage quickly merging those that passed all CI tests.

Once this is merged, I'm also going to apply this change to all the other Go repos (aside from evergreen-ci/evergreen, which isn't using Dependabot yet) without review, since these settings are basically the same across all our repos.

Checking and merging Dependabot PRs is a fairly smooth and easy process. The only catch is that right now, some of the modules we depend on (such as aws-sdk-go and gopsutil) have released new versions that rely on go1.17 features. Even though it's no longer officially supported, we have to compile for go1.16 until [EVG-18584](https://jira.mongodb.org/browse/EVG-18584) is done. For now, I just close PRs for dependencies that require go1.17.

* Update Dependabot PR reviewers.
* Update timezone to be less ambiguous (it uses UTC by default, but it seemed better to make it explicit).