### PR TITLE
DEVPROD-7257 Add index to support new pipeline

### DIFF
--- a/model/indexes.go
+++ b/model/indexes.go
@@ -89,6 +89,16 @@ func GetRequiredIndexes() []SystemIndexes {
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTestNameKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOverrideInfoKey, overrideInfoOverrideKey), Value: 1},
+			},
+			Collection: perfResultCollection,
+		},
+		{
+			Keys: bson.D{
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoProjectKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoVariantKey), Value: 1},
+				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoTaskNameKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoMainlineKey), Value: 1},
 				{Key: bsonutil.GetDottedKeyName(perfInfoKey, perfResultInfoOrderKey), Value: 1},
 			},


### PR DESCRIPTION
This PR adds the new index required for the overrides pipeline to the indexes.go file.

I've verified on staging that this matches the index we are planning to create.