### PR TITLE
EVG-18798: clean up TODOs and remove old routes

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
@@ -653,10 +652,6 @@ type TestResultsTaskOptions struct {
 	Execution int
 }
 
-func (opts *TestResultsTaskOptions) createFindOptions() *options.FindOptions {
-	return options.Find().SetSort(bson.D{{Key: bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey), Value: -1}})
-}
-
 func (opts *TestResultsTaskOptions) createFindQuery() bson.M {
 	return bson.M{
 		bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoTaskIDKey):    opts.TaskID,
@@ -679,7 +674,7 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts []TestResu
 		err error
 	)
 	if len(opts) == 1 {
-		cur, err = env.GetDB().Collection(testResultsCollection).Find(ctx, opts[0].createFindQuery(), opts[0].createFindOptions())
+		cur, err = env.GetDB().Collection(testResultsCollection).Find(ctx, opts[0].createFindQuery())
 	} else {
 		findQueries := make([]bson.M, len(opts))
 		for i, task := range opts {

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -649,52 +649,18 @@ func (t TestResult) convertToParquet() ParquetTestResult {
 // TestResultsTaskOptions specify the criteria for querying test results by
 // task.
 type TestResultsTaskOptions struct {
-	TaskID string
-	// TODO (EVG-18798): Make this field required once Evergreen and Spruce
-	// are updated.
-	Execution *int
-	// TODO (EVG-18798): Remove this field once Evergreen and Spruce are
-	// updated.
-	DisplayTask bool
+	TaskID    string
+	Execution int
 }
 
 func (opts *TestResultsTaskOptions) createFindOptions() *options.FindOptions {
-	findOpts := options.Find().SetSort(bson.D{{Key: bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey), Value: -1}})
-	if !opts.DisplayTask {
-		findOpts = findOpts.SetLimit(1)
-	}
-
-	return findOpts
+	return options.Find().SetSort(bson.D{{Key: bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey), Value: -1}})
 }
 
 func (opts *TestResultsTaskOptions) createFindQuery() bson.M {
-	if opts.DisplayTask {
-		query := bson.M{bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoDisplayTaskIDKey): opts.TaskID}
-		if opts.Execution != nil {
-			query[bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey)] = bson.M{"$lte": *opts.Execution}
-		}
-
-		return query
-	}
-
-	query := bson.M{bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoTaskIDKey): opts.TaskID}
-	if opts.Execution != nil {
-		query[bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey)] = *opts.Execution
-	}
-
-	return query
-}
-
-// TODO (EVG-18798): Remove once Evergreen and Spruce are updated.
-func (opts *TestResultsTaskOptions) createPipelineForDisplayTasks() []bson.M {
-	return []bson.M{
-		{"$match": opts.createFindQuery()},
-		{"$sort": bson.M{bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey): -1}},
-		{"$group": bson.M{
-			"_id":          "$" + bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoTaskIDKey),
-			"test_results": bson.M{"$first": "$$ROOT"},
-		}},
-		{"$replaceRoot": bson.M{"newRoot": "$test_results"}},
+	return bson.M{
+		bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoTaskIDKey):    opts.TaskID,
+		bsonutil.GetDottedKeyName(testResultsInfoKey, testResultsInfoExecutionKey): opts.Execution,
 	}
 }
 
@@ -713,11 +679,7 @@ func FindTestResults(ctx context.Context, env cedar.Environment, opts []TestResu
 		err error
 	)
 	if len(opts) == 1 {
-		if opts[0].DisplayTask {
-			cur, err = env.GetDB().Collection(testResultsCollection).Aggregate(ctx, opts[0].createPipelineForDisplayTasks())
-		} else {
-			cur, err = env.GetDB().Collection(testResultsCollection).Find(ctx, opts[0].createFindQuery(), opts[0].createFindOptions())
-		}
+		cur, err = env.GetDB().Collection(testResultsCollection).Find(ctx, opts[0].createFindQuery(), opts[0].createFindOptions())
 	} else {
 		findQueries := make([]bson.M, len(opts))
 		for i, task := range opts {
@@ -1043,35 +1005,6 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 func FindTestResultsStats(ctx context.Context, env cedar.Environment, opts []TestResultsTaskOptions) (TestResultsStats, error) {
 	if len(opts) == 0 {
 		return TestResultsStats{}, errors.New("must specify at least one task to search")
-	}
-
-	if opts[0].DisplayTask {
-		if env == nil {
-			return TestResultsStats{}, errors.New("cannot find with a nil environment")
-		}
-
-		pipeline := opts[0].createPipelineForDisplayTasks()
-		pipeline = append(pipeline, bson.M{
-			"$group": bson.M{
-				"_id": nil,
-				testResultsStatsTotalCountKey: bson.M{
-					"$sum": "$" + bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsTotalCountKey),
-				},
-				testResultsStatsFailedCountKey: bson.M{
-					"$sum": "$" + bsonutil.GetDottedKeyName(testResultsStatsKey, testResultsStatsFailedCountKey),
-				},
-			},
-		})
-		cur, err := env.GetDB().Collection(testResultsCollection).Aggregate(ctx, pipeline)
-		if err != nil {
-			return TestResultsStats{}, errors.Wrap(err, "aggregating test results stats")
-		}
-		if !cur.Next(ctx) {
-			return TestResultsStats{}, nil
-		}
-
-		var stats TestResultsStats
-		return stats, errors.Wrap(cur.Decode(&stats), "decoding aggregated test results stats")
 	}
 
 	testResultsRecords, err := FindTestResults(ctx, env, opts)

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -584,20 +584,17 @@ func TestFindTestResults(t *testing.T) {
 	}()
 
 	tr1 := getTestResults()
-	tr1.Info.DisplayTaskID = "display"
 	tr1.Info.Execution = 0
 	_, err := db.Collection(testResultsCollection).InsertOne(ctx, tr1)
 	require.NoError(t, err)
 
 	tr2 := getTestResults()
-	tr2.Info.DisplayTaskID = "display"
 	tr2.Info.TaskID = tr1.Info.TaskID
 	tr2.Info.Execution = 1
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr2)
 	require.NoError(t, err)
 
 	tr3 := getTestResults()
-	tr3.Info.DisplayTaskID = "display"
 	tr3.Info.Execution = 0
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr3)
 	require.NoError(t, err)
