### PR TITLE
EVG-18181: Fix how we calculate totalWallTime.

### DIFF
--- a/perf/ftdc_rollups_test.go
+++ b/perf/ftdc_rollups_test.go
@@ -62,12 +62,12 @@ func create25SecondOperations() ([]byte, error) {
 	recorder.BeginIteration()
 	recorder.IncOperations(1)
 	recorder.SetTime(time.Unix(1000000010, 0))
-	recorder.EndIteration(time.Duration(10 * time.Second))
+	recorder.EndIteration(10 * time.Second)
 
 	recorder.BeginIteration()
 	recorder.IncOperations(1)
 	recorder.SetTime(time.Unix(1000000025, 0))
-	recorder.EndIteration(time.Duration(10 * time.Second))
+	recorder.EndIteration(10 * time.Second)
 	data, err := collector.Resolve()
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/perf/rollup_factory.go
+++ b/perf/rollup_factory.go
@@ -145,7 +145,7 @@ type documentThroughput struct{}
 
 const (
 	documentThroughputName    = "DocumentThroughput"
-	documentThroughputVersion = 2
+	documentThroughputVersion = 1
 )
 
 func (f *documentThroughput) Type() string    { return documentThroughputName }

--- a/perf/rollup_factory.go
+++ b/perf/rollup_factory.go
@@ -120,7 +120,7 @@ type operationThroughput struct{}
 
 const (
 	operationThroughputName    = "OperationThroughput"
-	operationThroughputVersion = 4
+	operationThroughputVersion = 5
 )
 
 func (f *operationThroughput) Type() string    { return operationThroughputName }
@@ -145,7 +145,7 @@ type documentThroughput struct{}
 
 const (
 	documentThroughputName    = "DocumentThroughput"
-	documentThroughputVersion = 0
+	documentThroughputVersion = 2
 )
 
 func (f *documentThroughput) Type() string    { return documentThroughputName }
@@ -170,7 +170,7 @@ type sizeThroughput struct{}
 
 const (
 	sizeThroughputName    = "SizeThroughput"
-	sizeThroughputVersion = 4
+	sizeThroughputVersion = 5
 )
 
 func (f *sizeThroughput) Type() string    { return sizeThroughputName }
@@ -194,7 +194,7 @@ type errorThroughput struct{}
 
 const (
 	errorThroughputName    = "ErrorRate"
-	errorThroughputVersion = 4
+	errorThroughputVersion = 5
 )
 
 func (f *errorThroughput) Type() string    { return errorThroughputName }
@@ -366,7 +366,7 @@ type durationSum struct{}
 
 const (
 	durationSumName    = "DurationTotal"
-	durationSumVersion = 4
+	durationSumVersion = 5
 )
 
 func (f *durationSum) Type() string    { return durationSumName }

--- a/units/find_outdated_rollups.go
+++ b/units/find_outdated_rollups.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	findOutdatedRollupsJobName = "find-outdated-rollups"
-	maxOutdatedPerfResults     = 1000
+	maxOutdatedPerfResults     = 10000
 )
 
 type findOutdatedRollupsJob struct {

--- a/units/find_outdated_rollups.go
+++ b/units/find_outdated_rollups.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	findOutdatedRollupsJobName = "find-outdated-rollups"
-	maxOutdatedPerfResults     = 10000
+	maxOutdatedPerfResults     = 1000
 )
 
 type findOutdatedRollupsJob struct {


### PR DESCRIPTION
We weren't including the duration of the first operation in the totalWallTime calculation, which leads DurationTotal to be wrong in the trend charts / rollups.