### PR TITLE
EVG-14306: Enable multi sort on test results

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -760,8 +760,8 @@ func makeTestSamples(records []TestResults, regexFilters []string) ([]TestResult
 // TestResultsSortBy describes the properties by which to sort a set of test
 // results.
 type TestResultsSortBy struct {
-	Key          string
-	SortOrderDSC bool
+	Key      string
+	OrderDSC bool
 }
 
 const (
@@ -975,7 +975,7 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 				if results[i].TestStartTime == results[j].TestStartTime {
 					continue
 				}
-				if sortBy.SortOrderDSC {
+				if sortBy.OrderDSC {
 					return results[i].TestStartTime.After(results[j].TestStartTime)
 				}
 				return results[i].TestStartTime.Before(results[j].TestStartTime)
@@ -983,7 +983,7 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 				if results[i].getDuration() == results[j].getDuration() {
 					continue
 				}
-				if sortBy.SortOrderDSC {
+				if sortBy.OrderDSC {
 					return results[i].getDuration() > results[j].getDuration()
 				}
 				return results[i].getDuration() < results[j].getDuration()
@@ -991,7 +991,7 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 				if results[i].GetDisplayName() == results[j].GetDisplayName() {
 					continue
 				}
-				if sortBy.SortOrderDSC {
+				if sortBy.OrderDSC {
 					return results[i].GetDisplayName() > results[j].GetDisplayName()
 				}
 				return results[i].GetDisplayName() < results[j].GetDisplayName()
@@ -999,7 +999,7 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 				if results[i].Status == results[j].Status {
 					continue
 				}
-				if sortBy.SortOrderDSC {
+				if sortBy.OrderDSC {
 					return results[i].Status > results[j].Status
 				}
 				return results[i].Status < results[j].Status
@@ -1007,7 +1007,7 @@ func sortTestResults(results []TestResult, opts *TestResultsFilterAndSortOptions
 				if opts.baseStatusMap[results[i].GetDisplayName()] == opts.baseStatusMap[results[j].GetDisplayName()] {
 					continue
 				}
-				if sortBy.SortOrderDSC {
+				if sortBy.OrderDSC {
 					return opts.baseStatusMap[results[i].GetDisplayName()] > opts.baseStatusMap[results[j].GetDisplayName()]
 				}
 				return opts.baseStatusMap[results[i].GetDisplayName()] < opts.baseStatusMap[results[j].GetDisplayName()]

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -757,7 +757,7 @@ func makeTestSamples(records []TestResults, regexFilters []string) ([]TestResult
 	return samples, nil
 }
 
-// TestResultsSortBy describes the property by which to sort a set of test
+// TestResultsSortBy describes the properties by which to sort a set of test
 // results.
 type TestResultsSortBy struct {
 	Key          string

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -1103,8 +1103,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				Sort: []TestResultsSortBy{
 					{
-						Key:          TestResultsSortByDurationKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByDurationKey,
+						OrderDSC: true,
 					},
 				},
 			},
@@ -1134,8 +1134,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				Sort: []TestResultsSortBy{
 					{
-						Key:          TestResultsSortByTestNameKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByTestNameKey,
+						OrderDSC: true,
 					},
 				},
 			},
@@ -1165,8 +1165,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				Sort: []TestResultsSortBy{
 					{
-						Key:          TestResultsSortByStatusKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByStatusKey,
+						OrderDSC: true,
 					},
 				},
 			},
@@ -1192,12 +1192,12 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			expectedCount: 4,
 		},
 		{
-			name: "SortByStartTimeDCS",
+			name: "SortByStartTimeDSC",
 			opts: &TestResultsFilterAndSortOptions{
 				Sort: []TestResultsSortBy{
 					{
-						Key:          TestResultsSortByStartKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByStartKey,
+						OrderDSC: true,
 					},
 				},
 			},
@@ -1228,8 +1228,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			opts: &TestResultsFilterAndSortOptions{
 				Sort: []TestResultsSortBy{
 					{
-						Key:          TestResultsSortByBaseStatusKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByBaseStatusKey,
+						OrderDSC: true,
 					},
 				},
 				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
@@ -1250,8 +1250,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 						Key: TestResultsSortByStatusKey,
 					},
 					{
-						Key:          TestResultsSortByTestNameKey,
-						SortOrderDSC: true,
+						Key:      TestResultsSortByTestNameKey,
+						OrderDSC: true,
 					},
 				},
 			},

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -996,13 +996,31 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		hasErr          bool
 	}{
 		{
-			name:   "InvalidSortBy",
-			opts:   &TestResultsFilterAndSortOptions{SortBy: "invalid"},
+			name: "InvalidSortByKey",
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{
+					{Key: TestResultsSortByStatusKey},
+					{Key: "invalid"},
+				},
+			},
 			hasErr: true,
 		},
 		{
-			name:   "SortByBaseStatusWithoutBaseTasksFindOptions",
-			opts:   &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByBaseStatus},
+			name: "DuplicateSortByKey",
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{
+					{Key: TestResultsSortByStatusKey},
+					{Key: TestResultsSortByTestNameKey},
+					{Key: TestResultsSortByStatusKey},
+				},
+			},
+			hasErr: true,
+		},
+		{
+			name: "SortByBaseStatusWithoutBaseTasksFindOptions",
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{{Key: TestResultsSortByBaseStatusKey}},
+			},
 			hasErr: true,
 		},
 		{
@@ -1069,7 +1087,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByDurationASC",
-			opts: &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByDuration},
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{{Key: TestResultsSortByDurationKey}},
+			},
 			expectedResults: []TestResult{
 				results[3],
 				results[0],
@@ -1081,8 +1101,12 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByDurationDSC",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:       TestResultsSortByDuration,
-				SortOrderDSC: true,
+				Sort: []TestResultsSortBy{
+					{
+						Key:          TestResultsSortByDurationKey,
+						SortOrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[1],
@@ -1094,7 +1118,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByTestNameASC",
-			opts: &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByTestName},
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{{Key: TestResultsSortByTestNameKey}},
+			},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -1106,8 +1132,12 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByTestNameDCS",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:       TestResultsSortByTestName,
-				SortOrderDSC: true,
+				Sort: []TestResultsSortBy{
+					{
+						Key:          TestResultsSortByTestNameKey,
+						SortOrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[1],
@@ -1119,7 +1149,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByStatusASC",
-			opts: &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByStatus},
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{{Key: TestResultsSortByStatusKey}},
+			},
 			expectedResults: []TestResult{
 				results[1],
 				results[2],
@@ -1131,8 +1163,12 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByStatusDSC",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:       TestResultsSortByStatus,
-				SortOrderDSC: true,
+				Sort: []TestResultsSortBy{
+					{
+						Key:          TestResultsSortByStatusKey,
+						SortOrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[0],
@@ -1144,7 +1180,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByStartTimeASC",
-			opts: &TestResultsFilterAndSortOptions{SortBy: TestResultsSortByStart},
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{{Key: TestResultsSortByStartKey}},
+			},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -1156,8 +1194,12 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByStartTimeDCS",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:       TestResultsSortByStart,
-				SortOrderDSC: true,
+				Sort: []TestResultsSortBy{
+					{
+						Key:          TestResultsSortByStartKey,
+						SortOrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[3],
@@ -1170,7 +1212,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByBaseStatusASC",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:    TestResultsSortByBaseStatus,
+				Sort:      []TestResultsSortBy{{Key: TestResultsSortByBaseStatusKey}},
 				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
 			},
 			expectedResults: []TestResult{
@@ -1184,15 +1226,40 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByBaseStatusDSC",
 			opts: &TestResultsFilterAndSortOptions{
-				SortBy:       TestResultsSortByBaseStatus,
-				SortOrderDSC: true,
-				BaseTasks:    []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
+				Sort: []TestResultsSortBy{
+					{
+						Key:          TestResultsSortByBaseStatusKey,
+						SortOrderDSC: true,
+					},
+				},
+				BaseTasks: []TestResultsTaskOptions{{TaskID: base.Info.TaskID, Execution: base.Info.Execution}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
 				resultsWithBaseStatus[2],
 				resultsWithBaseStatus[1],
 				resultsWithBaseStatus[3],
+			},
+			expectedCount: 4,
+		},
+		{
+			name: "MultiSort",
+			opts: &TestResultsFilterAndSortOptions{
+				Sort: []TestResultsSortBy{
+					{
+						Key: TestResultsSortByStatusKey,
+					},
+					{
+						Key:          TestResultsSortByTestNameKey,
+						SortOrderDSC: true,
+					},
+				},
+			},
+			expectedResults: []TestResult{
+				results[1],
+				results[2],
+				results[3],
+				results[0],
 			},
 			expectedCount: 4,
 		},

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -135,7 +135,7 @@ type TestResultsTaskOptions struct {
 	Execution int    `json:"execution"`
 }
 
-// TestResultsSortBy describes the property by which to sort a set of test
+// TestResultsSortBy describes the properties by which to sort a set of test
 // results using the Connector functions.
 type TestResultsSortBy struct {
 	Key          string `json:"key"`

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -135,17 +135,28 @@ type TestResultsTaskOptions struct {
 	Execution int    `json:"execution"`
 }
 
+// TestResultsSortBy describes the property by which to sort a set of test
+// results using the Connector functions.
+type TestResultsSortBy struct {
+	Key          string `json:"key"`
+	SortOrderDSC bool   `json:"sort_order_dsc"`
+}
+
 // TestResultsFilterAndSortOptions holds all values required for filtering,
 // sorting, and paginating test results using the Connector functions.
 type TestResultsFilterAndSortOptions struct {
-	TestName     string                   `json:"test_name"`
-	Statuses     []string                 `json:"statuses"`
-	GroupID      string                   `json:"group_id"`
-	SortBy       string                   `json:"sort_by"`
-	SortOrderDSC bool                     `json:"sort_order_dsc"`
-	Limit        int                      `json:"limit"`
-	Page         int                      `json:"page"`
-	BaseTasks    []TestResultsTaskOptions `json:"base_tasks"`
+	TestName  string                   `json:"test_name"`
+	Statuses  []string                 `json:"statuses"`
+	GroupID   string                   `json:"group_id"`
+	Sort      []TestResultsSortBy      `json:"sort"`
+	Limit     int                      `json:"limit"`
+	Page      int                      `json:"page"`
+	BaseTasks []TestResultsTaskOptions `json:"base_tasks"`
+
+	// TODO (EVG-14306): Remove these two fields once Evergreen's GraphQL
+	// service is no longer using them.
+	SortBy       string `json:"sort_by"`
+	SortOrderDSC bool   `json:"sort_order_dsc"`
 }
 
 // PerformanceOptions holds all values required to find a specific

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -138,8 +138,8 @@ type TestResultsTaskOptions struct {
 // TestResultsSortBy describes the properties by which to sort a set of test
 // results using the Connector functions.
 type TestResultsSortBy struct {
-	Key          string `json:"key"`
-	SortOrderDSC bool   `json:"sort_order_dsc"`
+	Key      string `json:"key"`
+	OrderDSC bool   `json:"order_dsc"`
 }
 
 // TestResultsFilterAndSortOptions holds all values required for filtering,

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -184,7 +184,7 @@ func convertToDBTestResultsSortOptions(opts []TestResultsSortBy) []dbModel.TestR
 	dbOpts := make([]dbModel.TestResultsSortBy, len(opts))
 	for i, sortBy := range opts {
 		dbOpts[i].Key = sortBy.Key
-		dbOpts[i].SortOrderDSC = sortBy.SortOrderDSC
+		dbOpts[i].OrderDSC = sortBy.OrderDSC
 	}
 
 	return dbOpts
@@ -210,8 +210,8 @@ func convertToDBTestResultsFilterAndSortOptions(opts *TestResultsFilterAndSortOp
 	if opts.SortBy != "" {
 		dbOpts.Sort = []dbModel.TestResultsSortBy{
 			{
-				Key:          opts.SortBy,
-				SortOrderDSC: opts.SortOrderDSC,
+				Key:      opts.SortBy,
+				OrderDSC: opts.SortOrderDSC,
 			},
 		}
 	}

--- a/rest/test_results_routes.go
+++ b/rest/test_results_routes.go
@@ -13,18 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	isDisplayTask         = "display_task"
-	testResultsTestName   = "test_name"
-	testResultsStatus     = "status"
-	testResultsGroupID    = "group_id"
-	testResultsSortBy     = "sort_by"
-	testResultsSortDSC    = "sort_order_dsc"
-	testResultsLimit      = "limit"
-	testResultsPage       = "page"
-	testResultsBaseTaskID = "base_task_id"
-)
-
 type testResultsBaseHandler struct {
 	sc      data.Connector
 	payload struct {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14306

This code change enables multiple sort criteria on test results. I kept the API backwards compatible for the switchover.