@@ -611,7 +608,7 @@ func TestFindTestResults(t *testing.T) {
 		opts := []TestResultsTaskOptions{
 			{
 				TaskID:    tr1.Info.TaskID,
-				Execution: utility.ToIntPtr(tr1.Info.Execution),
+				Execution: tr1.Info.Execution,
 			},
 		}
 		results, err := FindTestResults(ctx, nil, opts)
@@ -628,7 +625,7 @@ func TestFindTestResults(t *testing.T) {
 		opts := []TestResultsTaskOptions{
 			{
 				TaskID:    tr1.Info.TaskID,
-				Execution: utility.ToIntPtr(tr1.Info.Execution),
+				Execution: tr1.Info.Execution,
 			},
 		}
 		results, err := FindTestResults(ctx, env, opts)
@@ -645,133 +642,16 @@ func TestFindTestResults(t *testing.T) {
 		opts := []TestResultsTaskOptions{
 			{
 				TaskID:    tr2.Info.TaskID,
-				Execution: utility.ToIntPtr(tr2.Info.Execution),
+				Execution: tr2.Info.Execution,
 			},
 			{
 				TaskID:    tr3.Info.TaskID,
-				Execution: utility.ToIntPtr(tr3.Info.Execution),
+				Execution: tr3.Info.Execution,
 			},
 		}
 		results, err := FindTestResults(ctx, env, opts)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
-
-		count := 0
-		for _, result := range results {
-			if result.ID == tr2.ID {
-				assert.Equal(t, tr2.ID, result.ID)
-				assert.Equal(t, tr2.Info, result.Info)
-				assert.Equal(t, tr2.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-			if result.ID == tr3.ID {
-				assert.Equal(t, tr3.ID, result.ID)
-				assert.Equal(t, tr3.Info, result.Info)
-				assert.Equal(t, tr3.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-		}
-		assert.Equal(t, 2, count)
-	})
-	t.Run("TaskIDWithoutExecution", func(t *testing.T) {
-		opts := []TestResultsTaskOptions{
-			{
-				TaskID: tr2.Info.TaskID,
-			},
-		}
-		results, err := FindTestResults(ctx, env, opts)
-		require.NoError(t, err)
-		require.NotEmpty(t, results)
-
-		assert.Equal(t, tr2.ID, results[0].ID)
-		assert.Equal(t, tr2.Info, results[0].Info)
-		assert.Equal(t, tr2.Artifact, results[0].Artifact)
-		assert.True(t, results[0].populated)
-		assert.Equal(t, env, results[0].env)
-	})
-	t.Run("DisplayTaskIDAndExecution", func(t *testing.T) {
-		opts := []TestResultsTaskOptions{
-			{
-				TaskID:      "display",
-				Execution:   utility.ToIntPtr(0),
-				DisplayTask: true,
-			},
-		}
-		results, err := FindTestResults(ctx, env, opts)
-		require.NoError(t, err)
-
-		count := 0
-		for _, result := range results {
-			if result.ID == tr1.ID {
-				assert.Equal(t, tr1.ID, result.ID)
-				assert.Equal(t, tr1.Info, result.Info)
-				assert.Equal(t, tr1.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-			if result.ID == tr3.ID {
-				assert.Equal(t, tr3.ID, result.ID)
-				assert.Equal(t, tr3.Info, result.Info)
-				assert.Equal(t, tr3.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-		}
-		assert.Equal(t, 2, count)
-	})
-	t.Run("DisplayTaskIDAndRestartedExecution", func(t *testing.T) {
-		opts := []TestResultsTaskOptions{
-			{
-				TaskID:      "display",
-				Execution:   utility.ToIntPtr(1),
-				DisplayTask: true,
-			},
-		}
-		results, err := FindTestResults(ctx, env, opts)
-		require.NoError(t, err)
-
-		count := 0
-		for _, result := range results {
-			if result.ID == tr2.ID {
-				assert.Equal(t, tr2.ID, result.ID)
-				assert.Equal(t, tr2.Info, result.Info)
-				assert.Equal(t, tr2.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-			if result.ID == tr3.ID {
-				assert.Equal(t, tr3.ID, result.ID)
-				assert.Equal(t, tr3.Info, result.Info)
-				assert.Equal(t, tr3.Artifact, result.Artifact)
-				assert.True(t, result.populated)
-				assert.Equal(t, env, result.env)
-				count++
-			}
-			fmt.Println(result.ID)
-		}
-		assert.Equal(t, 2, count)
-	})
-	t.Run("DisplayTaskIDWithoutExecution", func(t *testing.T) {
-		randomTask := getTestResults()
-		randomTask.Info.Execution = 1
-		_, err := db.Collection(testResultsCollection).InsertOne(ctx, randomTask)
-		require.NoError(t, err)
-
-		opts := []TestResultsTaskOptions{
-			{
-				TaskID:      "display",
-				DisplayTask: true,
-			},
-		}
-		results, err := FindTestResults(ctx, env, opts)
-		require.NoError(t, err)
 
 		count := 0
 		for _, result := range results {
@@ -821,7 +701,6 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 
 	tr0 := getTestResults()
 	tr0.Info.TaskID = "task0"
-	tr0.Info.DisplayTaskID = "display"
 	tr0.Info.Execution = 0
 	tr0.populated = true
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr0)
@@ -842,7 +721,6 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 
 	tr1 := getTestResults()
 	tr1.Info.TaskID = "task1"
-	tr1.Info.DisplayTaskID = "display"
 	tr1.Info.Execution = 0
 	tr1.populated = true
 	_, err = db.Collection(testResultsCollection).InsertOne(ctx, tr1)
@@ -879,15 +757,15 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 		taskOpts := []TestResultsTaskOptions{
 			{
 				TaskID:    tr1.Info.TaskID,
-				Execution: utility.ToIntPtr(tr1.Info.Execution),
+				Execution: tr1.Info.Execution,
 			},
 			{
 				TaskID:    tr2.Info.TaskID,
-				Execution: utility.ToIntPtr(tr2.Info.Execution),
+				Execution: tr2.Info.Execution,
 			},
 			{
 				TaskID:    tr0.Info.TaskID,
-				Execution: utility.ToIntPtr(tr0.Info.Execution),
+				Execution: tr0.Info.Execution,
 			},
 		}
 		stats, results, err := FindAndDownloadTestResults(ctx, env, taskOpts, nil)
@@ -903,7 +781,7 @@ func TestFindAndDownloadTestResults(t *testing.T) {
 		taskOpts := []TestResultsTaskOptions{
 			{
 				TaskID:    tr0.Info.TaskID,
-				Execution: utility.ToIntPtr(tr0.Info.Execution),
+				Execution: tr0.Info.Execution,
 			},
 		}
 		filterOpts := &TestResultsFilterAndSortOptions{Statuses: []string{"Pass"}}
@@ -930,7 +808,6 @@ func TestFindTestResultsStats(t *testing.T) {
 	}()
 
 	tr1 := getTestResults()
-	tr1.Info.DisplayTaskID = "display"
 	tr1.Info.Execution = 0
 	tr1.Stats.TotalCount = 10
 	tr1.Stats.FailedCount = 5
@@ -938,7 +815,6 @@ func TestFindTestResultsStats(t *testing.T) {
 	require.NoError(t, err)
 
 	tr2 := getTestResults()
-	tr2.Info.DisplayTaskID = "display"
 	tr2.Info.TaskID = tr1.Info.TaskID
 	tr2.Info.Execution = 1
 	tr2.Stats.TotalCount = 30
@@ -947,7 +823,6 @@ func TestFindTestResultsStats(t *testing.T) {
 	require.NoError(t, err)
 
 	tr3 := getTestResults()
-	tr3.Info.DisplayTaskID = "display"
 	tr3.Info.Execution = 1
 	tr3.Stats.TotalCount = 100
 	tr3.Stats.FailedCount = 15
@@ -955,7 +830,6 @@ func TestFindTestResultsStats(t *testing.T) {
 	require.NoError(t, err)
 
 	tr4 := getTestResults()
-	tr4.Info.DisplayTaskID = "display"
 	tr4.Info.Execution = 0
 	tr4.Stats.TotalCount = 40
 	tr4.Stats.FailedCount = 20
@@ -978,7 +852,7 @@ func TestFindTestResultsStats(t *testing.T) {
 		{
 			name:   "NilEnv",
 			env:    nil,
-			opts:   []TestResultsTaskOptions{{TaskID: tr1.Info.DisplayTaskID}},
+			opts:   []TestResultsTaskOptions{{TaskID: tr1.Info.TaskID}},
 			hasErr: true,
 		},
 		{
@@ -992,7 +866,7 @@ func TestFindTestResultsStats(t *testing.T) {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    tr1.Info.TaskID,
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedStats: tr1.Stats,
@@ -1003,51 +877,16 @@ func TestFindTestResultsStats(t *testing.T) {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    tr1.Info.TaskID,
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 				{
 					TaskID:    tr4.Info.TaskID,
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedStats: TestResultsStats{
 				TotalCount:  tr1.Stats.TotalCount + tr4.Stats.TotalCount,
 				FailedCount: tr1.Stats.FailedCount + tr4.Stats.FailedCount,
-			},
-		},
-		{
-			name:          "TaskIDAndNoExecution",
-			env:           env,
-			opts:          []TestResultsTaskOptions{{TaskID: tr1.Info.TaskID}},
-			expectedStats: tr2.Stats,
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			env:  env,
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display",
-					Execution:   utility.ToIntPtr(0),
-					DisplayTask: true,
-				},
-			},
-			expectedStats: TestResultsStats{
-				TotalCount:  tr1.Stats.TotalCount + tr4.Stats.TotalCount,
-				FailedCount: tr1.Stats.FailedCount + tr4.Stats.FailedCount,
-			},
-		},
-		{
-			name: "DisplayTaskIDAndNoExecution",
-			env:  env,
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display",
-					DisplayTask: true,
-				},
-			},
-			expectedStats: TestResultsStats{
-				TotalCount:  tr2.Stats.TotalCount + tr3.Stats.TotalCount + tr4.Stats.TotalCount,
-				FailedCount: tr2.Stats.FailedCount + tr3.Stats.FailedCount + tr4.Stats.FailedCount,
 			},
 		},
 	} {
@@ -1332,7 +1171,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			name: "SortByBaseStatusASC",
 			opts: &TestResultsFilterAndSortOptions{
 				SortBy:    TestResultsSortByBaseStatus,
-				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
+				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[1],
@@ -1347,7 +1186,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				SortBy:       TestResultsSortByBaseStatus,
 				SortOrderDSC: true,
-				BaseTasks:    []TestResultsTaskOptions{{TaskID: base.Info.TaskID}},
+				BaseTasks:    []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
@@ -1359,7 +1198,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "BaseStatus",
-			opts: &TestResultsFilterAndSortOptions{BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID}}},
+			opts: &TestResultsFilterAndSortOptions{BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}}},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
 				resultsWithBaseStatus[1],
@@ -1456,10 +1295,10 @@ func TestFindFailedTestResultsSamples(t *testing.T) {
 		{
 			name: "WithoutFilters",
 			tasks: []TestResultsTaskOptions{
-				{TaskID: t0_0.Info.TaskID, Execution: utility.ToIntPtr(t0_0.Info.Execution)},
-				{TaskID: t0_2.Info.TaskID, Execution: utility.ToIntPtr(t0_2.Info.Execution)},
-				{TaskID: t1_0.Info.TaskID, Execution: utility.ToIntPtr(t1_0.Info.Execution)},
-				{TaskID: t1_1.Info.TaskID, Execution: utility.ToIntPtr(t1_1.Info.Execution)},
+				{TaskID: t0_0.Info.TaskID, Execution: t0_0.Info.Execution},
+				{TaskID: t0_2.Info.TaskID, Execution: t0_2.Info.Execution},
+				{TaskID: t1_0.Info.TaskID, Execution: t1_0.Info.Execution},
+				{TaskID: t1_1.Info.TaskID, Execution: t1_1.Info.Execution},
 			},
 			expected: []TestResultsSample{
 				{
@@ -1489,10 +1328,10 @@ func TestFindFailedTestResultsSamples(t *testing.T) {
 		{
 			name: "WithFilters",
 			tasks: []TestResultsTaskOptions{
-				{TaskID: t0_0.Info.TaskID, Execution: utility.ToIntPtr(t0_0.Info.Execution)},
-				{TaskID: t0_2.Info.TaskID, Execution: utility.ToIntPtr(t0_2.Info.Execution)},
-				{TaskID: t1_0.Info.TaskID, Execution: utility.ToIntPtr(t1_0.Info.Execution)},
-				{TaskID: t1_1.Info.TaskID, Execution: utility.ToIntPtr(t1_1.Info.Execution)},
+				{TaskID: t0_0.Info.TaskID, Execution: t0_0.Info.Execution},
+				{TaskID: t0_2.Info.TaskID, Execution: t0_2.Info.Execution},
+				{TaskID: t1_0.Info.TaskID, Execution: t1_0.Info.Execution},
+				{TaskID: t1_1.Info.TaskID, Execution: t1_1.Info.Execution},
 			},
 			filters: []string{"test1", "test3", "test4", "test44"},
 			expected: []TestResultsSample{

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -131,13 +131,8 @@ type BuildloggerOptions struct {
 // TestResultsTaskOptions specify the arguments for fetching test results by
 // task using the Connector functions.
 type TestResultsTaskOptions struct {
-	TaskID string `json:"task_id"`
-	// TODO (EVG-18798): Make this field required once Evergreen and Spruce
-	// are updated.
-	Execution *int `json:"execution"`
-	// TODO (EVG-18798): Remove this field once Evergreen and Spruce are
-	// updated.
-	DisplayTask bool `json:"display_task"`
+	TaskID    string `json:"task_id"`
+	Execution int    `json:"execution"`
 }
 
 // TestResultsFilterAndSortOptions holds all values required for filtering,

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -171,7 +171,6 @@ func convertToDBTestResultsTaskOptions(opts []TestResultsTaskOptions) []dbModel.
 	for i, task := range opts {
 		dbOpts[i].TaskID = task.TaskID
 		dbOpts[i].Execution = task.Execution
-		dbOpts[i].DisplayTask = task.DisplayTask
 	}
 
 	return dbOpts

--- a/rest/data/test_results_test.go
+++ b/rest/data/test_results_test.go
@@ -153,7 +153,7 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			taskOpts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts: &TestResultsFilterAndSortOptions{SortBy: "invalid_sort"},
@@ -171,7 +171,7 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			taskOpts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			stats: model.APITestResultsStats{
@@ -190,7 +190,7 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			taskOpts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts: &TestResultsFilterAndSortOptions{TestName: "test1"},
@@ -206,11 +206,11 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			taskOpts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			stats: model.APITestResultsStats{
@@ -232,11 +232,11 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			taskOpts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts: &TestResultsFilterAndSortOptions{TestName: "test2"},
@@ -247,86 +247,6 @@ func (s *testResultsConnectorSuite) TestFindTestResults() {
 			},
 			expectedResults: []model.APITestResult{
 				s.apiResults["task1_1_test2"],
-				s.apiResults["task2_0_test2"],
-			},
-		},
-		{
-			name:     "TaskIDAndNoExecution",
-			taskOpts: []TestResultsTaskOptions{{TaskID: "task1"}},
-			stats: model.APITestResultsStats{
-				TotalCount:    3,
-				FailedCount:   3,
-				FilteredCount: utility.ToIntPtr(3),
-			},
-			expectedResults: []model.APITestResult{
-				s.apiResults["task1_1_test0"],
-				s.apiResults["task1_1_test1"],
-				s.apiResults["task1_1_test2"],
-			},
-		},
-
-		{
-			name: "DisplayTaskIDAndExecution",
-			taskOpts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					Execution:   utility.ToIntPtr(0),
-					DisplayTask: true,
-				},
-			},
-			stats: model.APITestResultsStats{
-				TotalCount:    6,
-				FailedCount:   6,
-				FilteredCount: utility.ToIntPtr(6),
-			},
-			expectedResults: []model.APITestResult{
-				s.apiResults["task1_0_test0"],
-				s.apiResults["task1_0_test1"],
-				s.apiResults["task1_0_test2"],
-				s.apiResults["task2_0_test0"],
-				s.apiResults["task2_0_test1"],
-				s.apiResults["task2_0_test2"],
-			},
-		},
-		{
-			name: "DisplayTaskIDAndNoExecution",
-			taskOpts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					DisplayTask: true,
-				},
-			},
-			stats: model.APITestResultsStats{
-				TotalCount:    6,
-				FailedCount:   6,
-				FilteredCount: utility.ToIntPtr(6),
-			},
-			expectedResults: []model.APITestResult{
-				s.apiResults["task1_1_test0"],
-				s.apiResults["task1_1_test1"],
-				s.apiResults["task1_1_test2"],
-				s.apiResults["task2_0_test0"],
-				s.apiResults["task2_0_test1"],
-				s.apiResults["task2_0_test2"],
-			},
-		},
-		{
-			name: "DisplayTaskIDAndFilterAndSort",
-			taskOpts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					Execution:   utility.ToIntPtr(0),
-					DisplayTask: true,
-				},
-			},
-			filterOpts: &TestResultsFilterAndSortOptions{TestName: "test2"},
-			stats: model.APITestResultsStats{
-				TotalCount:    6,
-				FailedCount:   6,
-				FilteredCount: utility.ToIntPtr(2),
-			},
-			expectedResults: []model.APITestResult{
-				s.apiResults["task1_0_test2"],
 				s.apiResults["task2_0_test2"],
 			},
 		},
@@ -367,7 +287,7 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSample() {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: []string{"test0", "test1", "test2"},
@@ -377,51 +297,11 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSample() {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
-				},
-			},
-			expectedResult: []string{
-				"test0",
-				"test1",
-				"test2",
-				"test0",
-				"test1",
-				"test2",
-			},
-		},
-		{
-			name:           "TaskIDWithoutExecution",
-			opts:           []TestResultsTaskOptions{{TaskID: "task1"}},
-			expectedResult: []string{"test0", "test1", "test2"},
-		},
-		{
-			name: "DisplayTaskIDWithExecution",
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					Execution:   utility.ToIntPtr(0),
-					DisplayTask: true,
-				},
-			},
-			expectedResult: []string{
-				"test0",
-				"test1",
-				"test2",
-				"test0",
-				"test1",
-				"test2",
-			},
-		},
-		{
-			name: "DisplayTaskIDWithoutExecution",
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					DisplayTask: true,
+					Execution: 0,
 				},
 			},
 			expectedResult: []string{
@@ -471,7 +351,7 @@ func (s *testResultsConnectorSuite) TestFindTestResultsStats() {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResultsStats{
@@ -484,46 +364,11 @@ func (s *testResultsConnectorSuite) TestFindTestResultsStats() {
 			opts: []TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
-				},
-			},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  6,
-				FailedCount: 6,
-			},
-		},
-		{
-			name: "TaskIDWithoutExecution",
-			opts: []TestResultsTaskOptions{{TaskID: "task1"}},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  3,
-				FailedCount: 3,
-			},
-		},
-		{
-			name: "DisplayTaskIDWithExecution",
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					Execution:   utility.ToIntPtr(0),
-					DisplayTask: true,
-				},
-			},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  6,
-				FailedCount: 6,
-			},
-		},
-		{
-			name: "DisplayTaskIDWithoutExecution",
-			opts: []TestResultsTaskOptions{
-				{
-					TaskID:      "display_task1",
-					DisplayTask: true,
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResultsStats{
@@ -556,7 +401,7 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSamples() {
 		{
 			name: "InvalidFilter",
 			tasks: []TestResultsTaskOptions{
-				{TaskID: "task3", Execution: utility.ToIntPtr(0)},
+				{TaskID: "task3", Execution: 0},
 			},
 			filters: []string{`[`},
 			hasErr:  true,
@@ -564,7 +409,7 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSamples() {
 		{
 			name: "NoFilter",
 			tasks: []TestResultsTaskOptions{
-				{TaskID: "task3", Execution: utility.ToIntPtr(0)},
+				{TaskID: "task3", Execution: 0},
 			},
 			expectedResult: []model.APITestResultsSample{
 				{
@@ -582,8 +427,8 @@ func (s *testResultsConnectorSuite) TestFindFailedTestResultsSamples() {
 		{
 			name: "WithFilters",
 			tasks: []TestResultsTaskOptions{
-				{TaskID: "task1", Execution: utility.ToIntPtr(1)},
-				{TaskID: "task2", Execution: utility.ToIntPtr(0)},
+				{TaskID: "task1", Execution: 1},
+				{TaskID: "task2", Execution: 0},
 			},
 			filters: []string{"1", "2"},
 			expectedResult: []model.APITestResultsSample{

--- a/rest/service.go
+++ b/rest/service.go
@@ -321,11 +321,6 @@ func (s *Service) addRoutes() {
 	s.app.AddRoute("/test_results/tasks").Version(1).Get().RouteHandler(makeGetTestResultsByTasks(s.sc))
 	s.app.AddRoute("/test_results/tasks/stats").Version(1).Get().RouteHandler(makeGetTestResultsStatsByTasks(s.sc))
 	s.app.AddRoute("/test_results/tasks/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSampleByTasks(s.sc))
-	// TODO (EVG-18798): Remove these test results routes once Spruce and
-	// Evergreen are updated.
-	s.app.AddRoute("/test_results/task_id/{task_id}").Version(1).Get().RouteHandler(makeGetTestResultsByTaskID(s.sc))
-	s.app.AddRoute("/test_results/task_id/{task_id}/failed_sample").Version(1).Get().RouteHandler(makeGetTestResultsFailedSample(s.sc))
-	s.app.AddRoute("/test_results/task_id/{task_id}/stats").Version(1).Get().RouteHandler(makeGetTestResultsStats(s.sc))
 	s.app.AddRoute("/test_results/filtered_samples").Version(1).Get().RouteHandler(makeGetTestResultsFilteredSamples(s.sc))
 
 	s.app.AddRoute("/system_metrics/type/{task_id}/{type}").Version(1).Get().RouteHandler(makeGetSystemMetricsByType(s.sc))

--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -3,9 +3,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/evergreen-ci/cedar/rest/data"
 	"github.com/evergreen-ci/gimlet"
@@ -27,7 +25,7 @@ const (
 	testResultsBaseTaskID = "base_task_id"
 )
 
-type testResultsTasksBaseHandler struct {
+type testResultsBaseHandler struct {
 	sc      data.Connector
 	payload struct {
 		TaskOpts   []data.TestResultsTaskOptions         `json:"tasks"`
@@ -35,7 +33,7 @@ type testResultsTasksBaseHandler struct {
 	}
 }
 
-func (h *testResultsTasksBaseHandler) Parse(_ context.Context, r *http.Request) error {
+func (h *testResultsBaseHandler) Parse(_ context.Context, r *http.Request) error {
 	if r.Body == nil {
 		return errors.New("missing request payload")
 	}
@@ -58,7 +56,7 @@ func (h *testResultsTasksBaseHandler) Parse(_ context.Context, r *http.Request) 
 // GET /test_results/tasks
 
 type testResultsGetByTasksHandler struct {
-	testResultsTasksBaseHandler
+	testResultsBaseHandler
 }
 
 func makeGetTestResultsByTasks(sc data.Connector) *testResultsGetByTasksHandler {
@@ -96,7 +94,7 @@ func (h *testResultsGetByTasksHandler) Run(ctx context.Context) gimlet.Responder
 // GET /test_results/tasks/stats
 
 type testResultsStatsGetByTasksHandler struct {
-	testResultsTasksBaseHandler
+	testResultsBaseHandler
 }
 
 func makeGetTestResultsStatsByTasks(sc data.Connector) *testResultsStatsGetByTasksHandler {
@@ -134,7 +132,7 @@ func (h *testResultsStatsGetByTasksHandler) Run(ctx context.Context) gimlet.Resp
 // GET /test_results/tasks/failed_sample
 
 type testResultsFailedSampleGetByTasksHandler struct {
-	testResultsTasksBaseHandler
+	testResultsBaseHandler
 }
 
 func makeGetTestResultsFailedSampleByTasks(sc data.Connector) *testResultsFailedSampleGetByTasksHandler {
@@ -162,233 +160,6 @@ func (h *testResultsFailedSampleGetByTasksHandler) Run(ctx context.Context) giml
 			"request_payload": h.payload,
 		})
 		return gimlet.MakeJSONErrorResponder(err)
-	}
-
-	return gimlet.NewJSONResponse(sample)
-}
-
-// TODO (EVG-18798): Remove these route handlers once Spruce and Evergreen are
-// updated.
-
-type testResultsBaseHandler struct {
-	taskOpts   data.TestResultsTaskOptions
-	filterOpts *data.TestResultsFilterAndSortOptions
-}
-
-// Parse fetches the task ID from the HTTP request.
-func (h *testResultsBaseHandler) Parse(_ context.Context, r *http.Request) error {
-	h.taskOpts.TaskID = gimlet.GetVars(r)["task_id"]
-
-	vals := r.URL.Query()
-	if len(vals[execution]) > 0 {
-		exec, err := strconv.Atoi(vals[execution][0])
-		if err != nil {
-			return err
-		}
-		h.taskOpts.Execution = utility.ToIntPtr(exec)
-	}
-	if vals.Get(isDisplayTask) == trueString {
-		h.taskOpts.DisplayTask = true
-	}
-
-	return nil
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-// GET /test_results/task_id/{task_id}
-
-type testResultsGetByTaskIDHandler struct {
-	sc data.Connector
-	testResultsBaseHandler
-}
-
-func makeGetTestResultsByTaskID(sc data.Connector) gimlet.RouteHandler {
-	return &testResultsGetByTaskIDHandler{
-		sc: sc,
-	}
-}
-
-// Parse fetches the task ID from the HTTP request and any filter, sort, or
-// pagination options.
-func (h *testResultsGetByTaskIDHandler) Parse(ctx context.Context, r *http.Request) error {
-	catcher := grip.NewBasicCatcher()
-
-	catcher.Add(h.testResultsBaseHandler.Parse(ctx, r))
-	vals := r.URL.Query()
-	testName := vals.Get(testResultsTestName)
-	statuses := vals[testResultsStatus]
-	groupID := vals.Get(testResultsGroupID)
-	sortBy := vals.Get(testResultsSortBy)
-	baseTaskID := vals.Get(testResultsBaseTaskID)
-	var limit, page int
-	if len(vals[testResultsLimit]) > 0 {
-		var err error
-		limit, err = strconv.Atoi(vals[testResultsLimit][0])
-		catcher.Add(err)
-	}
-	if len(vals[testResultsPage]) > 0 {
-		var err error
-		page, err = strconv.Atoi(vals[testResultsPage][0])
-		catcher.Add(err)
-	}
-
-	if testName == "" && len(statuses) == 0 && groupID == "" && sortBy == "" && baseTaskID == "" && limit <= 0 && page <= 0 {
-		return catcher.Resolve()
-	}
-
-	h.filterOpts = &data.TestResultsFilterAndSortOptions{
-		TestName: testName,
-		Statuses: statuses,
-		GroupID:  groupID,
-		SortBy:   sortBy,
-		Limit:    limit,
-		Page:     page,
-	}
-	if vals.Get(testResultsSortDSC) == trueString {
-		h.filterOpts.SortOrderDSC = true
-	}
-	if baseTaskID != "" {
-		h.filterOpts.BaseTasks = []data.TestResultsTaskOptions{
-			{
-				TaskID:      baseTaskID,
-				DisplayTask: h.taskOpts.DisplayTask,
-			},
-		}
-	}
-
-	return catcher.Resolve()
-}
-
-// Factory returns a pointer to a new testResultsGetByTaskIDHandler.
-func (h *testResultsGetByTaskIDHandler) Factory() gimlet.RouteHandler {
-	return &testResultsGetByTaskIDHandler{
-		sc: h.sc,
-	}
-}
-
-// Run finds and returns the desired test result based on the task ID.
-func (h *testResultsGetByTaskIDHandler) Run(ctx context.Context) gimlet.Responder {
-	testResults, err := h.sc.FindTestResults(ctx, []data.TestResultsTaskOptions{h.taskOpts}, h.filterOpts)
-	if err != nil {
-		err = errors.Wrapf(err, "getting test results by task ID '%s'", h.taskOpts.TaskID)
-		logFindError(err, message.Fields{
-			"request":    gimlet.GetRequestID(ctx),
-			"method":     "GET",
-			"route":      "/test_results/task_id/{task_id}",
-			"task_id":    h.taskOpts.TaskID,
-			"is_display": h.taskOpts.DisplayTask,
-		})
-		return gimlet.MakeJSONErrorResponder(err)
-	}
-
-	var resp gimlet.Responder
-	resp = gimlet.NewJSONResponse(testResults)
-	if h.filterOpts != nil && h.filterOpts.Limit > 0 {
-		pages := &gimlet.ResponsePages{
-			Prev: &gimlet.Page{
-				BaseURL:         h.sc.GetBaseURL(),
-				KeyQueryParam:   testResultsPage,
-				LimitQueryParam: testResultsLimit,
-				Key:             fmt.Sprintf("%d", h.filterOpts.Page),
-				Limit:           h.filterOpts.Limit,
-				Relation:        "prev",
-			},
-		}
-		if len(testResults.Results) > 0 {
-			pages.Next = &gimlet.Page{
-				BaseURL:         h.sc.GetBaseURL(),
-				KeyQueryParam:   testResultsPage,
-				LimitQueryParam: testResultsLimit,
-				Key:             fmt.Sprintf("%d", h.filterOpts.Page+1),
-				Limit:           h.filterOpts.Limit,
-				Relation:        "next",
-			}
-		}
-
-		if err := resp.SetPages(pages); err != nil {
-			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "setting response pages"))
-		}
-	}
-
-	return resp
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-// GET /test_results/task_id/{task_id}/stats
-
-type testResultsGetStatsHandler struct {
-	sc data.Connector
-	testResultsBaseHandler
-}
-
-func makeGetTestResultsStats(sc data.Connector) gimlet.RouteHandler {
-	return &testResultsGetStatsHandler{
-		sc: sc,
-	}
-}
-
-// Factory returns a pointer to a new testResultsGetStatsHandler.
-func (h *testResultsGetStatsHandler) Factory() gimlet.RouteHandler {
-	return &testResultsGetStatsHandler{
-		sc: h.sc,
-	}
-}
-
-// Run finds and returns the desired failed test results stats.
-func (h *testResultsGetStatsHandler) Run(ctx context.Context) gimlet.Responder {
-	stats, err := h.sc.FindTestResultsStats(ctx, []data.TestResultsTaskOptions{h.taskOpts})
-	if err != nil {
-		err = errors.Wrapf(err, "getting test results stats by task ID '%s'", h.taskOpts.TaskID)
-		logFindError(err, message.Fields{
-			"request":         gimlet.GetRequestID(ctx),
-			"method":          "GET",
-			"route":           "/test_results/task_id/{task_id}/stats",
-			"task_id":         h.taskOpts.TaskID,
-			"is_display_task": h.taskOpts.DisplayTask,
-		})
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-
-	return gimlet.NewJSONResponse(stats)
-}
-
-///////////////////////////////////////////////////////////////////////////////
-//
-// GET /test_results/task_id/{task_id}/failed_sample
-
-type testResultsGetFailedSampleHandler struct {
-	sc data.Connector
-	testResultsBaseHandler
-}
-
-func makeGetTestResultsFailedSample(sc data.Connector) gimlet.RouteHandler {
-	return &testResultsGetFailedSampleHandler{
-		sc: sc,
-	}
-}
-
-// Factory returns a pointer to a new testResultsGetFailedSampleHandler.
-func (h *testResultsGetFailedSampleHandler) Factory() gimlet.RouteHandler {
-	return &testResultsGetFailedSampleHandler{
-		sc: h.sc,
-	}
-}
-
-// Run finds and returns the desired failed test results sample.
-func (h *testResultsGetFailedSampleHandler) Run(ctx context.Context) gimlet.Responder {
-	sample, err := h.sc.FindFailedTestResultsSample(ctx, []data.TestResultsTaskOptions{h.taskOpts})
-	if err != nil {
-		err = errors.Wrapf(err, "getting failed test results sample by task ID '%s'", h.taskOpts.TaskID)
-		logFindError(err, message.Fields{
-			"request":         gimlet.GetRequestID(ctx),
-			"method":          "GET",
-			"route":           "/test_results/task_id/{task_id}/failed_sample",
-			"task_id":         h.taskOpts.TaskID,
-			"is_display_task": h.taskOpts.DisplayTask,
-		})
-		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
 	return gimlet.NewJSONResponse(sample)

--- a/rest/test_results_routes_test.go
+++ b/rest/test_results_routes_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -147,12 +146,6 @@ func (s *TestResultsHandlerSuite) setup(tempDir string) {
 			s.apiResults[key] = append(s.apiResults[key], apiResult)
 		}
 	}
-
-	s.rh = map[string]gimlet.RouteHandler{
-		"task_id":             makeGetTestResultsByTaskID(s.sc),
-		"failed_tests_sample": makeGetTestResultsFailedSample(s.sc),
-		"stats":               makeGetTestResultsStats(s.sc),
-	}
 }
 
 func TestTestResultsHandlerSuite(t *testing.T) {
@@ -203,11 +196,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsBaseHandler() {
 				TaskOpts: []data.TestResultsTaskOptions{
 					{
 						TaskID:    "task1",
-						Execution: utility.ToIntPtr(1),
+						Execution: 1,
 					},
 					{
 						TaskID:    "task2",
-						Execution: utility.ToIntPtr(0),
+						Execution: 0,
 					},
 				},
 			},
@@ -221,11 +214,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsBaseHandler() {
 				TaskOpts: []data.TestResultsTaskOptions{
 					{
 						TaskID:    "task1",
-						Execution: utility.ToIntPtr(1),
+						Execution: 1,
 					},
 					{
 						TaskID:    "task2",
-						Execution: utility.ToIntPtr(0),
+						Execution: 0,
 					},
 				},
 				FilterOpts: &data.TestResultsFilterAndSortOptions{
@@ -239,11 +232,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsBaseHandler() {
 					BaseTasks: []data.TestResultsTaskOptions{
 						{
 							TaskID:    "base_task1",
-							Execution: utility.ToIntPtr(0),
+							Execution: 0,
 						},
 						{
 							TaskID:    "base_task2",
-							Execution: utility.ToIntPtr(1),
+							Execution: 1,
 						},
 					},
 				},
@@ -259,7 +252,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsBaseHandler() {
 			}
 			req := &http.Request{Body: body}
 
-			rh := &testResultsTasksBaseHandler{sc: s.sc}
+			rh := &testResultsBaseHandler{sc: s.sc}
 			err := rh.Parse(context.Background(), req)
 			if test.hasErr {
 				s.Error(err)
@@ -289,7 +282,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			errorStatus: http.StatusInternalServerError,
@@ -299,11 +292,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts:  &data.TestResultsFilterAndSortOptions{SortBy: "invalid_sort"},
@@ -314,7 +307,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "DNE",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResults{
@@ -327,11 +320,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResults{
@@ -348,7 +341,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts: &data.TestResultsFilterAndSortOptions{TestName: "test1"},
@@ -366,11 +359,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			filterOpts: &data.TestResultsFilterAndSortOptions{Limit: 4},
@@ -427,7 +420,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetStatsByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			errorStatus: http.StatusInternalServerError,
@@ -437,7 +430,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetStatsByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "DNE",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResultsStats{},
@@ -447,11 +440,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetStatsByTasksHandler() {
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: &model.APITestResultsStats{
@@ -499,7 +492,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetFailedSampleByTasksHandler()
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			errorStatus: http.StatusInternalServerError,
@@ -509,7 +502,7 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetFailedSampleByTasksHandler()
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "DNE",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 		},
@@ -518,11 +511,11 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetFailedSampleByTasksHandler()
 			taskOpts: []data.TestResultsTaskOptions{
 				{
 					TaskID:    "task1",
-					Execution: utility.ToIntPtr(1),
+					Execution: 1,
 				},
 				{
 					TaskID:    "task2",
-					Execution: utility.ToIntPtr(0),
+					Execution: 0,
 				},
 			},
 			expectedResult: []string{"test0", "test1", "test2", "test0", "test1", "test2"},
@@ -548,445 +541,4 @@ func (s *TestResultsHandlerSuite) TestTestResultsGetFailedSampleByTasksHandler()
 			}
 		})
 	}
-}
-
-func (s *TestResultsHandlerSuite) TestTestResultsGetByTaskIDHandler() {
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-	rh := s.rh["task_id"].(*testResultsGetByTaskIDHandler)
-
-	for _, test := range []struct {
-		name           string
-		ctx            context.Context
-		taskOpts       data.TestResultsTaskOptions
-		filterOpts     *data.TestResultsFilterAndSortOptions
-		expectedResult *model.APITestResults
-		errorStatus    int
-	}{
-		{
-			name:        "ContextError",
-			ctx:         canceledCtx,
-			taskOpts:    data.TestResultsTaskOptions{TaskID: "task1"},
-			errorStatus: http.StatusInternalServerError,
-		},
-		{
-			name:     "TaskIDDNE",
-			taskOpts: data.TestResultsTaskOptions{TaskID: "DNE"},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{FilteredCount: utility.ToIntPtr(0)},
-			},
-		},
-		{
-			name: "TaskIDAndExecution",
-			taskOpts: data.TestResultsTaskOptions{
-				TaskID:    "task1",
-				Execution: utility.ToIntPtr(0),
-			},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    3,
-					FailedCount:   3,
-					FilteredCount: utility.ToIntPtr(3),
-				},
-				Results: s.apiResults["abc"],
-			},
-		},
-		{
-			name:     "TaskIDWithoutExecution",
-			taskOpts: data.TestResultsTaskOptions{TaskID: "task1"},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    3,
-					FailedCount:   3,
-					FilteredCount: utility.ToIntPtr(3),
-				},
-				Results: s.apiResults["def"],
-			},
-		},
-		{
-			name: "TaskIDAndFilterAndSort",
-			taskOpts: data.TestResultsTaskOptions{
-				TaskID:    "task1",
-				Execution: utility.ToIntPtr(0),
-			},
-			filterOpts: &data.TestResultsFilterAndSortOptions{TestName: "test1"},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    3,
-					FailedCount:   3,
-					FilteredCount: utility.ToIntPtr(1),
-				},
-				Results: s.apiResults["abc"][1:2],
-			},
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			taskOpts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				Execution:   utility.ToIntPtr(1),
-				DisplayTask: true,
-			},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    6,
-					FailedCount:   6,
-					FilteredCount: utility.ToIntPtr(6),
-				},
-				Results: append(append([]model.APITestResult{}, s.apiResults["def"]...), s.apiResults["ghi"]...),
-			},
-		},
-		{
-			name: "DisplayTaskIDAndNoExecution",
-			taskOpts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				DisplayTask: true,
-			},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    6,
-					FailedCount:   6,
-					FilteredCount: utility.ToIntPtr(6),
-				},
-				Results: append(append([]model.APITestResult{}, s.apiResults["def"]...), s.apiResults["ghi"]...),
-			},
-		},
-		{
-			name: "DisplayTaskIDAndFilterAndSort",
-			taskOpts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				DisplayTask: true,
-			},
-			filterOpts: &data.TestResultsFilterAndSortOptions{TestName: "test1"},
-			expectedResult: &model.APITestResults{
-				Stats: model.APITestResultsStats{
-					TotalCount:    6,
-					FailedCount:   6,
-					FilteredCount: utility.ToIntPtr(2),
-				},
-				Results: []model.APITestResult{s.apiResults["def"][1], s.apiResults["ghi"][1]},
-			},
-		},
-	} {
-		s.Run(test.name, func() {
-			rh.taskOpts = test.taskOpts
-			rh.filterOpts = test.filterOpts
-			ctx := test.ctx
-			if ctx == nil {
-				ctx = context.TODO()
-			}
-			resp := rh.Run(ctx)
-
-			s.Require().NotNil(resp)
-			if test.errorStatus > 0 {
-				s.Equal(test.errorStatus, resp.Status())
-			} else {
-				s.Equal(http.StatusOK, resp.Status())
-				actualResult, ok := resp.Data().(*model.APITestResults)
-				s.Require().True(ok)
-				s.Equal(test.expectedResult.Stats.FailedCount, actualResult.Stats.FailedCount)
-				s.Equal(test.expectedResult.Stats.TotalCount, actualResult.Stats.TotalCount)
-				s.Equal(test.expectedResult.Stats.FilteredCount, actualResult.Stats.FilteredCount)
-				s.Equal(len(test.expectedResult.Results), len(actualResult.Results))
-				for _, expected := range test.expectedResult.Results {
-					found := false
-					for _, actual := range actualResult.Results {
-						if utility.FromStringPtr(expected.TestName) == utility.FromStringPtr(actual.TestName) &&
-							utility.FromStringPtr(expected.TaskID) == utility.FromStringPtr(actual.TaskID) &&
-							expected.Execution == actual.Execution {
-							found = true
-							break
-						}
-					}
-					s.True(found)
-				}
-			}
-		})
-	}
-}
-
-func (s *TestResultsHandlerSuite) TestTestResultsGetFailedSample() {
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-	rh := s.rh["failed_tests_sample"].(*testResultsGetFailedSampleHandler)
-
-	for _, test := range []struct {
-		name           string
-		ctx            context.Context
-		opts           data.TestResultsTaskOptions
-		expectedResult []string
-		errorStatus    int
-	}{
-		{
-			name:        "ContextError",
-			ctx:         canceledCtx,
-			opts:        data.TestResultsTaskOptions{TaskID: "task1"},
-			errorStatus: http.StatusInternalServerError,
-		},
-		{
-			name: "TaskIDDNE",
-			opts: data.TestResultsTaskOptions{TaskID: "DNE"},
-		},
-		{
-			name: "TaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:    "task1",
-				Execution: utility.ToIntPtr(0),
-			},
-			expectedResult: []string{"test0", "test1", "test2"},
-		},
-		{
-			name:           "TaskIDAndNoExecution",
-			opts:           data.TestResultsTaskOptions{TaskID: "task1"},
-			expectedResult: []string{"test0", "test1", "test2"},
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				Execution:   utility.ToIntPtr(0),
-				DisplayTask: true,
-			},
-			expectedResult: []string{"test0", "test1", "test2", "test0", "test1", "test2"},
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				DisplayTask: true,
-			},
-			expectedResult: []string{"test0", "test1", "test2", "test0", "test1", "test2"},
-		},
-	} {
-		s.Run(test.name, func() {
-			rh.taskOpts = test.opts
-			ctx := test.ctx
-			if ctx == nil {
-				ctx = context.TODO()
-			}
-			resp := rh.Run(ctx)
-
-			s.Require().NotNil(resp)
-			if test.errorStatus > 0 {
-				s.Equal(test.errorStatus, resp.Status())
-			} else {
-				s.Equal(http.StatusOK, resp.Status())
-				actualResult, ok := resp.Data().([]string)
-				s.Require().True(ok)
-				s.Equal(test.expectedResult, actualResult)
-			}
-		})
-	}
-}
-
-func (s *TestResultsHandlerSuite) TestTestResultsGetStats() {
-	canceledCtx, cancel := context.WithCancel(context.Background())
-	cancel()
-	rh := s.rh["stats"].(*testResultsGetStatsHandler)
-
-	for _, test := range []struct {
-		name           string
-		ctx            context.Context
-		opts           data.TestResultsTaskOptions
-		expectedResult *model.APITestResultsStats
-		errorStatus    int
-	}{
-		{
-			name:        "ContextError",
-			ctx:         canceledCtx,
-			opts:        data.TestResultsTaskOptions{TaskID: "task1"},
-			errorStatus: http.StatusInternalServerError,
-		},
-		{
-			name:           "TaskIDDNE",
-			opts:           data.TestResultsTaskOptions{TaskID: "DNE"},
-			expectedResult: &model.APITestResultsStats{},
-		},
-		{
-			name: "TaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:    "task1",
-				Execution: utility.ToIntPtr(0),
-			},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  3,
-				FailedCount: 3,
-			},
-		},
-		{
-			name: "TaskIDAndNoExecution",
-			opts: data.TestResultsTaskOptions{TaskID: "task1"},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  3,
-				FailedCount: 3,
-			},
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				Execution:   utility.ToIntPtr(0),
-				DisplayTask: true,
-			},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  6,
-				FailedCount: 6,
-			},
-		},
-		{
-			name: "DisplayTaskIDAndExecution",
-			opts: data.TestResultsTaskOptions{
-				TaskID:      "display_task1",
-				DisplayTask: true,
-			},
-			expectedResult: &model.APITestResultsStats{
-				TotalCount:  6,
-				FailedCount: 6,
-			},
-		},
-	} {
-		s.Run(test.name, func() {
-			rh.taskOpts = test.opts
-			ctx := test.ctx
-			if ctx == nil {
-				ctx = context.TODO()
-			}
-			resp := rh.Run(ctx)
-
-			s.Require().NotNil(resp)
-			if test.errorStatus > 0 {
-				s.Equal(test.errorStatus, resp.Status())
-			} else {
-				s.Equal(http.StatusOK, resp.Status())
-				actualResult, ok := resp.Data().(*model.APITestResultsStats)
-				s.Require().True(ok)
-				s.Equal(test.expectedResult, actualResult)
-			}
-		})
-	}
-}
-
-func (s *TestResultsHandlerSuite) TestBaseParse() {
-	for _, test := range []struct {
-		urlString string
-		handler   string
-	}{
-		{
-			handler:   "task_id",
-			urlString: "http://cedar.mongodb.com/test_results/task_id/task_id1",
-		},
-		{
-			handler:   "failed_tests_sample",
-			urlString: "http://cedar.mongodb.com/test_results/task_id/task_id1/failed_sample",
-		},
-		{
-			handler:   "stats",
-			urlString: "http://cedar.mongodb.com/test_results/task_id/task_id1/stats",
-		},
-	} {
-		s.testParseValid(test.handler, test.urlString)
-		s.testParseInvalid(test.handler, test.urlString)
-		s.testParseDefaults(test.handler, test.urlString)
-	}
-}
-
-func (s *TestResultsHandlerSuite) testParseValid(handler, urlString string) {
-	ctx := context.Background()
-	urlString += "?execution=1&display_task=true"
-	req := &http.Request{Method: http.MethodGet}
-	req.URL, _ = url.Parse(urlString)
-	rh := s.rh[handler]
-	// Need to reset this since we are reusing the handlers.
-	rh = rh.Factory()
-
-	err := rh.Parse(ctx, req)
-	s.Require().NoError(err)
-	s.Equal(1, utility.FromIntPtr(getTestResultsExecution(rh, handler)))
-	s.True(getTestResultsDisplayTask(rh, handler))
-}
-
-func (s *TestResultsHandlerSuite) testParseInvalid(handler, urlString string) {
-	ctx := context.Background()
-	invalidExecution := "?execution=hello"
-	req := &http.Request{Method: http.MethodGet}
-	rh := s.rh[handler]
-	// Need to reset this since we are reusing the handlers.
-	rh = rh.Factory()
-
-	req.URL, _ = url.Parse(urlString + invalidExecution)
-	err := rh.Parse(ctx, req)
-	s.Error(err)
-}
-
-func (s *TestResultsHandlerSuite) testParseDefaults(handler, urlString string) {
-	ctx := context.Background()
-	req := &http.Request{Method: http.MethodGet}
-	req.URL, _ = url.Parse(urlString)
-	rh := s.rh[handler]
-	// Need to reset this since we are reusing the handlers.
-	rh = rh.Factory()
-
-	err := rh.Parse(ctx, req)
-	s.Require().NoError(err)
-	s.Nil(getTestResultsExecution(rh, handler))
-}
-
-func getTestResultsExecution(rh gimlet.RouteHandler, handler string) *int {
-	switch handler {
-	case "task_id":
-		return rh.(*testResultsGetByTaskIDHandler).taskOpts.Execution
-	case "failed_tests_sample":
-		return rh.(*testResultsGetFailedSampleHandler).taskOpts.Execution
-	case "stats":
-		return rh.(*testResultsGetStatsHandler).taskOpts.Execution
-	default:
-		return nil
-	}
-}
-
-func getTestResultsDisplayTask(rh gimlet.RouteHandler, handler string) bool {
-	switch handler {
-	case "task_id":
-		return rh.(*testResultsGetByTaskIDHandler).taskOpts.DisplayTask
-	case "failed_tests_sample":
-		return rh.(*testResultsGetFailedSampleHandler).taskOpts.DisplayTask
-	case "stats":
-		return rh.(*testResultsGetStatsHandler).taskOpts.DisplayTask
-	default:
-		return false
-	}
-}
-
-func (s *TestResultsHandlerSuite) TestTaskIDParse() {
-	rh := s.rh["task_id"].Factory().(*testResultsGetByTaskIDHandler)
-
-	// Test default.
-	urlString := "http://cedar.mongodb.com/rest/v1/test_results/task_id/task_id1"
-	expectedTaskOpts := data.TestResultsTaskOptions{}
-	req := &http.Request{Method: http.MethodGet}
-	req.URL, _ = url.Parse(urlString)
-
-	err := rh.Parse(context.TODO(), req)
-	s.Require().NoError(err)
-	s.Equal(expectedTaskOpts, rh.taskOpts)
-	s.Nil(rh.filterOpts)
-
-	// Test valid query parameters.
-	rh = rh.Factory().(*testResultsGetByTaskIDHandler)
-	urlString += "?test_name=test&status=fail&status=silentfail&group_id=group&sort_by=sort&sort_order_dsc=true&limit=5&page=2"
-	expectedFilterOpts := &data.TestResultsFilterAndSortOptions{
-		TestName:     "test",
-		Statuses:     []string{"fail", "silentfail"},
-		GroupID:      "group",
-		SortBy:       "sort",
-		SortOrderDSC: true,
-		Limit:        5,
-		Page:         2,
-	}
-	req = &http.Request{Method: http.MethodGet}
-	req.URL, _ = url.Parse(urlString)
-
-	err = rh.Parse(context.TODO(), req)
-	s.Require().NoError(err)
-	s.Equal(expectedTaskOpts, rh.taskOpts)
-	s.Equal(expectedFilterOpts, rh.filterOpts)
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-18798

- Remove old test results fetching routes
- Clean up any other TODOs

Tested that the fetching routes work as expected and the legacy + Spruce UIs test fetching works in staging.