### PR TITLE
EVG-18798: Add multi-task test results rest routes

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -893,7 +893,7 @@ type TestResultsFilterAndSortOptions struct {
 	baseStatusMap map[string]string
 }
 
-func (o *TestResultsFilterAndSortOptions) validate() error {
+func (o *TestResultsFilterAndSortOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 
 	catcher.AddWhen(o.SortBy != "", o.SortBy.validate())
@@ -991,7 +991,7 @@ func filterAndSortTestResults(ctx context.Context, env cedar.Environment, result
 		return results, len(results), nil
 	}
 
-	if err := opts.validate(); err != nil {
+	if err := opts.Validate(); err != nil {
 		return nil, 0, errors.Wrap(err, "validating filter and sort test results options")
 	}
 

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -70,6 +70,7 @@ type TestResults struct {
 	bucket             string
 	prestoBucketPrefix string
 	populated          bool
+	results            []TestResult
 }
 
 var (
@@ -922,64 +923,56 @@ func FindAndDownloadTestResults(ctx context.Context, env cedar.Environment, task
 	}
 
 	stats := TestResultsStats{}
-	testResultsChan := make(chan TestResults, len(testResults))
+	toDownload := make(chan *TestResults, len(testResults))
 	for i := range testResults {
 		stats.TotalCount += testResults[i].Stats.TotalCount
 		stats.FailedCount += testResults[i].Stats.FailedCount
 
-		testResultsChan <- testResults[i]
+		toDownload <- &testResults[i]
 	}
-	close(testResultsChan)
+	close(toDownload)
 
-	var (
-		combinedResults []TestResult
-		cwg             sync.WaitGroup
-		pwg             sync.WaitGroup
-	)
-	combinedResultsChan := make(chan []TestResult, len(testResults))
+	var wg sync.WaitGroup
 	catcher := grip.NewBasicCatcher()
-	cwg.Add(1)
-	go func() {
-		defer func() {
-			catcher.Add(recovery.HandlePanicWithError(recover(), nil, "test results download consumer"))
-			cwg.Done()
-		}()
-
-		for results := range combinedResultsChan {
-			combinedResults = append(combinedResults, results...)
-		}
-	}()
-
 	for i := 0; i < runtime.NumCPU(); i++ {
-		pwg.Add(1)
+		wg.Add(1)
 		go func() {
 			defer func() {
 				catcher.Add(recovery.HandlePanicWithError(recover(), nil, "test results download producer"))
-				pwg.Done()
+				wg.Done()
 			}()
 
-			for trs := range testResultsChan {
+			for trs := range toDownload {
 				results, err := trs.Download(ctx)
 				if err != nil {
 					catcher.Add(err)
 					return
 				}
+				trs.results = results
 
-				select {
-				case <-ctx.Done():
-					catcher.Add(ctx.Err())
+				if err = ctx.Err(); err != nil {
+					catcher.Add(err)
 					return
-				case combinedResultsChan <- results:
 				}
 			}
 		}()
 	}
-	pwg.Wait()
-	close(combinedResultsChan)
-	cwg.Wait()
-
+	wg.Wait()
 	if catcher.HasErrors() {
 		return TestResultsStats{}, nil, catcher.Resolve()
+	}
+
+	// Sort the test results in order by (task ID, execution) to ensure
+	// that paginated responses return consistent results.
+	sort.SliceStable(testResults, func(i, j int) bool {
+		if testResults[i].Info.TaskID == testResults[j].Info.TaskID {
+			return testResults[i].Info.Execution < testResults[j].Info.Execution
+		}
+		return testResults[i].Info.TaskID < testResults[j].Info.TaskID
+	})
+	var combinedResults []TestResult
+	for _, trs := range testResults {
+		combinedResults = append(combinedResults, trs.results...)
 	}
 
 	filteredResults, filteredCount, err := filterAndSortTestResults(ctx, env, combinedResults, filterOpts)

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -887,7 +887,7 @@ type TestResultsFilterAndSortOptions struct {
 	SortOrderDSC bool
 	Limit        int
 	Page         int
-	BaseResults  []TestResultsTaskOptions
+	BaseTasks    []TestResultsTaskOptions
 
 	testNameRegex *regexp.Regexp
 	baseStatusMap map[string]string
@@ -897,7 +897,7 @@ func (o *TestResultsFilterAndSortOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 
 	catcher.AddWhen(o.SortBy != "", o.SortBy.validate())
-	catcher.NewWhen(o.SortBy == TestResultsSortByBaseStatus && o.BaseResults == nil, "must specify base task ID when sorting by base status")
+	catcher.NewWhen(o.SortBy == TestResultsSortByBaseStatus && len(o.BaseTasks) == 0, "must specify base task ID when sorting by base status")
 	catcher.NewWhen(o.Limit < 0, "limit cannot be negative")
 	catcher.NewWhen(o.Page < 0, "page cannot be negative")
 	catcher.NewWhen(o.Limit == 0 && o.Page > 0, "cannot specify a page without a limit")
@@ -995,8 +995,8 @@ func filterAndSortTestResults(ctx context.Context, env cedar.Environment, result
 		return nil, 0, errors.Wrap(err, "validating filter and sort test results options")
 	}
 
-	if opts.BaseResults != nil {
-		_, baseResults, err := FindAndDownloadTestResults(ctx, env, opts.BaseResults, nil)
+	if opts.BaseTasks != nil {
+		_, baseResults, err := FindAndDownloadTestResults(ctx, env, opts.BaseTasks, nil)
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "getting base test results")
 		}

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -1446,7 +1446,7 @@ func TestFilterTestNames(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.ElementsMatch(t, filteredSamples, []TestResultsSample{{MatchingFailedTestNames: testCase.expected}})
+				assert.Equal(t, filteredSamples, []TestResultsSample{{MatchingFailedTestNames: testCase.expected}})
 			}
 		})
 	}
@@ -1556,7 +1556,7 @@ func TestConsolidateSamples(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			assert.ElementsMatch(t, consolidateSamples(testCase.tasks, testCase.results), testCase.expected)
+			assert.Equal(t, consolidateSamples(testCase.tasks, testCase.results), testCase.expected)
 		})
 	}
 }
@@ -1687,7 +1687,7 @@ func TestMakeTestSamples(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.ElementsMatch(t, samples, testCase.expected)
+				assert.Equal(t, samples, testCase.expected)
 			}
 		})
 	}
