### PR TITLE
DEVPROD-1950: only check for and mark analyzed perf results for the most recent 7 days

### DIFF
--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -11,6 +11,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+const maxTimeSeriesUpdateTime = -7 * 24 * time.Hour
+
 // PerfAnalysis contains information about when the associated performance
 // result was analyzed for change points.
 type PerfAnalysis struct {
@@ -48,7 +50,7 @@ func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey):  performanceResultId.Test,
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey): performanceResultId.Arguments,
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey):  true,
-		perfCreatedAtKey: bson.M{"$gt": time.Now().Add(-7 * 24 * time.Hour)},
+		perfCreatedAtKey: bson.M{"$gt": time.Now().Add(maxTimeSeriesUpdateTime)},
 	}
 	update := bson.M{
 		"$currentDate": bson.M{
@@ -127,7 +129,7 @@ func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) 
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey):    bson.M{"$not": bson.M{"$size": 0}},
-				perfCreatedAtKey: bson.M{"$gt": time.Now().Add(-7 * 24 * time.Hour)},
+				perfCreatedAtKey: bson.M{"$gt": time.Now().Add(maxTimeSeriesUpdateTime)},
 			},
 		},
 		{

--- a/model/time_series_update.go
+++ b/model/time_series_update.go
@@ -37,8 +37,9 @@ func (p PerformanceResultSeriesID) String() string {
 	return fmt.Sprintf("%s %s %s %s %s", p.Project, p.Variant, p.Task, p.Test, p.Arguments)
 }
 
-// MarkPerformanceResultsAsAnalyzed marks all the performance results with the
-// given series ID as analyzed with the current date timestamp.
+// MarkPerformanceResultsAsAnalyzed marks the most recent mainline performance
+// results with the given series ID as analyzed with the current date
+// timestamp.
 func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment, performanceResultId PerformanceResultSeriesID) error {
 	filter := bson.M{
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey):   performanceResultId.Project,
@@ -46,8 +47,9 @@ func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey):  performanceResultId.Task,
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey):  performanceResultId.Test,
 		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoArgumentsKey): performanceResultId.Arguments,
+		bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey):  true,
+		perfCreatedAtKey: bson.M{"$gt": time.Now().Add(-7 * 24 * time.Hour)},
 	}
-
 	update := bson.M{
 		"$currentDate": bson.M{
 			bsonutil.GetDottedKeyName(perfAnalysisKey, perfAnalysisProcessedAtKey): true,
@@ -57,6 +59,7 @@ func MarkPerformanceResultsAsAnalyzed(ctx context.Context, env cedar.Environment
 	if err != nil {
 		return errors.Wrapf(err, "marking performance results as analyzed for change points")
 	}
+
 	return nil
 }
 
@@ -110,8 +113,9 @@ func (s UnanalyzedPerformanceSeries) CreateSeriesIDs() []PerformanceResultSeries
 	return ids
 }
 
-// GetUnanalyzedPerformanceSeries queries the DB and gets all the
-// performance series that contain results that have not yet been analyzed.
+// GetUnanalyzedPerformanceSeries queries the DB and gets all the most recent
+// mainline performance series that contain results that have not yet been
+// analyzed.
 func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) ([]UnanalyzedPerformanceSeries, error) {
 	cur, err := env.GetDB().Collection(perfResultCollection).Aggregate(ctx, []bson.M{
 		{
@@ -123,6 +127,7 @@ func GetUnanalyzedPerformanceSeries(ctx context.Context, env cedar.Environment) 
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey): bson.M{"$exists": true},
 				bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey):    bson.M{"$not": bson.M{"$size": 0}},
+				perfCreatedAtKey: bson.M{"$gt": time.Now().Add(-7 * 24 * time.Hour)},
 			},
 		},
 		{


### PR DESCRIPTION
[DEVPROD-1950](https://jira.mongodb.org/browse/DEVPROD-1950)

- Update `GetUnanalyzedPerformanceSeries` to look only check for unanalyzed perf results from the past 7 days
- Update `MarkPerformanceResultsAsAnalyzed` to only update results for mainline perf results from the most recent 7 days