### PR TITLE
DEVPROD-7253 Add a new index to the cedar DB for the overrides field

### DIFF
--- a/model/indexes.go
+++ b/model/indexes.go
@@ -114,6 +114,7 @@ func GetRequiredIndexes() []SystemIndexes {
 		{
 			Keys: bson.D{
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOverrideInfoKey, overrideInfoOverrideKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVersionKey), Value: 1},
 			},
 			Collection: perfResultCollection,
 		},

--- a/model/indexes.go
+++ b/model/indexes.go
@@ -122,6 +122,10 @@ func GetRequiredIndexes() []SystemIndexes {
 			Collection: perfResultCollection,
 		},
 		{
+			Keys:       bson.D{{Key: overrideInfoOverrideKey, Value: 1}},
+			Collection: perfResultCollection,
+		},
+		{
 			Keys: bson.D{
 				{Key: bsonutil.GetDottedKeyName(logInfoKey, logInfoTaskIDKey), Value: 1},
 				{Key: logCreatedAtKey, Value: -1},

--- a/model/indexes.go
+++ b/model/indexes.go
@@ -113,16 +113,18 @@ func GetRequiredIndexes() []SystemIndexes {
 		},
 		{
 			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, overrideInfoOverrideKey, perfResultInfoOverrideInfoKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
 				{Key: bsonutil.GetDottedKeyName(perfArtifactsKey, artifactInfoFormatKey), Value: 1},
 				{Key: perfFailedRollupAttempts, Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueNameKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfRollupsKey, perfRollupsStatsKey, perfRollupValueVersionKey), Value: 1},
 				{Key: perfCreatedAtKey, Value: 1},
 			},
-			Collection: perfResultCollection,
-		},
-		{
-			Keys:       bson.D{{Key: overrideInfoOverrideKey, Value: 1}},
 			Collection: perfResultCollection,
 		},
 		{

--- a/model/indexes.go
+++ b/model/indexes.go
@@ -113,7 +113,7 @@ func GetRequiredIndexes() []SystemIndexes {
 		},
 		{
 			Keys: bson.D{
-				{Key: bsonutil.GetDottedKeyName(perfInfoKey, overrideInfoOverrideKey, perfResultInfoOverrideInfoKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOverrideInfoKey, overrideInfoOverrideKey), Value: 1},
 			},
 			Collection: perfResultCollection,
 		},


### PR DESCRIPTION
This PR adds a new index to the list of required cedar indexes.

I've tested this by adding pushing this to staging, where no indexes exist. This results in the following warning in the log:
  ```
  [cedar] 2024/05/21 14:19:30 [p=error]: missing expected DB indexes: 
  ...
  expected index '[{info.override_info.override_mainline 1}]' is missing from collection 'perf_results'
  ...
  ```
   With the index, the above line disappears.
   
Before we deploy this change, I'll manually create the index in production as well. Once the change goes in, I'll monitor that the newly deployed version does not print the above warning.
  