### PR TITLE
EVG-19750: fix time-series-update job race condition when there is both user-submitted rollups and FTDC rollups

### DIFF
--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/cedar"
@@ -57,7 +58,7 @@ func NewUpdateTimeSeriesJob(series model.UnanalyzedPerformanceSeries) amboy.Job 
 		series.Arguments,
 	)
 	j.SetID(fmt.Sprintf("%s.%s", baseID, time.Now().UTC()))
-	j.SetScopes([]string{baseID})
+	j.SetScopes([]string{baseID, strings.Join(series.Measurements, ",")})
 	j.SetEnqueueAllScopes(true)
 	j.Series = series
 	return j


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-19750

- Only enqueue the time-series-update job once for a performance result upon the final call to `CloseMetrics`
- Add the `measurements` to the scope for each job
- Add more better testing to the perf results RPC service code