### PR TITLE
EVG-19750: use a single scope for the time-series-update job

### DIFF
--- a/units/time_series_update.go
+++ b/units/time_series_update.go
@@ -58,7 +58,7 @@ func NewUpdateTimeSeriesJob(series model.UnanalyzedPerformanceSeries) amboy.Job 
 		series.Arguments,
 	)
 	j.SetID(fmt.Sprintf("%s.%s", baseID, time.Now().UTC()))
-	j.SetScopes([]string{baseID, strings.Join(series.Measurements, ",")})
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", baseID, strings.Join(series.Measurements, "."))})
 	j.SetEnqueueAllScopes(true)
 	j.Series = series
 	return j


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-19750

Scopes do not employ an "all or nothing" approach, if one of the scopes an existing scope matches, the job won't enqueue. I combined the two scopes into a single string to prevent this.