### PR TITLE
EVG-20455: enable the exclusion of display test names from the test name regex filter

### DIFF
--- a/model/test_results.go
+++ b/model/test_results.go
@@ -951,7 +951,7 @@ func filterTestResults(results []TestResult, opts *TestResultsFilterAndSortOptio
 
 	var filteredResults []TestResult
 	for _, result := range results {
-		if opts.testNameRegex != nil && !opts.testNameRegex.MatchString(result.GetDisplayName()) {
+		if opts.testNameRegex != nil && !opts.testNameRegex.MatchString(result.GetDisplayName()) && opts.TestName != result.TestName {
 			continue
 		}
 		if len(opts.Statuses) > 0 && !utility.StringSliceContains(opts.Statuses, result.Status) {

--- a/model/test_results.go
+++ b/model/test_results.go
@@ -785,13 +785,14 @@ func (s TestResultsSortBy) validate() error {
 // TestResultsFilterAndSortOptions allow for filtering, sorting, and paginating
 // a set of test results.
 type TestResultsFilterAndSortOptions struct {
-	TestName  string
-	Statuses  []string
-	GroupID   string
-	Sort      []TestResultsSortBy
-	Limit     int
-	Page      int
-	BaseTasks []TestResultsTaskOptions
+	TestName            string
+	ExcludeDisplayNames bool
+	Statuses            []string
+	GroupID             string
+	Sort                []TestResultsSortBy
+	Limit               int
+	Page                int
+	BaseTasks           []TestResultsTaskOptions
 
 	testNameRegex *regexp.Regexp
 	baseStatusMap map[string]string
@@ -951,8 +952,14 @@ func filterTestResults(results []TestResult, opts *TestResultsFilterAndSortOptio
 
 	var filteredResults []TestResult
 	for _, result := range results {
-		if opts.testNameRegex != nil && !opts.testNameRegex.MatchString(result.GetDisplayName()) && opts.TestName != result.TestName {
-			continue
+		if opts.testNameRegex != nil {
+			if opts.ExcludeDisplayNames {
+				if !opts.testNameRegex.MatchString(result.TestName) {
+					continue
+				}
+			} else if !opts.testNameRegex.MatchString(result.GetDisplayName()) {
+				continue
+			}
 		}
 		if len(opts.Statuses) > 0 && !utility.StringSliceContains(opts.Statuses, result.Status) {
 			continue

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -1053,12 +1053,6 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			expectedCount:   4,
 		},
 		{
-			name:            "TestNameExactMatchFilter",
-			opts:            &TestResultsFilterAndSortOptions{TestName: "B test"},
-			expectedResults: results[1:2],
-			expectedCount:   1,
-		},
-		{
 			name: "TestNameRegexFilter",
 			opts: &TestResultsFilterAndSortOptions{TestName: "A|C"},
 			expectedResults: []TestResult{
@@ -1068,8 +1062,17 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			expectedCount: 2,
 		},
 		{
+			name: "TestNameExcludeDisplayNamesFilter",
+			opts: &TestResultsFilterAndSortOptions{
+				TestName:            "B test",
+				ExcludeDisplayNames: true,
+			},
+			expectedResults: results[1:2],
+			expectedCount:   1,
+		},
+		{
 			name:            "DisplayTestNameFilter",
-			opts:            &TestResultsFilterAndSortOptions{TestName: "Display"},
+			opts:            &TestResultsFilterAndSortOptions{TestName: "Di"},
 			expectedResults: results[1:2],
 			expectedCount:   1,
 		},

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -941,10 +941,11 @@ func TestFilterAndSortTestResults(t *testing.T) {
 				TestEndTime:     time.Date(1996, time.August, 31, 12, 5, 16, 0, time.UTC),
 			},
 			{
-				TestName:      "C test",
-				Status:        "Fail",
-				TestStartTime: time.Date(1996, time.August, 31, 12, 5, 10, 2, time.UTC),
-				TestEndTime:   time.Date(1996, time.August, 31, 12, 5, 15, 0, time.UTC),
+				TestName:        "C test",
+				DisplayTestName: "B",
+				Status:          "Fail",
+				TestStartTime:   time.Date(1996, time.August, 31, 12, 5, 10, 2, time.UTC),
+				TestEndTime:     time.Date(1996, time.August, 31, 12, 5, 15, 0, time.UTC),
 			},
 			{
 				TestName:      "D test",
@@ -972,8 +973,9 @@ func TestFilterAndSortTestResults(t *testing.T) {
 			Status:          "Fail",
 		},
 		{
-			TestName: "C test",
-			Status:   "Pass",
+			TestName:        "C test",
+			DisplayTestName: "B",
+			Status:          "Pass",
 		},
 		{
 			TestName: "D test",
@@ -1054,7 +1056,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "TestNameRegexFilter",
-			opts: &TestResultsFilterAndSortOptions{TestName: "A|C"},
+			opts: &TestResultsFilterAndSortOptions{TestName: "A|B"},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -1064,7 +1066,7 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "TestNameExcludeDisplayNamesFilter",
 			opts: &TestResultsFilterAndSortOptions{
-				TestName:            "B test",
+				TestName:            "B",
 				ExcludeDisplayNames: true,
 			},
 			expectedResults: results[1:2],

--- a/model/test_results_test.go
+++ b/model/test_results_test.go
@@ -1054,8 +1054,8 @@ func TestFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name:            "TestNameExactMatchFilter",
-			opts:            &TestResultsFilterAndSortOptions{TestName: "A test"},
-			expectedResults: results[0:1],
+			opts:            &TestResultsFilterAndSortOptions{TestName: "B test"},
+			expectedResults: results[1:2],
 			expectedCount:   1,
 		},
 		{

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -137,13 +137,14 @@ type TestResultsSortBy struct {
 // TestResultsFilterAndSortOptions holds all values required for filtering,
 // sorting, and paginating test results using the Connector functions.
 type TestResultsFilterAndSortOptions struct {
-	TestName  string                   `json:"test_name"`
-	Statuses  []string                 `json:"statuses"`
-	GroupID   string                   `json:"group_id"`
-	Sort      []TestResultsSortBy      `json:"sort"`
-	Limit     int                      `json:"limit"`
-	Page      int                      `json:"page"`
-	BaseTasks []TestResultsTaskOptions `json:"base_tasks"`
+	TestName            string                   `json:"test_name"`
+	ExcludeDisplayNames bool                     `json:"exclude_display_names"`
+	Statuses            []string                 `json:"statuses"`
+	GroupID             string                   `json:"group_id"`
+	Sort                []TestResultsSortBy      `json:"sort"`
+	Limit               int                      `json:"limit"`
+	Page                int                      `json:"page"`
+	BaseTasks           []TestResultsTaskOptions `json:"base_tasks"`
 
 	// TODO (EVG-14306): Remove these two fields once Evergreen's GraphQL
 	// service is no longer using them.

--- a/rest/data/test_results.go
+++ b/rest/data/test_results.go
@@ -196,13 +196,14 @@ func convertToDBTestResultsFilterAndSortOptions(opts *TestResultsFilterAndSortOp
 	}
 
 	dbOpts := &dbModel.TestResultsFilterAndSortOptions{
-		TestName:  opts.TestName,
-		Statuses:  opts.Statuses,
-		GroupID:   opts.GroupID,
-		Sort:      convertToDBTestResultsSortOptions(opts.Sort),
-		Limit:     opts.Limit,
-		Page:      opts.Page,
-		BaseTasks: convertToDBTestResultsTaskOptions(opts.BaseTasks),
+		TestName:            opts.TestName,
+		ExcludeDisplayNames: opts.ExcludeDisplayNames,
+		Statuses:            opts.Statuses,
+		GroupID:             opts.GroupID,
+		Sort:                convertToDBTestResultsSortOptions(opts.Sort),
+		Limit:               opts.Limit,
+		Page:                opts.Page,
+		BaseTasks:           convertToDBTestResultsTaskOptions(opts.BaseTasks),
 	}
 
 	// TODO (EVG-14306): Remove this logic once Evergreen's GraphQL service


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-20455

We need to enable not only regex matches on display test names but also on the unique test names to support fetching test logs with the graphql resolver [EVG-20443](https://jira.mongodb.org/browse/EVG-20443). This adds a new option to "exclude display names" when matching on the test name regex, the default behavior will continue to favor matching on display test name—the changes are backwards compatible.