@@ -1768,7 +1768,7 @@ func TestGetTestResultsFilteredSamples(t *testing.T) {
 
 			samples, err := FindFailedTestResultsSamples(ctx, env, testCase.tasks, nil)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, testCase.expected, samples)
+			assert.Equal(t, testCase.expected, samples)
 		})
 	}
 }

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -1162,7 +1162,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			hasErr: true,
 		},
 		{
-			name:   "SortByBaseStatusWithoutBaseResultsFindOptions",
+			name:   "SortByBaseStatusWithoutBaseTasksFindOptions",
 			opts:   &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByBaseStatus},
 			hasErr: true,
 		},
@@ -1331,8 +1331,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByBaseStatusASC",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:      TestResultsSortByBaseStatus,
-				BaseResults: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
+				SortBy:    TestResultsSortByBaseStatus,
+				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[1],
@@ -1347,7 +1347,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				SortBy:       TestResultsSortByBaseStatus,
 				SortOrderDSC: true,
-				BaseResults:  []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
+				BaseTasks:    []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
@@ -1359,7 +1359,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "BaseStatus",
-			opts: &TestResultsFilterAndSortOptions{BaseResults: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}}},
+			opts: &TestResultsFilterAndSortOptions{BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}}},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
 				resultsWithBaseStatus[1],

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -819,7 +819,29 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 	conf.Setup(env)
 	require.NoError(t, conf.Save())
 
+	tr0 := getTestResults()
+	tr0.Info.TaskID = "task0"
+	tr0.Info.DisplayTaskID = "display"
+	tr0.Info.Execution = 0
+	tr0.populated = true
+	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr0)
+	require.NoError(t, err)
+
+	savedResults0 := make([]TestResult, 10)
+	for i := 0; i < len(savedResults0); i++ {
+		result := getTestResult()
+		result.TaskID = tr0.Info.TaskID
+		result.Execution = tr0.Info.Execution
+		if i%2 != 0 {
+			result.Status = "Fail"
+		}
+		savedResults0[i] = result
+	}
+	tr0.Setup(env)
+	require.NoError(t, tr0.Append(ctx, savedResults0))
+
 	tr1 := getTestResults()
+	tr1.Info.TaskID = "task1"
 	tr1.Info.DisplayTaskID = "display"
 	tr1.Info.Execution = 0
 	tr1.populated = true
@@ -831,17 +853,14 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 		result := getTestResult()
 		result.TaskID = tr1.Info.TaskID
 		result.Execution = tr1.Info.Execution
-		if i%2 != 0 {
-			result.Status = "Fail"
-		}
 		savedResults1[i] = result
 	}
 	tr1.Setup(env)
 	require.NoError(t, tr1.Append(ctx, savedResults1))
 
 	tr2 := getTestResults()
