### PR TITLE
DEVPROD-4495: Dockerize Cedar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.20-bullseye as build
+
+WORKDIR /build
+
+COPY . .
+
+RUN ["make", "cedar"]
+
+FROM debian:bullseye
+
+WORKDIR /project
+
+COPY --from=build /build/build/cedar .
+
+CMD /project/cedar --level=info service --rpcUserAuth --workers=1


### PR DESCRIPTION
This is just adding the base Dockerfile for Cedar. It has a default cmd that will spin up a very small instance of Cedar - this will be overridden in actual production deployments to have a more appropriately sized worker number. 