### PR TITLE
DEVPROD-7132 Document the requirements to run the cedar tests locally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ The Cedar project uses a ``makefile`` to coordinate testing. Use the following c
 
 The artifact is at ``build/cedar``. The makefile provides the following targets:
 
-``test`` Runs all tests, sequentially, for all packages.
+``test`` Runs all tests, sequentially, for all packages. Some of the tests require a *replica set* to be running under http://127.0.0.1:27017.
 
 ``test-<package>`` Runs all tests for a specific package
 


### PR DESCRIPTION
Some of the cedar tests require a replicaset to be available locally in order to run `make cedar test`.

This PR updates the documentation to reflect that.