-	tr2.Info.DisplayTaskID = "display"
-	tr2.Info.Execution = 0
+	tr2.Info.TaskID = "task1"
+	tr2.Info.Execution = 1
 	tr2.populated = true
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
@@ -866,35 +885,37 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 				TaskID:    tr2.Info.TaskID,
 				Execution: utility.ToIntPtr(tr2.Info.Execution),
 			},
+			{
+				TaskID:    tr0.Info.TaskID,
+				Execution: utility.ToIntPtr(tr0.Info.Execution),
+			},
 		}
 		stats, results, err := FindAndDownloadTestResults(ctx, env, taskOpts, nil)
 		require.NoError(t, err)
 
-		require.Len(t, results, len(savedResults1)+len(savedResults2))
 		assert.Equal(t, len(results), stats.TotalCount)
 		assert.Equal(t, len(savedResults1)/2, stats.FailedCount)
 		assert.Equal(t, len(results), utility.FromIntPtr(stats.FilteredCount))
-		for _, result := range append(savedResults1, savedResults2...) {
-			require.Contains(t, results, result)
-		}
+		expectedResults := append(append(append([]TestResult{}, savedResults0...), savedResults1...), savedResults2...)
+		assert.Equal(t, expectedResults, results)
 	})
 	t.Run("WithFilterAndSortOpts", func(t *testing.T) {
 		taskOpts := []TestResultsTaskOptions{
 			{
-				TaskID:    tr1.Info.TaskID,
-				Execution: utility.ToIntPtr(tr1.Info.Execution),
+				TaskID:    tr0.Info.TaskID,
+				Execution: utility.ToIntPtr(tr0.Info.Execution),
 			},
 		}
 		filterOpts := &TestResultsFilterAndSortOptions{Statuses: []string{"Pass"}}
 		stats, results, err := FindAndDownloadTestResults(ctx, env, taskOpts, filterOpts)
 		require.NoError(t, err)
 
-		assert.Equal(t, len(savedResults1), stats.TotalCount)
-		assert.Equal(t, len(savedResults1)/2, stats.FailedCount)
-		assert.Equal(t, len(savedResults1)/2, utility.FromIntPtr(stats.FilteredCount))
-		require.Len(t, results, len(savedResults1)/2)
+		assert.Equal(t, len(savedResults0), stats.TotalCount)
+		assert.Equal(t, len(savedResults0)/2, stats.FailedCount)
+		assert.Equal(t, len(savedResults0)/2, utility.FromIntPtr(stats.FilteredCount))
+		require.Len(t, results, len(savedResults0)/2)
 		for i, result := range results {
-			assert.Equal(t, savedResults1[2*i], result)
+			require.Equal(t, savedResults0[2*i], result)
 		}
 	})
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -150,7 +150,7 @@ type TestResultsFilterAndSortOptions struct {
 	SortOrderDSC bool                     `json:"sort_order_dsc"`
 	Limit        int                      `json:"limit"`
 	Page         int                      `json:"page"`
-	BaseResults  []TestResultsTaskOptions `json:"base_results"`
+	BaseTasks    []TestResultsTaskOptions `json:"base_tasks"`
 }
 
 // PerformanceOptions holds all values required to find a specific

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -190,7 +190,7 @@ func convertToDBTestResultsFilterAndSortOptions(opts *TestResultsFilterAndSortOp
 		SortOrderDSC: opts.SortOrderDSC,
 		Limit:        opts.Limit,
 		Page:         opts.Page,
-		BaseResults:  convertToDBTestResultsTaskOptions(opts.BaseResults),
+		BaseTasks:    convertToDBTestResultsTaskOptions(opts.BaseTasks),
 	}
 	if err := dbOpts.Validate(); err != nil {
 		return nil, gimlet.ErrorResponse{

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -145,6 +145,18 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			hasErr: true,
 		},
 		{
+			name: "InvalidFilterOptions",
+			taskOpts: []TestResultsTaskOptions{
+				{
+					TaskID:    "task1",
+					Execution: utility.ToIntPtr(0),
+				},
+			},
+			filterOpts: &TestResultsFilterAndSortOptions{SortBy: "invalid_sort"},
+			hasErr:     true,
+		},
+
+		{
 			name:     "TaskIDDNE",
 			taskOpts: []TestResultsTaskOptions{{TaskID: "DNE"}},
 			stats:    model.APITestResultsStats{FilteredCount: utility.ToIntPtr(0)},

--- a/rest/service.go
+++ b/rest/service.go
@@ -318,6 +318,9 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/buildlogger/test_name/{task_id}/{test_name}/meta").Version(1).Get().Wrap(evgAuthReadLogByTaskID).RouteHandler(makeGetLogMetaByTestName(s.sc))
 	s.app.AddRoute("/buildlogger/test_name/{task_id}/{test_name}/group/{group_id}").Version(1).Get().Wrap(evgAuthReadLogByTaskID).RouteHandler(makeGetLogGroupByTestName(s.sc))
 
+	s.app.AddRoute("/test_results/tasks").Version(1).Get().RouteHandler(makeGetTestResultsByTasks(s.sc))
+	//s.app.AddRoute("/test_results/tasks/stats").Version(1).Get().RouteHandler(makeGetTestResultsStatsByTasks(s.sc))
+	//s.app.AddRoute("/test_results/tasks/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSampleByTasks(s.sc))
 	// TODO (EVG-18798): Remove these once Spruce and Evergreen are
 	// updated.
 	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskID(s.sc))

--- a/rest/service.go
+++ b/rest/service.go
@@ -319,10 +319,10 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/buildlogger/test_name/{task_id}/{test_name}/group/{group_id}").Version(1).Get().Wrap(evgAuthReadLogByTaskID).RouteHandler(makeGetLogGroupByTestName(s.sc))
 
 	s.app.AddRoute("/test_results/tasks").Version(1).Get().RouteHandler(makeGetTestResultsByTasks(s.sc))
-	//s.app.AddRoute("/test_results/tasks/stats").Version(1).Get().RouteHandler(makeGetTestResultsStatsByTasks(s.sc))
-	//s.app.AddRoute("/test_results/tasks/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSampleByTasks(s.sc))
-	// TODO (EVG-18798): Remove these once Spruce and Evergreen are
-	// updated.
+	s.app.AddRoute("/test_results/tasks/stats").Version(1).Get().RouteHandler(makeGetTestResultsStatsByTasks(s.sc))
+	s.app.AddRoute("/test_results/tasks/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSampleByTasks(s.sc))
+	// TODO (EVG-18798): Remove these test results routes once Spruce and
+	// Evergreen are updated.
 	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskID(s.sc))
 	s.app.AddRoute("/test_results/task_id/{task_id}/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSample(s.sc))
 	s.app.AddRoute("/test_results/task_id/{task_id}/stats").Version(1).Get().RouteHandler(makeGetTestResultsStats(s.sc))

--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -249,7 +249,7 @@ func (h *testResultsGetByTaskIDHandler) Parse(ctx context.Context, r *http.Reque
 		h.filterOpts.SortOrderDSC = true
 	}
 	if baseTaskID != "" {
-		h.filterOpts.BaseResults = []data.TestResultsTaskOptions{
+		h.filterOpts.BaseTasks = []data.TestResultsTaskOptions{
 			{
 				TaskID:      baseTaskID,
 				DisplayTask: h.taskOpts.DisplayTask,

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -318,7 +318,8 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 				},
 			},
 			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{FilteredCount: utility.ToIntPtr(0)},
+				Stats:   model.APITestResultsStats{FilteredCount: utility.ToIntPtr(0)},
+				Results: []model.APITestResult{},
 			},
 		},
 		{
@@ -403,19 +404,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 				s.Equal(test.expectedResult.Stats.FailedCount, actualResult.Stats.FailedCount)
 				s.Equal(test.expectedResult.Stats.TotalCount, actualResult.Stats.TotalCount)
 				s.Equal(test.expectedResult.Stats.FilteredCount, actualResult.Stats.FilteredCount)
-				s.Require().Equal(len(test.expectedResult.Results), len(actualResult.Results))
-				for _, expected := range test.expectedResult.Results {
-					found := false
-					for _, actual := range actualResult.Results {
-						if utility.FromStringPtr(expected.TestName) == utility.FromStringPtr(actual.TestName) &&
-							utility.FromStringPtr(expected.TaskID) == utility.FromStringPtr(actual.TaskID) &&
-							expected.Execution == actual.Execution {
-							found = true
-							break
-						}
-					}
-					s.True(found)
-				}
+				s.Equal(test.expectedResult.Results, actualResult.Results)
 			}
 		})
 	}

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -236,7 +236,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsBaseHandler() {
 					SortOrderDSC: true,
 					Limit:        100,
 					Page:         1,
-					BaseResults: []data.TestResultsTaskOptions{
+					BaseTasks: []data.TestResultsTaskOptions{
 						{
 							TaskID:    "base_task1",
 							Execution: utility.ToIntPtr(0),


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-18798

- Add three new routes to fetch test results, test result stats, and failed test sample by multiple (task ID, execution) pairs
- Fix pagination bug that was caused by not sorting test results that were downloaded in parallel (the order needs to be consistent for pagination to work properly)
- Write new tests for both the routes and the bug fix